### PR TITLE
chore: add pyyaml runtime dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Parse Claude Code session data and generate an interactive HTML u
 requires-python = ">=3.10"
 dependencies = [
     "jinja2>=3.1",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Adds `pyyaml>=6.0` to `[project].dependencies` in `pyproject.toml`.

## Why

Needed by upstream PM Router Advisor work ([cbeaulieu-gt/claude_personal_configs#69](https://github.com/cbeaulieu-gt/claude_personal_configs/issues/69)) — the forthcoming `advisor_analyzer` module parses agent-file YAML frontmatter, and the existing ad-hoc verification commands call `import yaml; yaml.safe_load(...)`.

Runtime dep, not dev-only — the analyzer imports it at normal execution time.

fixes #15

## Test plan

- [x] `pyproject.toml` updated — 1-line addition to `dependencies`
- [ ] `uv pip install -e .` resolves cleanly in the consuming venv
- [ ] `python -c "import yaml; print(yaml.__version__)"` works after install
- [ ] Existing test suite passes (`pytest` — previously 90/90 green per upstream sub-agent run)

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*