### PR TITLE
Fix false positive skill-pass detection for common words

### DIFF
--- a/claude_usage/skill_tracking.py
+++ b/claude_usage/skill_tracking.py
@@ -103,27 +103,97 @@ def build_skill_allowlist(claude_dir: Path) -> set[str]:
 
 
 # Patterns for extracting skill references from Agent dispatch prompts
-_BACKTICK_PATTERN = re.compile(r"`([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)`")
+_BACKTICK_PATTERN = re.compile(
+    r"`([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)`"
+)
 _PHRASE_PATTERNS = [
-    re.compile(r"[Uu]se (?:the )?[\"']?([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)[\"']? skill", re.IGNORECASE),
-    re.compile(r"[Ii]nvoke (?:the )?[\"']?([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)[\"']? skill", re.IGNORECASE),
-    re.compile(r"[Uu]se skill:?\s*[\"']?([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)[\"']?", re.IGNORECASE),
+    re.compile(
+        r"[Uu]se (?:the )?[\"']?"
+        r"([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)"
+        r"[\"']? skill",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"[Ii]nvoke (?:the )?[\"']?"
+        r"([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)"
+        r"[\"']? skill",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"[Uu]se skill:?\s*[\"']?"
+        r"([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)"
+        r"[\"']?",
+        re.IGNORECASE,
+    ),
 ]
+
+# Characters to search on each side of a backtick match when checking
+# for nearby "skill" context.
+_SKILL_PROXIMITY_CHARS = 60
+
+
+def _has_nearby_skill_word(prompt: str, match_start: int, match_end: int) -> bool:
+    """Return True if the word 'skill' appears within proximity of a match.
+
+    Args:
+        prompt: The full prompt text being scanned.
+        match_start: Start index of the backtick match in the prompt.
+        match_end: End index of the backtick match in the prompt.
+
+    Returns:
+        True if the word ``skill`` or ``skills`` (case-insensitive)
+        appears within ``_SKILL_PROXIMITY_CHARS`` characters before or
+        after the match boundaries, False otherwise.
+    """
+    window_start = max(0, match_start - _SKILL_PROXIMITY_CHARS)
+    window_end = min(len(prompt), match_end + _SKILL_PROXIMITY_CHARS)
+    window = prompt[window_start:window_end]
+    return bool(re.search(r"\bskills?\b", window, re.IGNORECASE))
 
 
 def extract_skills_from_prompt(prompt: str, allowlist: set[str]) -> list[str]:
     """Extract skill names from an Agent dispatch prompt.
 
-    Uses backtick-quoted names and phrase patterns, then validates
-    against the allowlist to reduce false positives.
+    Uses two detection strategies and merges results before filtering
+    against the allowlist:
+
+    1. **Backtick matches** — any backtick-quoted token.  Namespaced
+       names (containing ``:``) are always accepted.  Single-segment
+       names are only accepted when the word *skill* (or *skills*)
+       appears within ``_SKILL_PROXIMITY_CHARS`` characters of the
+       match, preventing incidental mentions like a bare ``git`` in
+       command examples from inflating metrics.
+
+    2. **Phrase pattern matches** — patterns like *"Use the python
+       skill"* or *"Invoke the powershell skill"*.  These already
+       require the word *skill* in their regex, so they are accepted
+       unconditionally (no proximity check needed).
+
+    Args:
+        prompt: The Agent dispatch prompt to scan.
+        allowlist: Set of known installed skill names to validate
+            candidates against.
+
+    Returns:
+        Sorted list of skill names that appear in the prompt and are
+        present in the allowlist.
     """
-    candidates: set[str] = set()
+    backtick_candidates: set[str] = set()
 
     for match in _BACKTICK_PATTERN.finditer(prompt):
-        candidates.add(match.group(1))
+        name = match.group(1)
+        if ":" in name:
+            # Namespaced skills (e.g. superpowers:brainstorming) are
+            # unambiguous — accept without proximity check.
+            backtick_candidates.add(name)
+        elif _has_nearby_skill_word(prompt, match.start(), match.end()):
+            # Single-segment name confirmed by nearby "skill" keyword.
+            backtick_candidates.add(name)
 
+    phrase_candidates: set[str] = set()
     for pattern in _PHRASE_PATTERNS:
         for match in pattern.finditer(prompt):
-            candidates.add(match.group(1))
+            phrase_candidates.add(match.group(1))
 
+    candidates = backtick_candidates | phrase_candidates
     return sorted(c for c in candidates if c in allowlist)

--- a/tests/test_skill_tracking.py
+++ b/tests/test_skill_tracking.py
@@ -79,7 +79,8 @@ class TestParseSkillTracking:
 class TestExtractSkillsFromPrompt:
     def setup_method(self):
         self.allowlist = {
-            "python", "powershell", "superpowers:test-driven-development",
+            "python", "powershell", "git",
+            "superpowers:test-driven-development",
             "superpowers:brainstorming", "commit-commands:commit",
         }
 
@@ -104,7 +105,10 @@ class TestExtractSkillsFromPrompt:
         assert result == ["powershell"]
 
     def test_multiple_skills_in_prompt(self):
-        prompt = "Use the `python` skill and invoke `superpowers:brainstorming` first."
+        prompt = (
+            "Use the `python` skill and invoke "
+            "`superpowers:brainstorming` first."
+        )
         result = extract_skills_from_prompt(prompt, self.allowlist)
         assert result == ["python", "superpowers:brainstorming"]
 
@@ -120,6 +124,61 @@ class TestExtractSkillsFromPrompt:
 
     def test_deduplicates(self):
         prompt = "Use the `python` skill. Also invoke the python skill."
+        result = extract_skills_from_prompt(prompt, self.allowlist)
+        assert result == ["python"]
+
+    # ------------------------------------------------------------------
+    # False-positive filtering tests
+    # ------------------------------------------------------------------
+
+    def test_backtick_without_skill_context_rejected(self):
+        """Backtick mention of a skill name with no nearby 'skill' word
+        should NOT be counted as a skill pass."""
+        prompt = "Run `python` -m pytest"
+        result = extract_skills_from_prompt(prompt, self.allowlist)
+        assert result == []
+
+    def test_backtick_with_nearby_skill_word_accepted(self):
+        """Backtick mention with 'skill' in close proximity should be
+        detected via both the backtick path and the phrase pattern."""
+        prompt = "Use the `python` skill for style"
+        result = extract_skills_from_prompt(prompt, self.allowlist)
+        assert result == ["python"]
+
+    def test_namespaced_backtick_always_accepted(self):
+        """Namespaced skills in backticks need no 'skill' word nearby —
+        the colon makes them unambiguous."""
+        prompt = (
+            "Use `superpowers:test-driven-development` before coding"
+        )
+        result = extract_skills_from_prompt(prompt, self.allowlist)
+        assert result == ["superpowers:test-driven-development"]
+
+    def test_git_backtick_in_command_context_rejected(self):
+        """'git' in a command context (no nearby 'skill') should NOT
+        be detected."""
+        prompt = "Run `git diff` to check changes"
+        result = extract_skills_from_prompt(prompt, self.allowlist)
+        assert result == []
+
+    def test_powershell_incidental_mention_rejected(self):
+        """An incidental backtick mention of 'powershell' without a
+        nearby 'skill' keyword should be filtered out."""
+        prompt = "Use Bash not `powershell` for this agent"
+        result = extract_skills_from_prompt(prompt, self.allowlist)
+        assert result == []
+
+    def test_phrase_pattern_still_works_without_backticks(self):
+        """Phrase patterns ('Use the X skill') must still work even
+        when there are no backticks around the skill name."""
+        prompt = "Use the python skill for this"
+        result = extract_skills_from_prompt(prompt, self.allowlist)
+        assert result == ["python"]
+
+    def test_mixed_real_and_incidental(self):
+        """A prompt that genuinely passes 'python' via phrase pattern
+        AND mentions 'git' incidentally should match only 'python'."""
+        prompt = "Use the `python` skill. Run `git diff` first."
         result = extract_skills_from_prompt(prompt, self.allowlist)
         assert result == ["python"]
 


### PR DESCRIPTION
## Summary

- `extract_skills_from_prompt()` now separates backtick candidates from phrase-pattern candidates
- Single-segment backtick matches require "skill"/"skills" within 60 chars (new `_has_nearby_skill_word()` helper)
- Namespaced skills (containing `:`) bypass the proximity check — they're unambiguous
- 7 new test cases covering false positive scenarios

## Context

Skill adoption metrics in the usage dashboard showed inflated `skill_passed` counts for common words like `python`, `powershell`, and `git`. The backtick pattern was matching incidental code mentions (e.g. "Run `git diff`") as skill passes.

**Companion PR**: cbeaulieu-gt/claude_personal_configs — same logic applied to the hook's fallback `_extract_skills()` path.

## Test plan

- [x] All 23 skill_tracking tests pass (7 new)
- [x] Full claude-usage test suite passes

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*