### PR TITLE
refactor(cli): Phase 0+1 — subparser skeleton + dashboard snapshot gate (#19)

### DIFF
--- a/claude_usage/__main__.py
+++ b/claude_usage/__main__.py
@@ -1,156 +1,42 @@
-"""CLI entry point for claude-usage dashboard."""
+"""CLI entry point for claude-usage — subparser dispatcher."""
 
 from __future__ import annotations
 
-import argparse
-import json
-import re
 import sys
-from datetime import datetime, timezone
-from pathlib import Path
 
-from claude_usage.aggregator import aggregate
-from claude_usage.parser import parse_sessions
-from claude_usage.renderer import render
-from claude_usage.skill_tracking import parse_skill_tracking
-
-
-def _parse_window(window_str: str) -> float:
-    """Parse a window string like '5h' or '7d' into hours."""
-    match = re.match(r"^(\d+(?:\.\d+)?)(h|d)$", window_str.strip().lower())
-    if not match:
-        raise argparse.ArgumentTypeError(
-            f"Invalid window format: '{window_str}'. Use e.g. '5h' or '7d'."
-        )
-    value = float(match.group(1))
-    unit = match.group(2)
-    if unit == "d":
-        value *= 24
-    return value
-
-
-def _parse_date(date_str: str) -> datetime:
-    """Parse a date string (YYYY-MM-DD) into a timezone-aware datetime."""
-    try:
-        dt = datetime.strptime(date_str, "%Y-%m-%d")
-        return dt.replace(tzinfo=timezone.utc)
-    except ValueError:
-        raise argparse.ArgumentTypeError(
-            f"Invalid date format: '{date_str}'. Use YYYY-MM-DD."
-        )
+from claude_usage.cli import dashboard, session_summary
 
 
 def main() -> None:
+    """Parse top-level subcommand and dispatch to the appropriate runner."""
+    import argparse
+
     parser = argparse.ArgumentParser(
         prog="claude-usage",
-        description="Generate an HTML dashboard of Claude Code token usage.",
+        description=(
+            "Claude Code token usage tools. "
+            "Run 'claude-usage <subcommand> --help' for details."
+        ),
     )
-    parser.add_argument(
-        "--data-dir",
-        type=Path,
-        default=Path.home() / ".claude",
-        help="Path to Claude Code data directory (default: ~/.claude)",
+    subparsers = parser.add_subparsers(
+        dest="subcommand",
+        metavar="subcommand",
     )
-    parser.add_argument(
-        "--from", dest="from_date", type=_parse_date,
-        help="Start date (YYYY-MM-DD). Only include data on or after this date.",
-    )
-    parser.add_argument(
-        "--to", dest="to_date", type=_parse_date,
-        help="End date (YYYY-MM-DD). Only include data before this date.",
-    )
-    parser.add_argument(
-        "--window", type=_parse_window,
-        help="Rolling window (e.g. '5h', '7d'). Overrides --from.",
-    )
-    parser.add_argument(
-        "--output", "-o", type=Path,
-        help="Output file path. If omitted, writes to a temp file.",
-    )
-    parser.add_argument(
-        "--no-open", action="store_true",
-        help="Don't open the dashboard in a browser.",
-    )
-    parser.add_argument(
-        "--limit-5h", type=int, default=None,
-        help="Token budget for 5-hour rolling window (for gauge percentage).",
-    )
-    parser.add_argument(
-        "--limit-7d", type=int, default=None,
-        help="Token budget for 7-day rolling window (for gauge percentage).",
-    )
-    parser.add_argument(
-        "--limit-sonnet-7d", type=int, default=None,
-        help="Token budget for Sonnet-only 7-day window (for gauge percentage).",
-    )
-    parser.add_argument(
-        "--format", dest="output_format", choices=["html", "json"], default="html",
-        help="Output format: 'html' (default) opens a dashboard; 'json' writes structured data to stdout.",
-    )
+
+    dashboard.build_parser(subparsers)
+    session_summary.build_parser(subparsers)
 
     args = parser.parse_args()
 
-    # In json mode, status messages go to stderr so stdout carries only the JSON payload.
-    status_file = sys.stderr if args.output_format == "json" else sys.stdout
+    if args.subcommand is None:
+        parser.print_help()
+        sys.exit(0)
 
-    print(f"Scanning sessions in {args.data_dir}...", file=status_file)
-    sessions = parse_sessions(args.data_dir)
-    print(f"Found {len(sessions)} sessions.", file=status_file)
+    if args.subcommand == "dashboard":
+        sys.exit(dashboard.run(args))
 
-    result = aggregate(
-        sessions,
-        from_date=args.from_date,
-        to_date=args.to_date,
-        window_hours=args.window,
-    )
-    print(
-        f"Aggregated: {result.total_tokens:,} tokens across {result.total_sessions} sessions.",
-        file=status_file,
-    )
-
-    # Skill adoption tracking (from PreToolUse hook log)
-    passed_events, invoked_events = parse_skill_tracking(args.data_dir)
-    if passed_events or invoked_events:
-        from claude_usage.aggregator import compute_skill_adoption
-        result.by_skill_adoption = compute_skill_adoption(
-            passed_events,
-            invoked_events,
-            from_date=args.from_date,
-            to_date=args.to_date,
-        )
-
-    limits = None
-    if any([args.limit_5h, args.limit_7d, args.limit_sonnet_7d]):
-        limits = {
-            "limit_5h": args.limit_5h,
-            "limit_7d": args.limit_7d,
-            "limit_sonnet_7d": args.limit_sonnet_7d,
-        }
-
-    if args.output_format == "json":
-        payload = {
-            "generated_at": datetime.now(timezone.utc).isoformat(),
-            "total_tokens": result.total_tokens,
-            "total_messages": result.total_messages,
-            "total_sessions": result.total_sessions,
-            "by_model": result.by_model,
-            "by_agent": result.by_agent,
-            "by_skill": result.by_skill,
-            "by_project": result.by_project,
-            "by_day": result.by_day,
-            "sessions": result.sessions,
-            "limits": limits,
-        }
-        print(json.dumps(payload, indent=2))
-        return
-
-    output = render(
-        result,
-        output_path=args.output,
-        open_browser=not args.no_open,
-        limits=limits,
-    )
-    print(f"Dashboard written to {output}")
+    if args.subcommand == "session-summary":
+        sys.exit(session_summary.run(args))
 
 
 if __name__ == "__main__":

--- a/claude_usage/cli/__init__.py
+++ b/claude_usage/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI subcommands for claude-usage."""

--- a/claude_usage/cli/dashboard.py
+++ b/claude_usage/cli/dashboard.py
@@ -1,0 +1,203 @@
+"""Dashboard subcommand for claude-usage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from claude_usage.aggregator import aggregate
+from claude_usage.parser import parse_sessions
+from claude_usage.renderer import render
+from claude_usage.skill_tracking import parse_skill_tracking
+
+
+def _parse_window(window_str: str) -> float:
+    """Parse a window string like '5h' or '7d' into hours.
+
+    Args:
+        window_str: A string of the form '<number>h' or '<number>d'.
+
+    Returns:
+        The window duration expressed as a float number of hours.
+
+    Raises:
+        argparse.ArgumentTypeError: If the format is not recognised.
+    """
+    match = re.match(
+        r"^(\d+(?:\.\d+)?)(h|d)$", window_str.strip().lower()
+    )
+    if not match:
+        raise argparse.ArgumentTypeError(
+            f"Invalid window format: '{window_str}'. Use e.g. '5h' or '7d'."
+        )
+    value = float(match.group(1))
+    unit = match.group(2)
+    if unit == "d":
+        value *= 24
+    return value
+
+
+def _parse_date(date_str: str) -> datetime:
+    """Parse a date string (YYYY-MM-DD) into a timezone-aware datetime.
+
+    Args:
+        date_str: A date string in YYYY-MM-DD format.
+
+    Returns:
+        A UTC-aware datetime set to midnight on the given date.
+
+    Raises:
+        argparse.ArgumentTypeError: If the string is not YYYY-MM-DD.
+    """
+    try:
+        dt = datetime.strptime(date_str, "%Y-%m-%d")
+        return dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"Invalid date format: '{date_str}'. Use YYYY-MM-DD."
+        )
+
+
+def build_parser(parent: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Register the 'dashboard' subparser and return it.
+
+    Args:
+        parent: The subparsers action from the top-level parser.
+
+    Returns:
+        The configured dashboard ArgumentParser.
+    """
+    p = parent.add_parser(
+        "dashboard",
+        help="Generate an HTML or JSON dashboard of Claude Code token usage.",
+    )
+    p.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path.home() / ".claude",
+        help=(
+            "Path to Claude Code data directory (default: ~/.claude)"
+        ),
+    )
+    p.add_argument(
+        "--from", dest="from_date", type=_parse_date,
+        help=(
+            "Start date (YYYY-MM-DD). Only include data on or after this date."
+        ),
+    )
+    p.add_argument(
+        "--to", dest="to_date", type=_parse_date,
+        help=(
+            "End date (YYYY-MM-DD). Only include data before this date."
+        ),
+    )
+    p.add_argument(
+        "--window", type=_parse_window,
+        help="Rolling window (e.g. '5h', '7d'). Overrides --from.",
+    )
+    p.add_argument(
+        "--output", "-o", type=Path,
+        help="Output file path. If omitted, writes to a temp file.",
+    )
+    p.add_argument(
+        "--no-open", action="store_true",
+        help="Don't open the dashboard in a browser.",
+    )
+    p.add_argument(
+        "--limit-5h", type=int, default=None,
+        help="Token budget for 5-hour rolling window.",
+    )
+    p.add_argument(
+        "--limit-7d", type=int, default=None,
+        help="Token budget for 7-day rolling window.",
+    )
+    p.add_argument(
+        "--limit-sonnet-7d", type=int, default=None,
+        help="Token budget for Sonnet-only 7-day window.",
+    )
+    p.add_argument(
+        "--format", dest="output_format",
+        choices=["html", "json"], default="html",
+        help=(
+            "Output format: 'html' (default) opens a dashboard; "
+            "'json' writes structured data to stdout."
+        ),
+    )
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the dashboard subcommand.
+
+    Args:
+        args: Parsed argument namespace from the dashboard subparser.
+
+    Returns:
+        Integer exit code (0 on success).
+    """
+    # In json mode, status messages go to stderr so stdout carries only the JSON payload.
+    status_file = sys.stderr if args.output_format == "json" else sys.stdout
+
+    print(f"Scanning sessions in {args.data_dir}...", file=status_file)
+    sessions = parse_sessions(args.data_dir)
+    print(f"Found {len(sessions)} sessions.", file=status_file)
+
+    result = aggregate(
+        sessions,
+        from_date=args.from_date,
+        to_date=args.to_date,
+        window_hours=args.window,
+    )
+    print(
+        f"Aggregated: {result.total_tokens:,} tokens across {result.total_sessions} sessions.",
+        file=status_file,
+    )
+
+    # Skill adoption tracking (from PreToolUse hook log)
+    passed_events, invoked_events = parse_skill_tracking(args.data_dir)
+    if passed_events or invoked_events:
+        from claude_usage.aggregator import compute_skill_adoption
+        result.by_skill_adoption = compute_skill_adoption(
+            passed_events,
+            invoked_events,
+            from_date=args.from_date,
+            to_date=args.to_date,
+        )
+
+    limits = None
+    if any([args.limit_5h, args.limit_7d, args.limit_sonnet_7d]):
+        limits = {
+            "limit_5h": args.limit_5h,
+            "limit_7d": args.limit_7d,
+            "limit_sonnet_7d": args.limit_sonnet_7d,
+        }
+
+    if args.output_format == "json":
+        payload = {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "total_tokens": result.total_tokens,
+            "total_messages": result.total_messages,
+            "total_sessions": result.total_sessions,
+            "by_model": result.by_model,
+            "by_agent": result.by_agent,
+            "by_skill": result.by_skill,
+            "by_project": result.by_project,
+            "by_day": result.by_day,
+            "sessions": result.sessions,
+            "limits": limits,
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    output = render(
+        result,
+        output_path=args.output,
+        open_browser=not args.no_open,
+        limits=limits,
+    )
+    print(f"Dashboard written to {output}")
+    return 0

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -1,0 +1,67 @@
+"""Session-summary subcommand for claude-usage (stub).
+
+Full implementation added in Phase 2. This file exists so that
+__main__.py can import it without ImportError during the Phase 1
+refactor tasks.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+EXIT_OK = 0
+EXIT_IO_FAILURE = 1
+EXIT_NO_USER_TURNS = 2
+EXIT_NOT_JSONL = 3
+
+
+def build_parser(parent: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Register the 'session-summary' subparser and return it.
+
+    Args:
+        parent: The subparsers action from the top-level parser.
+
+    Returns:
+        The configured session-summary ArgumentParser.
+    """
+    p = parent.add_parser(
+        "session-summary",
+        help="Emit a deterministic JSON recap of a Claude Code transcript.",
+    )
+    p.add_argument(
+        "--path",
+        required=True,
+        help="Path to the transcript JSONL file.",
+    )
+    p.add_argument(
+        "--format", dest="output_format",
+        choices=["json", "text"], default="json",
+        help="Output format: 'json' (default) or 'text' (debug view).",
+    )
+    p.add_argument(
+        "--max-actions", type=int, default=50,
+        dest="max_actions",
+        help=(
+            "Soft cap on emitted actions. 0 disables the cap. "
+            "Default: 50."
+        ),
+    )
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the session-summary subcommand.
+
+    Args:
+        args: Parsed argument namespace from the session-summary subparser.
+
+    Returns:
+        Integer exit code.
+
+    Raises:
+        NotImplementedError: Always — full implementation pending Phase 2.
+    """
+    raise NotImplementedError(
+        "session-summary is not yet implemented. "
+        "Full implementation arrives in Phase 2."
+    )

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -717,7 +717,7 @@ and resolves Open Question #2 from the spec.
 **Files:**
 - Create: `tests/test_dashboard_snapshot.py`
 
-- [ ] **Step 1: Write the snapshot regression test.**
+- [x] **Step 1: Write the snapshot regression test.**
 
   Create `tests/test_dashboard_snapshot.py`:
 
@@ -790,7 +790,7 @@ and resolves Open Question #2 from the spec.
       )
   ```
 
-- [ ] **Step 2: Run the test.**
+- [x] **Step 2: Run the test.**
 
   ```bash
   uv run pytest tests/test_dashboard_snapshot.py -v
@@ -799,7 +799,7 @@ and resolves Open Question #2 from the spec.
   Expected: `test_existing_dashboard_unchanged` passes. The refactor was a verbatim body move;
   dashboard behavior is unchanged.
 
-- [ ] **Step 3: Commit.**
+- [x] **Step 3: Commit.**
 
   ```bash
   git add tests/test_dashboard_snapshot.py

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -218,7 +218,7 @@ and resolves Open Question #2 from the spec.
 - Create: `claude_usage/cli/dashboard.py`
 - Modify: `claude_usage/__main__.py` (temporary intermediate state)
 
-- [ ] **Step 1: Create `claude_usage/cli/__init__.py`.**
+- [x] **Step 1: Create `claude_usage/cli/__init__.py`.**
 
   Exact file contents:
 
@@ -228,7 +228,7 @@ and resolves Open Question #2 from the spec.
 
   That is the entire file — one docstring line, nothing else.
 
-- [ ] **Step 2: Create `claude_usage/cli/dashboard.py`.**
+- [x] **Step 2: Create `claude_usage/cli/dashboard.py`.**
 
   Move the body of `__main__.py`'s `main()` function into a new `run(args)` function. Preserve all
   imports and helper functions. The helper functions `_parse_window` and `_parse_date` move into
@@ -453,7 +453,7 @@ and resolves Open Question #2 from the spec.
       return 0
   ```
 
-- [ ] **Step 3: Run existing tests to confirm nothing is broken.**
+- [x] **Step 3: Run existing tests to confirm nothing is broken.**
 
   ```bash
   uv run pytest -x
@@ -462,7 +462,7 @@ and resolves Open Question #2 from the spec.
   Expected: all tests pass. The old `main()` in `__main__.py` is still present (import surface
   intact); the new `cli/dashboard.py` is now importable but not yet wired to anything.
 
-- [ ] **Step 4: Commit.**
+- [x] **Step 4: Commit.**
 
   ```bash
   git add claude_usage/cli/__init__.py claude_usage/cli/dashboard.py

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -139,7 +139,7 @@ and resolves Open Question #2 from the spec.
 - Create: `tests/fixtures/session_summaries/dashboard_baseline_input/` (minimal fake `.claude` tree)
 - Create: `tests/fixtures/dashboard_snapshot_pre_refactor.json`
 
-- [ ] **Step 1: Construct the minimal input fixture tree.**
+- [x] **Step 1: Construct the minimal input fixture tree.**
 
   Create the directory structure that mimics what `parse_sessions` expects under a `.claude` data
   directory. The current `__main__.py` passes `args.data_dir` (a `Path`) to `parse_sessions`. The
@@ -165,7 +165,7 @@ and resolves Open Question #2 from the spec.
   Write this file verbatim. The `fake-project-abc123` slug does not need to decode to a real path;
   `parse_sessions` reads the JSONL content, not the directory name.
 
-- [ ] **Step 2: Capture the baseline snapshot.**
+- [x] **Step 2: Capture the baseline snapshot.**
 
   With `main` checked out (no refactor changes present), run:
 
@@ -188,7 +188,7 @@ and resolves Open Question #2 from the spec.
   > If that flag name has changed in the actual file on disk, read `claude_usage/__main__.py`
   > and adapt the command accordingly before running. Do not assume — verify.
 
-- [ ] **Step 3: Commit the baseline fixtures.**
+- [x] **Step 3: Commit the baseline fixtures.**
 
   ```bash
   git -C "$(git rev-parse --show-toplevel)" add \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -487,7 +487,7 @@ and resolves Open Question #2 from the spec.
 - Create: `claude_usage/cli/session_summary.py` (stub only — full implementation in Phase 2+)
 - Create: `tests/test_cli_subcommands.py`
 
-- [ ] **Step 1: Write the failing test first.**
+- [x] **Step 1: Write the failing test first.**
 
   Create `tests/test_cli_subcommands.py` with the following content:
 
@@ -541,7 +541,7 @@ and resolves Open Question #2 from the spec.
       assert result.returncode != 0
   ```
 
-- [ ] **Step 2: Run the test — confirm it fails.**
+- [x] **Step 2: Run the test — confirm it fails.**
 
   ```bash
   uv run pytest tests/test_cli_subcommands.py -x -v
@@ -552,7 +552,7 @@ and resolves Open Question #2 from the spec.
     will not contain "session-summary".
   - `test_old_flag_only_form_exits_nonzero` — current CLI accepts `--format json` and exits 0.
 
-- [ ] **Step 3: Create the `session_summary.py` stub.**
+- [x] **Step 3: Create the `session_summary.py` stub.**
 
   The stub must make `from claude_usage.cli import session_summary` succeed so `__main__.py` can
   import it. Full implementation comes in Phase 2+.
@@ -629,7 +629,7 @@ and resolves Open Question #2 from the spec.
       )
   ```
 
-- [ ] **Step 4: Rewrite `claude_usage/__main__.py`.**
+- [x] **Step 4: Rewrite `claude_usage/__main__.py`.**
 
   Full new file contents (~30 lines):
 
@@ -679,7 +679,7 @@ and resolves Open Question #2 from the spec.
       main()
   ```
 
-- [ ] **Step 5: Run the full test suite.**
+- [x] **Step 5: Run the full test suite.**
 
   ```bash
   uv run pytest -x
@@ -690,7 +690,7 @@ and resolves Open Question #2 from the spec.
   `subprocess` will now hit the subparser dispatcher — confirm those still pass or update
   their invocation to `claude-usage dashboard [flags]`.)
 
-- [ ] **Step 6: Commit.**
+- [x] **Step 6: Commit.**
 
   ```bash
   git add claude_usage/__main__.py \

--- a/tests/fixtures/dashboard_snapshot_pre_refactor.json
+++ b/tests/fixtures/dashboard_snapshot_pre_refactor.json
@@ -1,0 +1,62 @@
+{
+  "generated_at": "2026-04-23T15:21:27.056197+00:00",
+  "total_tokens": 15,
+  "total_messages": 1,
+  "total_sessions": 1,
+  "by_model": {
+    "sonnet": {
+      "total_tokens": 15,
+      "input_tokens": 10,
+      "output_tokens": 5,
+      "cache_read_tokens": 0,
+      "cache_creation_tokens": 0,
+      "message_count": 1
+    }
+  },
+  "by_agent": {
+    "unknown": {
+      "total_tokens": 15,
+      "input_tokens": 10,
+      "output_tokens": 5,
+      "cache_read_tokens": 0,
+      "cache_creation_tokens": 0,
+      "message_count": 1,
+      "primary_model": "sonnet",
+      "session_count": 1
+    }
+  },
+  "by_skill": {},
+  "by_project": {
+    "fake-project-abc123": {
+      "total_tokens": 15,
+      "session_count": 1,
+      "message_count": 1
+    }
+  },
+  "by_day": {
+    "2026-03-01": {
+      "total_tokens": 15,
+      "by_model": {
+        "sonnet": 15
+      }
+    }
+  },
+  "sessions": [
+    {
+      "session_id": "session-001",
+      "project": "fake-project-abc123",
+      "start_time": "2026-03-01T10:00:01+00:00",
+      "root_agent": "unknown",
+      "agents": [
+        "unknown"
+      ],
+      "total_tokens": 15,
+      "model_split": {
+        "sonnet": 15
+      },
+      "duration_minutes": 0,
+      "message_count": 1
+    }
+  ],
+  "limits": null
+}

--- a/tests/fixtures/session_summaries/dashboard_baseline_input/projects/fake-project-abc123/session-001.jsonl
+++ b/tests/fixtures/session_summaries/dashboard_baseline_input/projects/fake-project-abc123/session-001.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","message":{"role":"user","content":"Hello"},"uuid":"u-001","timestamp":"2026-03-01T10:00:00.000Z","sessionId":"sess-001","userType":"external"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi there."}],"model":"claude-sonnet-4-6","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"uuid":"a-001","timestamp":"2026-03-01T10:00:01.000Z","sessionId":"sess-001"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,9 +39,9 @@ EXPECTED_TOP_LEVEL_KEYS = {
 
 class TestFormatJson:
     def test_outputs_valid_json(self, sample_session_dir: Path):
-        """--format json must write parseable JSON to stdout."""
+        """dashboard --format json must write parseable JSON to stdout."""
         result = run_cli(
-            ["--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
             cwd=WORKTREE_ROOT,
         )
         assert result.returncode == 0, f"CLI failed:\n{result.stderr}"
@@ -51,7 +51,7 @@ class TestFormatJson:
     def test_has_expected_top_level_keys(self, sample_session_dir: Path):
         """JSON output must contain all expected top-level keys."""
         result = run_cli(
-            ["--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
@@ -60,7 +60,7 @@ class TestFormatJson:
     def test_contains_aggregated_data(self, sample_session_dir: Path):
         """JSON output must reflect the parsed session data."""
         result = run_cli(
-            ["--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
@@ -74,7 +74,7 @@ class TestFormatJson:
         """generated_at must be a valid ISO-8601 datetime string."""
         from datetime import datetime
         result = run_cli(
-            ["--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
@@ -86,6 +86,7 @@ class TestFormatJson:
         """When limit flags are passed, they appear in the JSON output."""
         result = run_cli(
             [
+                "dashboard",
                 "--format", "json",
                 "--no-open",
                 "--data-dir", str(sample_session_dir),
@@ -104,16 +105,16 @@ class TestFormatJson:
     def test_limits_null_when_not_set(self, sample_session_dir: Path):
         """When no limit flags are passed, limits key is null."""
         result = run_cli(
-            ["--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
         assert data["limits"] is None
 
     def test_empty_data_dir_still_valid_json(self, tmp_path: Path):
-        """--format json with an empty data dir must still produce valid JSON."""
+        """dashboard --format json with an empty data dir must still produce valid JSON."""
         result = run_cli(
-            ["--format", "json", "--no-open", "--data-dir", str(tmp_path)],
+            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(tmp_path)],
             cwd=WORKTREE_ROOT,
         )
         assert result.returncode == 0
@@ -123,9 +124,10 @@ class TestFormatJson:
         assert data["sessions"] == []
 
     def test_does_not_write_html_file(self, sample_session_dir: Path, tmp_path: Path):
-        """--format json must not write any HTML file."""
+        """dashboard --format json must not write any HTML file."""
         result = run_cli(
             [
+                "dashboard",
                 "--format", "json",
                 "--no-open",
                 "--data-dir", str(sample_session_dir),
@@ -143,6 +145,7 @@ class TestFormatHtmlDefault:
         output_path = tmp_path / "dashboard.html"
         result = run_cli(
             [
+                "dashboard",
                 "--no-open",
                 "--data-dir", str(sample_session_dir),
                 "--output", str(output_path),
@@ -157,6 +160,7 @@ class TestFormatHtmlDefault:
         output_path = tmp_path / "dashboard.html"
         result = run_cli(
             [
+                "dashboard",
                 "--format", "html",
                 "--no-open",
                 "--data-dir", str(sample_session_dir),

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -1,0 +1,47 @@
+"""Tests for top-level CLI subparser routing."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run claude_usage as a module and capture output.
+
+    Args:
+        *args: Command-line arguments to pass after the module name.
+
+    Returns:
+        CompletedProcess with stdout, stderr, and returncode populated.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "claude_usage", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_bare_invocation_exits_0_and_shows_subcommands() -> None:
+    """Bare 'claude-usage' with no args must exit 0 and list subcommands."""
+    result = _run()
+    assert result.returncode == 0
+    combined = result.stdout + result.stderr
+    assert "dashboard" in combined
+    assert "session-summary" in combined
+
+
+def test_dashboard_help_exits_0() -> None:
+    """'claude-usage dashboard --help' must exit 0."""
+    result = _run("dashboard", "--help")
+    assert result.returncode == 0
+
+
+def test_old_flag_only_form_exits_nonzero() -> None:
+    """'claude-usage --format json' (old form) must exit non-zero post-refactor.
+
+    The top-level parser no longer accepts --format; callers must migrate
+    to 'claude-usage dashboard --format json'.
+    """
+    result = _run("--format", "json")
+    assert result.returncode != 0

--- a/tests/test_dashboard_snapshot.py
+++ b/tests/test_dashboard_snapshot.py
@@ -1,0 +1,66 @@
+"""Regression test: dashboard JSON output is byte-identical after refactor.
+
+Compares 'claude-usage dashboard --format json' output against the
+snapshot captured on main before the subparser refactor (Phase 0).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+FIXTURE_DIR = (
+    Path(__file__).parent
+    / "fixtures"
+    / "session_summaries"
+    / "dashboard_baseline_input"
+)
+SNAPSHOT_FILE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "dashboard_snapshot_pre_refactor.json"
+)
+
+
+def test_existing_dashboard_unchanged() -> None:
+    """dashboard --format json output must be byte-identical to pre-refactor.
+
+    Runs the dashboard subcommand against the committed minimal fixture
+    tree and compares stdout to the snapshot captured on main before the
+    refactor. Any diff indicates a behavior regression in the refactor.
+
+    Note: generated_at will differ between runs (it is the current
+    timestamp). The comparison therefore normalises that field to a
+    fixed sentinel before comparing, so only structural/data differences
+    trigger a failure.
+    """
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "claude_usage",
+            "dashboard",
+            "--from", "2026-01-01",
+            "--to", "2026-12-31",
+            "--format", "json",
+            "--data-dir", str(FIXTURE_DIR),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"dashboard exited {result.returncode}.\nstderr: {result.stderr}"
+    )
+
+    actual = json.loads(result.stdout)
+    expected = json.loads(SNAPSHOT_FILE.read_text(encoding="utf-8"))
+
+    # Normalise the timestamp field — it will differ between runs.
+    actual["generated_at"] = "__normalised__"
+    expected["generated_at"] = "__normalised__"
+
+    assert actual == expected, (
+        "Dashboard JSON output differs from pre-refactor snapshot.\n"
+        "If this is intentional, re-capture the snapshot (Phase 0 Task 0 "
+        "Step 2) and commit the updated file."
+    )


### PR DESCRIPTION
## Summary

First merge slice of the `session-summary` subcommand implementation (Issue #19, tracked by plan `docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md`). Covers Phase 0 (pre-refactor baseline) and Phase 1 (CLI subparser refactor).

**Part of #19** — does not close it. Phases 2–6 (dataclasses, core derivation, error handling, output formats, polish) land in follow-up PRs.

## What changed

**Phase 0 — baseline capture** (`68e3454`)
- Added minimal fake `.claude` fixture tree under `tests/fixtures/session_summaries/dashboard_baseline_input/`
- Captured byte-identical `claude-usage --format json` snapshot to `tests/fixtures/dashboard_snapshot_pre_refactor.json` (1,324 bytes)

**Phase 1 — CLI subparser refactor** (`f4a42ef`, `b2a32cf`, `de3d4f2`)
- New `claude_usage/cli/` package with `dashboard.py` (full body of old `main()` moved verbatim into `run(args)`) and `session_summary.py` stub (raises `NotImplementedError` until Phase 2)
- `claude_usage/__main__.py` rewritten as a ~30-line subparser dispatcher — old flag-only form (`claude-usage --format json`) removed; callers must use `claude-usage dashboard --format json`
- `tests/test_cli_subcommands.py` — 3 new tests covering bare-invocation, dashboard-help, and removal of old flag-only form
- `tests/test_dashboard_snapshot.py` — regression gate that diffs live CLI output against the Phase 0 snapshot
- `tests/test_cli.py` — 10 pre-existing invocations migrated to new `dashboard` subcommand form

## Breaking change

`claude-usage --format json` (top-level flag form) no longer works. Use `claude-usage dashboard --format json`. Any external `subprocess` callers of this project's CLI need the same migration.

## Test plan

- [x] `uv run pytest` — 99 passed / 0 failed / 0 skipped (95 pre-existing + 3 subcommand routing + 1 snapshot gate)
- [x] `uv run ruff check .` — 10 pre-existing issues, 0 new
- [x] `test_existing_dashboard_unchanged` passes — confirms Phase 1 refactor introduces zero behavioral drift vs. Phase 0 baseline
- [x] `claude-usage dashboard --help` exits 0; bare `claude-usage` lists both subcommands
- [x] `session-summary` stub raises `NotImplementedError` (expected — Phase 2 adds the implementation)

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*