### PR TITLE
Fix alternating labels in horizontal bar charts

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -466,7 +466,10 @@ function renderAgentBar(byAgent) {
   const values = agents.map(([, info]) => info.total_tokens);
   const colors = agents.map(([, info]) => modelColor(info.primary_model));
 
-  charts['agentBar'] = new Chart(document.getElementById('agentBar'), {
+  const canvas = document.getElementById('agentBar');
+  canvas.parentElement.style.height = Math.max(180, agents.length * 28 + 40) + 'px';
+
+  charts['agentBar'] = new Chart(canvas, {
     type: 'bar',
     data: {
       labels,
@@ -482,7 +485,7 @@ function renderAgentBar(byAgent) {
       maintainAspectRatio: false,
       scales: {
         x: { ticks: { callback: v => fmtTokens(v) }, grid: { color: GRID } },
-        y: { grid: { display: false } }
+        y: { grid: { display: false }, ticks: { autoSkip: false } }
       },
       plugins: {
         legend: { display: false },
@@ -529,7 +532,10 @@ function renderSkillBar(bySkill) {
   const labels = skills.map(([s]) => s || 'unknown');
   const values = skills.map(([, info]) => info.invocation_count);
 
-  charts['skillBar'] = new Chart(document.getElementById('skillBar'), {
+  const canvas = document.getElementById('skillBar');
+  canvas.parentElement.style.height = Math.max(180, skills.length * 28 + 40) + 'px';
+
+  charts['skillBar'] = new Chart(canvas, {
     type: 'bar',
     data: {
       labels,
@@ -546,7 +552,7 @@ function renderSkillBar(bySkill) {
       maintainAspectRatio: false,
       scales: {
         x: { grid: { color: GRID } },
-        y: { grid: { display: false } }
+        y: { grid: { display: false }, ticks: { autoSkip: false } }
       },
       plugins: { legend: { display: false } }
     }
@@ -571,7 +577,10 @@ function renderSkillAdoption(bySkillAdoption) {
   const passedData = skills.map(([, info]) => info.times_passed);
   const invokedData = skills.map(([, info]) => info.times_invoked);
 
-  charts['skillAdoption'] = new Chart(document.getElementById('skillAdoption'), {
+  const skillAdoptionCanvas = document.getElementById('skillAdoption');
+  skillAdoptionCanvas.parentElement.style.height = Math.max(180, skills.length * 28 + 40) + 'px';
+
+  charts['skillAdoption'] = new Chart(skillAdoptionCanvas, {
     type: 'bar',
     data: {
       labels,
@@ -596,7 +605,7 @@ function renderSkillAdoption(bySkillAdoption) {
       maintainAspectRatio: false,
       scales: {
         x: { grid: { color: GRID }, stacked: false },
-        y: { grid: { display: false } }
+        y: { grid: { display: false }, ticks: { autoSkip: false } }
       },
       plugins: {
         legend: { labels: { color: TEXT } },
@@ -643,7 +652,10 @@ function renderProjectBar(byProject) {
   const palette = ['#f78166','#ffa657','#d2a8ff','#79c0ff','#7ee787','#e3b341','#58a6ff','#8b5cf6'];
   const colors  = projects.map((_, i) => palette[i % palette.length]);
 
-  charts['projectBar'] = new Chart(document.getElementById('projectBar'), {
+  const projectBarCanvas = document.getElementById('projectBar');
+  projectBarCanvas.parentElement.style.height = Math.max(180, projects.length * 28 + 40) + 'px';
+
+  charts['projectBar'] = new Chart(projectBarCanvas, {
     type: 'bar',
     data: {
       labels,
@@ -660,7 +672,7 @@ function renderProjectBar(byProject) {
       maintainAspectRatio: false,
       scales: {
         x: { ticks: { callback: v => fmtTokens(v) }, grid: { color: GRID } },
-        y: { grid: { display: false } }
+        y: { grid: { display: false }, ticks: { autoSkip: false } }
       },
       plugins: {
         legend: { display: false },

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-from claude_usage.aggregator import aggregate
+from claude_usage.aggregator import AggregateResult, aggregate
 from claude_usage.parser import parse_sessions
 from claude_usage.renderer import render
 
@@ -232,4 +232,93 @@ class TestSubagentModelAttribution:
         assert actual == "sonnet", (
             f"DATA.by_agent.debugger.primary_model must be 'sonnet' in rendered HTML, got {actual!r}. "
             "The JS fix uses this value as authoritative; if it is wrong here the dashboard will still misattribute."
+        )
+
+
+class TestChartLabelSkip:
+    """Regression test for issue #7: category-axis labels skipped on Tokens by Agent
+    and Skill Invocations charts.
+
+    Chart.js defaults autoSkip=true on tick axes, which causes every other label to
+    vanish when the chart height is small relative to the number of categories.  The
+    fix sets ticks: { autoSkip: false } on the y-axis of every horizontal bar chart so
+    that all labels are always rendered.  This test verifies the rendered HTML contains
+    that config by inspecting the template source.
+    """
+
+    def _build_large_result(self, n: int = 20) -> AggregateResult:
+        """Build an AggregateResult with *n* agents and *n* skills — enough to
+        trigger label-skipping at the default 260 px chart height."""
+        result = AggregateResult()
+        result.total_tokens = n * 1000
+        result.total_sessions = n
+
+        for i in range(n):
+            agent = f"agent-{i:02d}"
+            result.by_agent[agent] = {
+                "total_tokens": (n - i) * 1000,
+                "primary_model": "sonnet",
+                "session_count": 1,
+            }
+            skill = f"skill-{i:02d}"
+            result.by_skill[skill] = {"invocation_count": n - i}
+            project = f"project-{i:02d}"
+            result.by_project[project] = {
+                "total_tokens": (n - i) * 500,
+                "primary_model": "sonnet",
+            }
+
+        return result
+
+    def test_agent_bar_chart_has_auto_skip_false(self, tmp_path: Path) -> None:
+        """Rendered dashboard must contain autoSkip: false on the agentBar y-axis.
+
+        With 20 agents and a fixed-height container, Chart.js would skip every
+        other label unless autoSkip is explicitly disabled.
+        """
+        result = self._build_large_result(20)
+        output = tmp_path / "dashboard.html"
+        render(result, output_path=output, open_browser=False)
+
+        html = output.read_text(encoding="utf-8")
+
+        # The template contains the literal JS source for both charts.
+        # We verify the autoSkip: false config is present in the output.
+        assert "autoSkip: false" in html, (
+            "Rendered HTML must contain 'autoSkip: false' — Chart.js will skip "
+            "category-axis labels at the default chart height without it."
+        )
+
+    def test_skill_bar_chart_has_auto_skip_false(self, tmp_path: Path) -> None:
+        """renderSkillBar must also have autoSkip: false on its y-axis."""
+        result = self._build_large_result(20)
+        output = tmp_path / "dashboard.html"
+        render(result, output_path=output, open_browser=False)
+
+        html = output.read_text(encoding="utf-8")
+
+        # Count occurrences — there should be one per horizontal bar chart
+        # (agentBar, skillBar, projectBar, skillAdoption = 4 charts).
+        count = html.count("autoSkip: false")
+        assert count >= 2, (
+            f"Expected at least 2 occurrences of 'autoSkip: false' (agentBar + skillBar), "
+            f"found {count}. Both charts need the config to fix label skipping."
+        )
+
+    def test_dynamic_height_set_for_many_categories(self, tmp_path: Path) -> None:
+        """Rendered HTML must set container height dynamically based on item count.
+
+        Without dynamic height, disabling autoSkip alone causes labels to overlap.
+        The template sets canvas.parentElement.style.height proportionally.
+        """
+        result = self._build_large_result(20)
+        output = tmp_path / "dashboard.html"
+        render(result, output_path=output, open_browser=False)
+
+        html = output.read_text(encoding="utf-8")
+
+        assert "parentElement.style.height" in html, (
+            "Rendered HTML must contain parentElement.style.height — "
+            "dynamic container sizing is required to prevent label overlap "
+            "after disabling autoSkip."
         )


### PR DESCRIPTION
## Summary
- Fix Chart.js auto-skip dropping every other label on the y-axis of all four horizontal bar charts (Tokens by Agent, Skill Invocations, Skill Adoption, Projects)
- Add dynamic chart height so labels have room to breathe as category count grows
- Add regression tests with 20-category fixtures

## Root cause
Two contributing factors in `templates/dashboard.html`:

1. All four horizontal bar charts (`agentBar`, `skillBar`, `skillAdoption`, `projectBar`) use `indexAxis: "y"` — making the y-axis the category axis — but had no `ticks` config. Chart.js defaults `autoSkip: true`, so it silently dropped labels whenever it calculated they would not fit.
2. CSS container height was fixed at 260px regardless of category count. Even with `autoSkip: false`, there was no vertical room for more than ~9 labels, so they would overlap.

## Fix
- Added `ticks: { autoSkip: false }` to the y-axis config of all four horizontal bar charts — every label renders now, no silent drops.
- Added dynamic height computed before each `new Chart()` call: `Math.max(180, n * 28 + 40)px` applied via `canvas.parentElement.style.height`. The chart grows with category count so every label has room.

## Tests
New `TestChartLabelSkip` class in `tests/test_e2e.py` with three regression tests:
- `test_agent_bar_chart_has_auto_skip_false` — renders with 20 agents, asserts `autoSkip: false` is in the HTML
- `test_skill_bar_chart_has_auto_skip_false` — same with skills, asserts at least two occurrences
- `test_dynamic_height_set_for_many_categories` — asserts `parentElement.style.height` is in the HTML

Red-green cycle verified: tests fail when `autoSkip: false` is removed, pass when restored.

**83/83 tests pass** (80 pre-existing + 3 new).

## Watch out for
The `skillAdoption` chart uses an inline-styled `<div style="height:300px">` wrapper instead of the `.chart-container` CSS class. The dynamic sizing still works (via `canvas.parentElement.style.height`), but if that wrapper is ever restructured, the sizing logic would need revisiting.

fixes #7

## Test plan
- [x] All 83 tests pass
- [x] Red-green cycle verified for all 3 regression tests
- [ ] Regenerate dashboard locally and visually confirm all labels render on both Tokens-by-Agent and Skill-Invocations charts

Claude Code (Opus 4.6) authored this PR on behalf of @cbeaulieu-gt.