### PR TITLE
feat(session-summary): Phase 3 — core derivation logic (TDD) (#19)

### DIFF
--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -25,6 +25,13 @@ EXIT_NOT_JSONL = 3
 
 DEFAULT_MAX_ACTIONS: int = 50
 
+_EDIT_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "NotebookEdit"})
+_SKIP_TOOLS: frozenset[str] = frozenset({
+    "Read", "Grep", "Glob",
+    "WebFetch", "WebSearch",
+    "Skill", "TodoWrite",
+})
+
 _XML_WRAPPER_RE = re.compile(
     r"<(system-reminder|command-message|command-name"
     r"|command-args|local-command-stdout)>.*?</\1>",
@@ -213,40 +220,104 @@ def _derive_intent(entries: list[dict], project: str) -> str:
     return f"Session on {project}"
 
 
+def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
+    """Classify a single tool-use content block into an ActionRecord.
+
+    Returns None for tools that should be skipped (info-gathering,
+    skill enablers, ceremony). Returns an ActionRecord for all
+    state-changing tools. Unknown tool names produce an "other"-class
+    record for forward compatibility.
+
+    Args:
+        tool_use: A content block dict with ``type == "tool_use"``.
+
+    Returns:
+        An ActionRecord, or None if this tool use should be skipped.
+    """
+    name: str = tool_use.get("name", "")
+    inp: dict = tool_use.get("input", {})
+
+    # Skip list — info-gathering and ceremony.
+    if name in _SKIP_TOOLS:
+        return None
+
+    # Edit family.
+    if name in _EDIT_TOOLS:
+        target = inp.get("file_path", "")
+        return ActionRecord(
+            type="edit",
+            raw_tool=name,
+            target=target,
+            summary=f"Edited {target}",
+        )
+
+    # Bash / PowerShell — implemented in Task 3.5.
+    # Agent — implemented in Task 3.5.
+    # MCP — implemented in Task 3.6 (next pass).
+
+    # Placeholder for not-yet-classified tools: skip rather than
+    # produce "other" until later tasks fill them in. Once Task 3.6
+    # is complete this branch will handle the "other" catch-all.
+    return None
+
+
+def _collapse_consecutive(
+    records: list[ActionRecord],
+) -> list[ActionRecord]:
+    """Collapse consecutive ActionRecords that share (type, target).
+
+    Non-adjacent duplicates are NOT collapsed — chronological order
+    is preserved and the collapse is strictly sequential.
+
+    Args:
+        records: Chronologically ordered list of ActionRecords.
+
+    Returns:
+        Collapsed list with no two adjacent records sharing
+        (type, target).
+    """
+    if not records:
+        return []
+    collapsed: list[ActionRecord] = [records[0]]
+    for rec in records[1:]:
+        prev = collapsed[-1]
+        if rec.type == prev.type and rec.target == prev.target:
+            continue  # Duplicate of the previous record — drop it.
+        collapsed.append(rec)
+    return collapsed
+
+
 def _collect_tool_uses(entries: list[dict]) -> list[ActionRecord]:
     """Classify all tool-use content blocks from assistant entries.
+
+    Iterates entries in file order, collects tool_use blocks from
+    assistant message content, classifies each, skips None results,
+    then collapses consecutive duplicates.
 
     Args:
         entries: Parsed JSONL entries in file order.
 
     Returns:
-        Chronologically ordered list of ActionRecord instances, with
-        consecutive records sharing (type, target) collapsed to one.
+        Chronologically ordered, collapsed list of ActionRecord
+        instances.
     """
-    # Stub — returns hardcoded actions matching happy_path fixture.
-    # Replaced by real logic in Tasks 3.4–3.6.
-    return [
-        ActionRecord(
-            type="edit",
-            raw_tool="Edit",
-            target="claude_usage/cli/session_summary.py",
-            summary="Edited claude_usage/cli/session_summary.py",
-        ),
-        ActionRecord(
-            type="bash",
-            raw_tool="Bash",
-            target="uv run pytest tests/test_session_summary.py -x",
-            summary=(
-                "Ran `uv run pytest tests/test_session_summary.py -x`"
-            ),
-        ),
-        ActionRecord(
-            type="agent_dispatch",
-            raw_tool="Agent",
-            target="code-reviewer",
-            summary="Dispatched code-reviewer sub-agent",
-        ),
-    ]
+    raw: list[ActionRecord] = []
+    for entry in entries:
+        if entry.get("type") != "assistant":
+            continue
+        msg = entry.get("message", {})
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_use":
+                continue
+            record = _classify_tool_use(block)
+            if record is not None:
+                raw.append(record)
+    return _collapse_consecutive(raw)
 
 
 def _derive_stopped_naturally(

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -28,10 +28,14 @@ DEFAULT_MAX_ACTIONS: int = 50
 _EDIT_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "NotebookEdit"})
 _BASH_TOOLS: frozenset[str] = frozenset({"Bash", "PowerShell"})
 _MAX_COMMAND_CHARS: int = 80
-_SKIP_TOOLS: frozenset[str] = frozenset({
-    "Read", "Grep", "Glob",
-    "WebFetch", "WebSearch",
-    "Skill", "TodoWrite",
+SKIPPED_TOOLS: frozenset[str] = frozenset({
+    "Read",
+    "Grep",
+    "Glob",
+    "WebFetch",
+    "WebSearch",
+    "Skill",
+    "TodoWrite",
 })
 
 _XML_WRAPPER_RE = re.compile(
@@ -288,7 +292,7 @@ def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
     inp: dict = tool_use.get("input", {})
 
     # Skip list — info-gathering and ceremony.
-    if name in _SKIP_TOOLS:
+    if name in SKIPPED_TOOLS:
         return None
 
     # Edit family.

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -222,6 +222,54 @@ def _derive_intent(entries: list[dict], project: str) -> str:
     return f"Session on {project}"
 
 
+def _normalize_mcp_tool_name(raw: str) -> str | None:
+    """Normalize an MCP tool name to '<server>.<method>'.
+
+    Handles both forms:
+    - Plugin-scoped: ``mcp__plugin_<plugin>_<server>__<method>``
+      e.g. ``mcp__plugin_github_github__create_issue`` → ``github.create_issue``
+    - Direct: ``mcp__<server>__<method>``
+      e.g. ``mcp__azure__storage`` → ``azure.storage``
+
+    Returns None when the name is malformed (starts with ``mcp__`` but
+    does not contain the expected structural separators after stripping
+    the plugin segment), so the caller can fall back to the ``other``
+    action class. This provides forward-compatibility when new MCP naming
+    conventions appear in future Claude Code versions.
+
+    Args:
+        raw: The raw tool name from the transcript.
+
+    Returns:
+        A normalised ``<server>.<method>`` string, or None if the name
+        is structurally malformed.
+    """
+    if not raw.startswith("mcp__"):
+        return None
+    remainder = raw[len("mcp__"):]
+
+    # Strip the plugin segment if present.
+    # Plugin form: plugin_<plugin>_<server>__<method>
+    # After stripping "plugin_", the next segment is "<plugin>_<server>"
+    # which is separated from <method> by "__".
+    if remainder.startswith("plugin_"):
+        after_plugin = remainder[len("plugin_"):]
+        # after_plugin is "<plugin>_<server>__<method>" — split once on "_"
+        # to skip the plugin label, leaving "<server>__<method>".
+        parts = after_plugin.split("_", 1)
+        if len(parts) < 2:
+            return None  # Malformed: nothing after plugin label.
+        remainder = parts[1]
+
+    # remainder is now "<server>__<method>" for both forms.
+    if "__" not in remainder:
+        return None  # Malformed: no method separator.
+    server, _, method = remainder.partition("__")
+    if not server or not method:
+        return None  # Malformed: empty server or method.
+    return f"{server}.{method}"
+
+
 def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
     """Classify a single tool-use content block into an ActionRecord.
 
@@ -278,12 +326,27 @@ def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
             summary=f"Dispatched {subagent_type} sub-agent",
         )
 
-    # MCP — implemented in Task 3.6 (next pass).
+    # MCP tools — both plugin-scoped and direct forms.
+    if name.startswith("mcp__"):
+        normalised = _normalize_mcp_tool_name(name)
+        if normalised is not None:
+            return ActionRecord(
+                type="mcp",
+                raw_tool=name,
+                target=normalised,
+                summary=f"Called `{normalised}` (MCP)",
+            )
+        # Malformed MCP name — fall through to the "other" default below.
+        # Do NOT return None here; let the catch-all produce an ActionRecord.
+        return ActionRecord(
+            type="other",
+            raw_tool=name,
+            target=name,
+            summary=f"Used {name} tool",
+        )
 
-    # Placeholder for not-yet-classified tools: skip rather than
-    # produce "other" until later tasks fill them in. Once Task 3.6
-    # is complete this branch will handle the "other" catch-all.
-    return None
+    # "other" default — implemented in Task 3.9.
+    return None   # temporary; replaced in Task 3.9
 
 
 def _collapse_consecutive(

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -277,25 +277,34 @@ def _normalize_mcp_tool_name(raw: str) -> str | None:
 def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
     """Classify a single tool-use content block into an ActionRecord.
 
-    Returns None for tools that should be skipped (info-gathering,
-    skill enablers, ceremony). Returns an ActionRecord for all
-    state-changing tools. Unknown tool names produce an "other"-class
-    record for forward compatibility.
+    Returns None only for tools in SKIPPED_TOOLS (info-gathering,
+    skill enablers, ceremony). Every other tool name produces an
+    ActionRecord — either a typed record for known tools or an
+    ``other``-type record for forward compatibility with unknown tools.
+
+    Classification priority:
+    1. Skip list (SKIPPED_TOOLS) — return None immediately.
+    2. Edit family (_EDIT_TOOLS) — return "edit" ActionRecord.
+    3. Bash/PowerShell family (_BASH_TOOLS) — return "bash" ActionRecord.
+    4. Agent dispatch — return "agent_dispatch" ActionRecord.
+    5. MCP tools (mcp__* prefix) — normalise name; return "mcp" on success,
+       "other" on malformed name.
+    6. Catch-all — return "other" ActionRecord for forward compatibility.
 
     Args:
         tool_use: A content block dict with ``type == "tool_use"``.
 
     Returns:
-        An ActionRecord, or None if this tool use should be skipped.
+        An ActionRecord, or None if this tool use is in the skip list.
     """
     name: str = tool_use.get("name", "")
     inp: dict = tool_use.get("input", {})
 
-    # Skip list — info-gathering and ceremony.
+    # 1. Skip list — info-gathering and ceremony.
     if name in SKIPPED_TOOLS:
         return None
 
-    # Edit family.
+    # 2. Edit family.
     if name in _EDIT_TOOLS:
         target = inp.get("file_path", "")
         return ActionRecord(
@@ -305,7 +314,7 @@ def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
             summary=f"Edited {target}",
         )
 
-    # Bash / PowerShell.
+    # 3. Bash / PowerShell.
     if name in _BASH_TOOLS:
         raw_command: str = inp.get("command", "")
         collapsed_command = " ".join(raw_command.split())
@@ -320,7 +329,7 @@ def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
             summary=f"Ran `{rendered}`",
         )
 
-    # Agent dispatch.
+    # 4. Agent dispatch.
     if name == "Agent":
         subagent_type: str = inp.get("subagent_type", "unknown")
         return ActionRecord(
@@ -330,7 +339,7 @@ def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
             summary=f"Dispatched {subagent_type} sub-agent",
         )
 
-    # MCP tools — both plugin-scoped and direct forms.
+    # 5. MCP tools — both plugin-scoped and direct forms.
     if name.startswith("mcp__"):
         normalised = _normalize_mcp_tool_name(name)
         if normalised is not None:
@@ -349,8 +358,13 @@ def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
             summary=f"Used {name} tool",
         )
 
-    # "other" default — implemented in Task 3.9.
-    return None   # temporary; replaced in Task 3.9
+    # 6. Catch-all — default-include unknown tools for forward compatibility.
+    return ActionRecord(
+        type="other",
+        raw_tool=name,
+        target=name,
+        summary=f"Used {name} tool",
+    )
 
 
 def _collapse_consecutive(

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -490,29 +490,32 @@ def _derive_stopped_naturally(
 
 
 def _apply_max_actions_cap(
-    records: list[ActionRecord],
+    actions: list[str],
     max_actions: int,
 ) -> list[str]:
-    """Convert ActionRecords to summary strings, applying the cap.
+    """Apply the --max-actions cap with sentinel truncation.
 
-    When max_actions > 0 and len(records) > max_actions, keep the first
-    max_actions - 1 records and append a sentinel string describing how
-    many were omitted.
+    When ``max_actions`` is 0, the cap is disabled and the full list is
+    returned. Otherwise, if ``len(actions) > max_actions``, keep the
+    first ``max_actions - 1`` entries and append a sentinel string of
+    the form ``'… (<K> additional actions omitted)'`` where ``K`` is the
+    number of dropped entries.
 
     Args:
-        records: Classified, collapsed ActionRecord list.
+        actions: Already-rendered past-tense action strings.
         max_actions: Cap value. 0 means no cap.
 
     Returns:
-        List of past-tense action strings, bounded by the cap.
+        The (possibly truncated) list of action strings.
     """
-    summaries = [r.summary for r in records]
-    if max_actions == 0 or len(summaries) <= max_actions:
-        return summaries
-    kept = summaries[: max_actions - 1]
-    dropped = len(summaries) - (max_actions - 1)
-    kept.append(f"… ({dropped} additional actions omitted)")
-    return kept
+    if max_actions <= 0:
+        return list(actions)
+    if len(actions) <= max_actions:
+        return list(actions)
+    kept = actions[: max_actions - 1]
+    dropped = len(actions) - (max_actions - 1)
+    sentinel = f"… ({dropped} additional actions omitted)"
+    return [*kept, sentinel]
 
 
 def build_session_summary(
@@ -542,7 +545,12 @@ def build_session_summary(
     intent = _derive_intent(entries, project)
     records = _collect_tool_uses(entries)
     stopped_naturally = _derive_stopped_naturally(entries)
-    action_strings = _apply_max_actions_cap(records, max_actions)
+
+    # Render ActionRecords to strings, then apply the cap.
+    action_strings_full = [r.summary for r in records]
+    action_strings = _apply_max_actions_cap(
+        action_strings_full, max_actions
+    )
 
     return SessionSummary(
         project=project,

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from pathlib import Path
 
 EXIT_OK = 0
 EXIT_IO_FAILURE = 1
@@ -86,9 +87,24 @@ def _derive_project(entries: list[dict], slug_fallback: str | None = None) -> st
     Returns:
         A non-empty project name string.
     """
-    # Stub — returns hardcoded value matching happy_path fixture.
-    # Replaced by real logic in Task 3.2.
-    return "claude-usage"
+    from claude_usage.parser import decode_project_hash
+
+    # Strategy 1: cwd field on any entry.
+    for entry in entries:
+        cwd = entry.get("cwd")
+        if cwd and isinstance(cwd, str):
+            name = Path(cwd).name
+            if name:
+                return name
+
+    # Strategy 2: decode the project-hash slug supplied by the caller.
+    if slug_fallback:
+        decoded = decode_project_hash(slug_fallback)
+        if decoded:
+            return decoded
+
+    # Strategy 3: final fallback.
+    return "unknown"
 
 
 def _derive_intent(entries: list[dict], project: str) -> str:

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -68,6 +68,126 @@ class SessionSummary:
     stopped_naturally: bool | None
 
 
+def _derive_project(entries: list[dict], slug_fallback: str | None = None) -> str:
+    """Derive the project name from transcript entries.
+
+    Strategy:
+    1. First entry with a non-empty ``cwd`` field → ``Path(cwd).name``.
+    2. Fallback: apply ``decode_project_hash`` to ``slug_fallback``
+       (the transcript-directory name passed in by ``run()``).
+    3. Final fallback: ``"unknown"``.
+
+    Args:
+        entries: Parsed JSONL entries in file order.
+        slug_fallback: Optional project-slug string from the transcript
+            directory name, used when no ``cwd`` field appears on any
+            entry.
+
+    Returns:
+        A non-empty project name string.
+    """
+    # Stub — returns hardcoded value matching happy_path fixture.
+    # Replaced by real logic in Task 3.2.
+    return "claude-usage"
+
+
+def _derive_intent(entries: list[dict], project: str) -> str:
+    """Derive the user's intent from the first external user turn.
+
+    Args:
+        entries: Parsed JSONL entries in file order.
+        project: The already-derived project name (used as fallback).
+
+    Returns:
+        A non-empty intent string.
+    """
+    # Stub — returns hardcoded value matching happy_path fixture.
+    # Replaced by real logic in Task 3.3.
+    return (
+        "Implement the session-summary subcommand for the /whats-next skill"
+    )
+
+
+def _collect_tool_uses(entries: list[dict]) -> list[ActionRecord]:
+    """Classify all tool-use content blocks from assistant entries.
+
+    Args:
+        entries: Parsed JSONL entries in file order.
+
+    Returns:
+        Chronologically ordered list of ActionRecord instances, with
+        consecutive records sharing (type, target) collapsed to one.
+    """
+    # Stub — returns hardcoded actions matching happy_path fixture.
+    # Replaced by real logic in Tasks 3.4–3.6.
+    return [
+        ActionRecord(
+            type="edit",
+            raw_tool="Edit",
+            target="claude_usage/cli/session_summary.py",
+            summary="Edited claude_usage/cli/session_summary.py",
+        ),
+        ActionRecord(
+            type="bash",
+            raw_tool="Bash",
+            target="uv run pytest tests/test_session_summary.py -x",
+            summary=(
+                "Ran `uv run pytest tests/test_session_summary.py -x`"
+            ),
+        ),
+        ActionRecord(
+            type="agent_dispatch",
+            raw_tool="Agent",
+            target="code-reviewer",
+            summary="Dispatched code-reviewer sub-agent",
+        ),
+    ]
+
+
+def _derive_stopped_naturally(
+    entries: list[dict],
+) -> bool | None:
+    """Determine whether the session ended naturally.
+
+    Args:
+        entries: Parsed JSONL entries in file order.
+
+    Returns:
+        True if last assistant stop_reason == "end_turn" and no
+        prevented-continuation marker was seen. False on a definitive
+        interrupt signal. None when the signal is indeterminate.
+    """
+    # Stub — returns True matching happy_path fixture.
+    # Replaced by real logic in Task 3.7 (next pass).
+    return True
+
+
+def _apply_max_actions_cap(
+    records: list[ActionRecord],
+    max_actions: int,
+) -> list[str]:
+    """Convert ActionRecords to summary strings, applying the cap.
+
+    When max_actions > 0 and len(records) > max_actions, keep the first
+    max_actions - 1 records and append a sentinel string describing how
+    many were omitted.
+
+    Args:
+        records: Classified, collapsed ActionRecord list.
+        max_actions: Cap value. 0 means no cap.
+
+    Returns:
+        List of past-tense action strings, bounded by the cap.
+    """
+    summaries = [r.summary for r in records]
+    if max_actions == 0 or len(summaries) <= max_actions:
+        return summaries
+    kept = summaries[: max_actions - 1]
+    dropped = len(summaries) - (max_actions - 1)
+    kept.append(f"… ({dropped} additional actions omitted)")
+    return kept
+
+
 def build_session_summary(
     entries: list[dict],
     *,
@@ -84,17 +204,25 @@ def build_session_summary(
         entries: Parsed JSONL entries (already filtered for successfully
             decoded objects).
         project_slug_fallback: Optional transcript-directory slug passed
-            through to `_derive_project` for the `decode_project_hash`
-            fallback when no `cwd` field appears on any entry.
+            through to ``_derive_project`` for the ``decode_project_hash``
+            fallback when no ``cwd`` field appears on any entry.
         max_actions: Soft cap on emitted actions; 0 disables the cap.
 
     Returns:
         Fully-populated SessionSummary.
-
-    Raises:
-        NotImplementedError: Temporarily, until Phase 3 fills this in.
     """
-    raise NotImplementedError("build_session_summary — implemented in Phase 3")
+    project = _derive_project(entries, project_slug_fallback)
+    intent = _derive_intent(entries, project)
+    records = _collect_tool_uses(entries)
+    stopped_naturally = _derive_stopped_naturally(entries)
+    action_strings = _apply_max_actions_cap(records, max_actions)
+
+    return SessionSummary(
+        project=project,
+        intent=intent,
+        actions=action_strings,
+        stopped_naturally=stopped_naturally,
+    )
 
 
 def render_json(summary: SessionSummary) -> str:

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -429,19 +429,64 @@ def _collect_tool_uses(entries: list[dict]) -> list[ActionRecord]:
 def _derive_stopped_naturally(
     entries: list[dict],
 ) -> bool | None:
-    """Determine whether the session ended naturally.
+    """Resolve the tri-state stoppedNaturally field per the spec's table.
+
+    Walks entries once, tracking:
+    - ``has_any_assistant``: True once any assistant entry is seen.
+    - ``last_stop_reason``: Updated on every assistant entry; last wins.
+    - ``prevented_continuation``: True if any stop_hook_summary entry
+      has ``preventedContinuation: true``.
+
+    Resolution table (applied in priority order):
+    - no assistant entries → None (nothing to judge)
+    - last stop_reason absent/empty → None (signal absent)
+    - prevented_continuation is True → False (definitive interrupt)
+    - last stop_reason == "end_turn" → True
+    - last stop_reason in {"max_tokens", "tool_use", "stop_sequence"} → False
+    - any other non-empty stop_reason → None (unknown variant; don't guess)
+
+    Callers emit None as JSON null so consumers can distinguish
+    'unknown' from 'interrupted'.
 
     Args:
         entries: Parsed JSONL entries in file order.
 
     Returns:
-        True if last assistant stop_reason == "end_turn" and no
-        prevented-continuation marker was seen. False on a definitive
-        interrupt signal. None when the signal is indeterminate.
+        True for a clean natural end, False for a definitive interrupt
+        signal, or None when the signal is genuinely indeterminate.
     """
-    # Stub — returns True matching happy_path fixture.
-    # Replaced by real logic in Task 3.7 (next pass).
-    return True
+    has_any_assistant: bool = False
+    last_stop_reason: str | None = None
+    prevented_continuation: bool = False
+
+    for entry in entries:
+        etype = entry.get("type")
+
+        if etype == "assistant":
+            has_any_assistant = True
+            message = entry.get("message") or {}
+            reason = message.get("stop_reason")
+            # Update on every assistant entry — last one wins.
+            last_stop_reason = reason if reason else None
+
+        elif etype == "system":
+            if entry.get("subtype") == "stop_hook_summary":
+                if entry.get("preventedContinuation") is True:
+                    prevented_continuation = True
+
+    # Resolution table — applied in priority order.
+    if not has_any_assistant:
+        return None
+    if last_stop_reason is None:
+        return None
+    if prevented_continuation:
+        return False
+    if last_stop_reason == "end_turn":
+        return True
+    if last_stop_reason in ("max_tokens", "tool_use", "stop_sequence"):
+        return False
+    # Unknown non-empty stop_reason — don't guess.
+    return None
 
 
 def _apply_max_actions_cap(

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -26,6 +26,8 @@ EXIT_NOT_JSONL = 3
 DEFAULT_MAX_ACTIONS: int = 50
 
 _EDIT_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "NotebookEdit"})
+_BASH_TOOLS: frozenset[str] = frozenset({"Bash", "PowerShell"})
+_MAX_COMMAND_CHARS: int = 80
 _SKIP_TOOLS: frozenset[str] = frozenset({
     "Read", "Grep", "Glob",
     "WebFetch", "WebSearch",
@@ -251,8 +253,31 @@ def _classify_tool_use(tool_use: dict) -> ActionRecord | None:
             summary=f"Edited {target}",
         )
 
-    # Bash / PowerShell — implemented in Task 3.5.
-    # Agent — implemented in Task 3.5.
+    # Bash / PowerShell.
+    if name in _BASH_TOOLS:
+        raw_command: str = inp.get("command", "")
+        collapsed_command = " ".join(raw_command.split())
+        if len(collapsed_command) > _MAX_COMMAND_CHARS:
+            rendered = collapsed_command[:_MAX_COMMAND_CHARS] + "…"
+        else:
+            rendered = collapsed_command
+        return ActionRecord(
+            type="bash",
+            raw_tool=name,
+            target=collapsed_command,
+            summary=f"Ran `{rendered}`",
+        )
+
+    # Agent dispatch.
+    if name == "Agent":
+        subagent_type: str = inp.get("subagent_type", "unknown")
+        return ActionRecord(
+            type="agent_dispatch",
+            raw_tool=name,
+            target=subagent_type,
+            summary=f"Dispatched {subagent_type} sub-agent",
+        )
+
     # MCP — implemented in Task 3.6 (next pass).
 
     # Placeholder for not-yet-classified tools: skip rather than

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -14,6 +14,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,6 +24,16 @@ EXIT_NO_USER_TURNS = 2
 EXIT_NOT_JSONL = 3
 
 DEFAULT_MAX_ACTIONS: int = 50
+
+_XML_WRAPPER_RE = re.compile(
+    r"<(system-reminder|command-message|command-name"
+    r"|command-args|local-command-stdout)>.*?</\1>",
+    flags=re.DOTALL,
+)
+_SLASH_COMMAND_RE = re.compile(
+    r"<command-name>(/[^<]+)</command-name>"
+)
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[\.\!\?])\s|\n")
 
 
 @dataclass(frozen=True)
@@ -107,8 +118,64 @@ def _derive_project(entries: list[dict], slug_fallback: str | None = None) -> st
     return "unknown"
 
 
+def _extract_text_from_content(
+    content: str | list,
+) -> str:
+    """Extract plain text from a message content value.
+
+    Args:
+        content: Either a raw string or a list of content blocks. In the
+            list form, only blocks with ``type == "text"`` are included;
+            tool_result and other block types are skipped.
+
+    Returns:
+        A single string with all text joined by spaces, not yet stripped.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            block["text"]
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and "text" in block
+        ]
+        return " ".join(parts)
+    return ""
+
+
+def _first_sentence(text: str, max_chars: int = 200) -> str:
+    """Return the first sentence of text, capped at max_chars.
+
+    Splits on ". ", "! ", "? ", or a newline. If the first segment is
+    longer than max_chars, truncates at max_chars. Trailing punctuation
+    from the split is not included in the result.
+
+    Args:
+        text: Already-stripped input text.
+        max_chars: Maximum character count for the returned string.
+
+    Returns:
+        The first sentence or the first max_chars characters.
+    """
+    parts = _SENTENCE_SPLIT_RE.split(text, maxsplit=1)
+    sentence = parts[0].rstrip(". !?")
+    return sentence[:max_chars]
+
+
 def _derive_intent(entries: list[dict], project: str) -> str:
     """Derive the user's intent from the first external user turn.
+
+    Steps:
+    1. Find the first ``type: "user"`` + ``userType: "external"`` entry.
+    2. Extract text from ``message.content`` (string or list of blocks).
+    3. Strip the five XML wrapper tag families via regex.
+    4. Trim whitespace. If non-empty → take the first sentence (or 200
+       chars, whichever is shorter).
+    5. If empty, look for a ``<command-name>/<name></command-name>``
+       pattern in the original content → ``"Ran /<name>"``.
+    6. Final fallback → ``"Session on <project>"``.
 
     Args:
         entries: Parsed JSONL entries in file order.
@@ -117,11 +184,33 @@ def _derive_intent(entries: list[dict], project: str) -> str:
     Returns:
         A non-empty intent string.
     """
-    # Stub — returns hardcoded value matching happy_path fixture.
-    # Replaced by real logic in Task 3.3.
-    return (
-        "Implement the session-summary subcommand for the /whats-next skill"
-    )
+    for entry in entries:
+        if not (
+            entry.get("type") == "user"
+            and entry.get("userType") == "external"
+        ):
+            continue
+        msg = entry.get("message", {})
+        raw_content = msg.get("content", "")
+        original_text = _extract_text_from_content(raw_content)
+
+        # Strip XML wrappers.
+        stripped = _XML_WRAPPER_RE.sub("", original_text).strip()
+
+        if stripped:
+            return _first_sentence(stripped)
+
+        # Slash-command fallback.
+        m = _SLASH_COMMAND_RE.search(original_text)
+        if m:
+            return f"Ran {m.group(1)}"
+
+        # Generic fallback.
+        return f"Session on {project}"
+
+    # No external user turn found (should not reach here after LookupError
+    # guard in build_session_summary, but keep defensive).
+    return f"Session on {project}"
 
 
 def _collect_tool_uses(entries: list[dict]) -> list[ActionRecord]:

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -1933,7 +1933,7 @@ step. No placeholders.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add four failing tests.**
+- [x] **Step 1: Add four failing tests.**
 
   Add to `TestBuildSessionSummary` in `tests/test_session_summary.py`:
 
@@ -2036,16 +2036,16 @@ step. No placeholders.
           assert summary.intent == "Session on myproject"
   ```
 
-- [ ] **Step 2: Run → confirm failures.**
+- [x] **Step 2: Run → confirm failures.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -k "intent" -x
   ```
 
   Expected: all four intent tests fail because `_derive_intent` returns a
-  hardcoded string.
+  hardcoded string. [confirmed: all 4 failed at red phase]
 
-- [ ] **Step 3: Implement `_derive_intent` with real logic.**
+- [x] **Step 3: Implement `_derive_intent` with real logic.**
 
   Replace the stub body of `_derive_intent` in `claude_usage/cli/session_summary.py`.
   Also add `import re` to the stdlib imports at the top of the file.
@@ -2162,7 +2162,7 @@ step. No placeholders.
       return f"Session on {project}"
   ```
 
-- [ ] **Step 4: Run → confirm pass.**
+- [x] **Step 4: Run → confirm pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -2170,7 +2170,7 @@ step. No placeholders.
 
   Expected: all tests pass, including all four new intent tests.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -2969,7 +2969,7 @@ name (prefix present but structural separators absent) falls through to the
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add four tests to `TestToolClassification`.**
+- [x] **Step 1: Add four tests to `TestToolClassification`.**
 
   ```python
       def test_action_classification_mcp_plugin_scoped(
@@ -3190,7 +3190,7 @@ name (prefix present but structural separators absent) falls through to the
           assert records[0].target == "github.create_issue"
   ```
 
-- [ ] **Step 2: Run → confirm all four tests fail.**
+- [x] **Step 2: Run → confirm all four tests fail.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestToolClassification \
@@ -3201,7 +3201,7 @@ name (prefix present but structural separators absent) falls through to the
   currently falls through to `return None` for any `mcp__*` name — the MCP
   branch does not yet exist.
 
-- [ ] **Step 3: Implement `_normalize_mcp_tool_name` and the MCP dispatch
+- [x] **Step 3: Implement `_normalize_mcp_tool_name` and the MCP dispatch
   branch.**
 
   Add the helper function at module level in `claude_usage/cli/session_summary.py`,
@@ -3300,7 +3300,7 @@ name (prefix present but structural separators absent) falls through to the
   > catch-all in Task 3.9 will never be reached for an `mcp__*` name. This
   > is intentional and matches the spec's forward-compat requirement.
 
-- [ ] **Step 4: Run → confirm all four MCP tests pass.**
+- [x] **Step 4: Run → confirm all four MCP tests pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -3309,7 +3309,7 @@ name (prefix present but structural separators absent) falls through to the
   Expected: all tests pass including all four new MCP tests. Existing tests
   are unaffected.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -2811,7 +2811,7 @@ step. No placeholders.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Confirm `test_action_classification_agent_dispatch` exists and
+- [x] **Step 1: Confirm `test_action_classification_agent_dispatch` exists and
   check its fixture contract.**
 
   The test was written in Task 3.5 and lives in `TestToolClassification`. It
@@ -2879,7 +2879,7 @@ step. No placeholders.
       )
   ```
 
-- [ ] **Step 2: Run → confirm both agent tests pass (green from Task 3.5).**
+- [x] **Step 2: Run → confirm both agent tests pass (green from Task 3.5).**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestToolClassification \
@@ -2890,7 +2890,7 @@ step. No placeholders.
   `test_action_classification_agent_dispatch_record_fields` pass. This is not
   a red step — it is a contract-verification step.
 
-- [ ] **Step 3: Confirm the dispatch branch in `_classify_tool_use`.**
+- [x] **Step 3: Confirm the dispatch branch in `_classify_tool_use`.**
 
   The Agent branch sits after the Bash/PowerShell block and before the final
   `return None`. For reference, the surrounding context in the function
@@ -2930,7 +2930,7 @@ step. No placeholders.
 
   No code change is needed here if Task 3.5 implemented the branch correctly.
 
-- [ ] **Step 4: Run full suite → confirm no regressions.**
+- [x] **Step 4: Run full suite → confirm no regressions.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -2938,7 +2938,7 @@ step. No placeholders.
 
   Expected: all tests pass.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -2533,7 +2533,7 @@ step. No placeholders.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add `test_action_classification_bash_tools` — confirm it fails.**
+- [x] **Step 1: Add `test_action_classification_bash_tools` — confirm it fails.**
 
   Add to `TestToolClassification` in `tests/test_session_summary.py`:
 
@@ -2719,7 +2719,7 @@ step. No placeholders.
           assert summary.actions[0] == "Dispatched code-reviewer sub-agent"
   ```
 
-- [ ] **Step 2: Run → confirm failures.**
+- [x] **Step 2: Run → confirm failures.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestToolClassification::test_action_classification_bash_tools tests/test_session_summary.py::TestToolClassification::test_action_classification_agent_dispatch -x
@@ -2728,7 +2728,7 @@ step. No placeholders.
   Expected: both tests fail because Bash, PowerShell, and Agent return `None`
   in the current `_classify_tool_use`.
 
-- [ ] **Step 3: Extend `_classify_tool_use` to handle Bash, PowerShell, and Agent.**
+- [x] **Step 3: Extend `_classify_tool_use` to handle Bash, PowerShell, and Agent.**
 
   Replace the Bash/PowerShell and Agent placeholder comments in
   `_classify_tool_use` with real dispatch blocks. Show the updated function
@@ -2769,7 +2769,7 @@ step. No placeholders.
           )
   ```
 
-- [ ] **Step 4: Run → confirm pass.**
+- [x] **Step 4: Run → confirm pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -2779,7 +2779,7 @@ step. No placeholders.
   real Bash and Agent classification in addition to Edit, so
   `len(summary.actions) > 0` remains trivially satisfied.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -4158,7 +4158,7 @@ where `K` is the count of dropped entries — is appended. Setting
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add three tests to a new `TestMaxActionsCap` class.**
+- [x] **Step 1: Add three tests to a new `TestMaxActionsCap` class.**
 
   The `over_fifty_actions.jsonl` fixture from Phase 2 contains 55 assistant
   entries each with a distinct `Edit` target (`src/file_001.py` …
@@ -4230,7 +4230,7 @@ where `K` is the count of dropped entries — is appended. Setting
           )
   ```
 
-- [ ] **Step 2: Run → confirm failures.**
+- [x] **Step 2: Run → confirm failures.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestMaxActionsCap -v
@@ -4253,7 +4253,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Expected: 56 lines (1 user entry + 55 assistant entries). If fewer, the
   Phase 2 fixture must be regenerated.
 
-- [ ] **Step 3: Implement `_apply_max_actions_cap` (standalone function) and
+- [x] **Step 3: Implement `_apply_max_actions_cap` (standalone function) and
   wire it into `build_session_summary`.**
 
   The Task 3.1 stub named this function `_apply_max_actions_cap` but had it
@@ -4321,7 +4321,7 @@ where `K` is the count of dropped entries — is appended. Setting
       )
   ```
 
-- [ ] **Step 4: Run → confirm all three tests pass.**
+- [x] **Step 4: Run → confirm all three tests pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestMaxActionsCap -v
@@ -4337,7 +4337,7 @@ where `K` is the count of dropped entries — is appended. Setting
   `list[str]` does not break any earlier tests because the function was only
   called from `build_session_summary`.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -1784,7 +1784,7 @@ step. No placeholders.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add two failing tests.**
+- [x] **Step 1: Add two failing tests.**
 
   Add to `TestBuildSessionSummary` in `tests/test_session_summary.py`:
 
@@ -1844,7 +1844,7 @@ step. No placeholders.
           assert summary.project == "unknown"
   ```
 
-- [ ] **Step 2: Run → confirm failures.**
+- [x] **Step 2: Run → confirm failures.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestBuildSessionSummary::test_project_falls_back_to_unknown -x
@@ -1855,7 +1855,7 @@ step. No placeholders.
   test may pass accidentally via the stub; confirm by temporarily removing the
   stub's hardcoded return and verifying it then fails before restoring.
 
-- [ ] **Step 3: Implement `_derive_project` with real logic.**
+- [x] **Step 3: Implement `_derive_project` with real logic.**
 
   Replace the stub body of `_derive_project` in `claude_usage/cli/session_summary.py`:
 
@@ -1900,7 +1900,7 @@ step. No placeholders.
       return "unknown"
   ```
 
-- [ ] **Step 4: Run → confirm pass.**
+- [x] **Step 4: Run → confirm pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -1908,7 +1908,7 @@ step. No placeholders.
 
   Expected: all tests pass, including both new project-derivation tests.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -3952,7 +3952,7 @@ resolution-table rows that produce deterministic outcomes.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add five tests to a new `TestStoppedNaturally` class.**
+- [x] **Step 1: Add five tests to a new `TestStoppedNaturally` class.**
 
   ```python
   class TestStoppedNaturally:
@@ -4019,7 +4019,7 @@ resolution-table rows that produce deterministic outcomes.
           assert summary.stopped_naturally is None
   ```
 
-- [ ] **Step 2: Run → confirm failures.**
+- [x] **Step 2: Run → confirm failures.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestStoppedNaturally -v
@@ -4030,7 +4030,7 @@ resolution-table rows that produce deterministic outcomes.
   `test_stopped_naturally_true_on_end_turn` test may pass accidentally through
   the stub; the other four will fail.
 
-- [ ] **Step 3: Implement `_derive_stopped_naturally` with real tri-state logic.**
+- [x] **Step 3: Implement `_derive_stopped_naturally` with real tri-state logic.**
 
   Replace the stub body in `claude_usage/cli/session_summary.py` with the
   full implementation. Show the complete function:
@@ -4108,7 +4108,7 @@ resolution-table rows that produce deterministic outcomes.
 
   No change to the call site is needed — only the function body changes.
 
-- [ ] **Step 4: Run → confirm all five tests pass.**
+- [x] **Step 4: Run → confirm all five tests pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestStoppedNaturally -v
@@ -4122,7 +4122,7 @@ resolution-table rows that produce deterministic outcomes.
 
   Expected: all tests pass.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -2195,7 +2195,7 @@ step. No placeholders.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add `test_action_classification_edit_tools` — confirm it fails.**
+- [x] **Step 1: Add `test_action_classification_edit_tools` — confirm it fails.**
 
   Add a new test class to `tests/test_session_summary.py`:
 
@@ -2369,7 +2369,7 @@ step. No placeholders.
           assert summary.actions == []
   ```
 
-- [ ] **Step 2: Run → confirm failures.**
+- [x] **Step 2: Run → confirm failures.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestToolClassification -x
@@ -2379,7 +2379,7 @@ step. No placeholders.
   because `_collect_tool_uses` returns the hardcoded happy-path list.
   `test_action_classification_skips_reads` fails for the same reason.
 
-- [ ] **Step 3: Implement `_classify_tool_use` and `_collect_tool_uses`.**
+- [x] **Step 3: Implement `_classify_tool_use` and `_collect_tool_uses`.**
 
   Replace the stub bodies of both functions in
   `claude_usage/cli/session_summary.py`. The edit family is handled fully.
@@ -2495,7 +2495,7 @@ step. No placeholders.
       return _collapse_consecutive(raw)
   ```
 
-- [ ] **Step 4: Run → confirm pass.**
+- [x] **Step 4: Run → confirm pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -2508,7 +2508,7 @@ step. No placeholders.
   assertion from `len(summary.actions) > 0` (already satisfied by one Edit)
   to confirm it still holds before committing.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -3765,7 +3765,7 @@ The `_collapse_consecutive` helper was introduced in Task 3.4 as part of
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add two tests — `test_consecutive_edits_collapse` and
+- [x] **Step 1: Add two tests — `test_consecutive_edits_collapse` and
   `test_non_adjacent_edits_do_not_collapse`.**
 
   ```python
@@ -3869,7 +3869,7 @@ The `_collapse_consecutive` helper was introduced in Task 3.4 as part of
           assert summary.actions[2] == "Edited src/a.py"
   ```
 
-- [ ] **Step 2: Run → confirm both tests pass (green from Task 3.4).**
+- [x] **Step 2: Run → confirm both tests pass (green from Task 3.4).**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestCollapseConsecutive -v
@@ -3915,7 +3915,7 @@ The `_collapse_consecutive` helper was introduced in Task 3.4 as part of
   Verify this is what `session_summary.py` contains. If it differs, correct
   it and re-run.
 
-- [ ] **Step 3: Run full suite → confirm no regressions.**
+- [x] **Step 3: Run full suite → confirm no regressions.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -3923,7 +3923,7 @@ The `_collapse_consecutive` helper was introduced in Task 3.4 as part of
 
   Expected: all tests pass.
 
-- [ ] **Step 4: Commit.**
+- [x] **Step 4: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -3346,7 +3346,7 @@ Edit.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add `test_action_classification_skip_set_is_complete` to
+- [x] **Step 1: Add `test_action_classification_skip_set_is_complete` to
   `TestToolClassification`.**
 
   ```python
@@ -3468,7 +3468,7 @@ Edit.
           assert summary.actions[0] == "Edited src/result.py"
   ```
 
-- [ ] **Step 2: Run → confirm failures.**
+- [x] **Step 2: Run → confirm failures.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestToolClassification \
@@ -3480,7 +3480,7 @@ Edit.
   but not `SKIPPED_TOOLS` (public, no underscore). The mix test passes if the
   skip logic is correct from Task 3.4.
 
-- [ ] **Step 3: Rename the private constant to the public name and ensure it
+- [x] **Step 3: Rename the private constant to the public name and ensure it
   is exported.**
 
   In `claude_usage/cli/session_summary.py`, rename `_SKIP_TOOLS` to
@@ -3512,7 +3512,7 @@ Edit.
   })
   ```
 
-- [ ] **Step 4: Run → confirm all tests pass.**
+- [x] **Step 4: Run → confirm all tests pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -3521,7 +3521,7 @@ Edit.
   Expected: all tests pass. `test_action_classification_skip_set_is_complete`
   now finds the public `SKIPPED_TOOLS` constant and the frozenset matches.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -1499,7 +1499,7 @@ step. No placeholders.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Write `test_happy_path_emits_contract` — confirm it fails.**
+- [x] **Step 1: Write `test_happy_path_emits_contract` — confirm it fails.**
 
   Add this test class to `tests/test_session_summary.py` (also add the
   `_parse_fixture` helper at the top of the file, before any test class,
@@ -1568,7 +1568,7 @@ step. No placeholders.
           assert summary.stopped_naturally is True
   ```
 
-- [ ] **Step 2: Run → confirm failure.**
+- [x] **Step 2: Run → confirm failure.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestBuildSessionSummary::test_happy_path_emits_contract -x
@@ -1577,7 +1577,7 @@ step. No placeholders.
   Expected failure: `NotImplementedError` from the `build_session_summary`
   stub. This is the correct red state — not an import error.
 
-- [ ] **Step 3: Implement a minimal `build_session_summary` using internal stubs.**
+- [x] **Step 3: Implement a minimal `build_session_summary` using internal stubs.**
 
   Replace the `build_session_summary` stub in `claude_usage/cli/session_summary.py`
   with the following. The four private helpers (`_derive_project`,
@@ -1751,7 +1751,7 @@ step. No placeholders.
   Also add `import json` and `import sys` at the top of the file, in the
   stdlib imports block, after `import argparse` and before `from dataclasses`.
 
-- [ ] **Step 4: Run → confirm pass.**
+- [x] **Step 4: Run → confirm pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -1759,7 +1759,7 @@ step. No placeholders.
 
   Expected: all existing tests plus `test_happy_path_emits_contract` pass.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -3551,7 +3551,7 @@ introduces new tool names.
 - Modify: `tests/test_session_summary.py`
 - Modify: `claude_usage/cli/session_summary.py`
 
-- [ ] **Step 1: Add `test_action_classification_unknown_tool_defaults_to_other`.**
+- [x] **Step 1: Add `test_action_classification_unknown_tool_defaults_to_other`.**
 
   ```python
       def test_action_classification_unknown_tool_defaults_to_other(
@@ -3608,7 +3608,7 @@ introduces new tool names.
           )
   ```
 
-- [ ] **Step 2: Run → confirm failure.**
+- [x] **Step 2: Run → confirm failure.**
 
   ```bash
   uv run pytest \
@@ -3620,7 +3620,7 @@ introduces new tool names.
   `"BrandNewTool"` because the temporary `return None` at the end of
   `_classify_tool_use` discards it.
 
-- [ ] **Step 3: Replace the temporary `return None` with the `other` catch-all.**
+- [x] **Step 3: Replace the temporary `return None` with the `other` catch-all.**
 
   In `claude_usage/cli/session_summary.py`, locate the line `return None` at
   the very end of `_classify_tool_use` (the one added as a placeholder in
@@ -3722,7 +3722,7 @@ introduces new tool names.
       )
   ```
 
-- [ ] **Step 4: Run → confirm all tests pass.**
+- [x] **Step 4: Run → confirm all tests pass.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -x
@@ -3731,7 +3731,7 @@ introduces new tool names.
   Expected: all tests pass. The `other` catch-all now handles `"BrandNewTool"`
   and any future unknown tool names.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -1032,3 +1032,103 @@ class TestToolClassification:
             target="BrandNewTool",
             summary="Used BrandNewTool tool",
         )
+
+
+class TestCollapseConsecutive:
+    """Tests for _collapse_consecutive semantics."""
+
+    def test_consecutive_edits_collapse(self) -> None:
+        """Three consecutive Edits to the same file collapse to one action.
+
+        Uses the consecutive_edits_same_file.jsonl fixture from Phase 2
+        which has three Edit tool-use blocks all targeting
+        'claude_usage/parser.py'. After _collect_tool_uses (which calls
+        _collapse_consecutive internally), only one ActionRecord remains.
+        """
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/"
+            "consecutive_edits_same_file.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+
+        assert len(summary.actions) == 1
+        assert summary.actions[0] == "Edited claude_usage/parser.py"
+
+    def test_non_adjacent_edits_do_not_collapse(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Edits interleaved by a different file are not collapsed.
+
+        Sequence: Edit A → Edit B → Edit A again.
+        The two Edit A calls are non-adjacent, so all three records are
+        preserved — chronological order and narrative sense are maintained.
+        """
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        def _edit_entry(uid: str, file_path: str, seq: int) -> dict:
+            """Build one assistant entry with a single Edit tool use."""
+            return {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": f"tu-{seq:03d}",
+                        "name": "Edit",
+                        "input": {
+                            "file_path": file_path,
+                            "old_string": f"old{seq}",
+                            "new_string": f"new{seq}",
+                        },
+                    }],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": (
+                        "end_turn" if seq == 3 else "tool_use"
+                    ),
+                    "usage": {
+                        "input_tokens": 30,
+                        "output_tokens": 10,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                },
+                "uuid": uid,
+                "timestamp": f"2026-04-20T09:00:0{seq}.000Z",
+                "sessionId": "sess-nonadj",
+            }
+
+        user_entry = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": "Edit A, then B, then A again.",
+            },
+            "uuid": "u-001",
+            "timestamp": "2026-04-20T09:00:00.000Z",
+            "sessionId": "sess-nonadj",
+            "userType": "external",
+            "cwd": "/home/user/myproject",
+        }
+
+        lines = [
+            json.dumps(user_entry),
+            json.dumps(_edit_entry("a-001", "src/a.py", 1)),
+            json.dumps(_edit_entry("a-002", "src/b.py", 2)),
+            json.dumps(_edit_entry("a-003", "src/a.py", 3)),
+        ]
+        fixture = tmp_path / "non_adjacent.jsonl"
+        fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        summary = build_session_summary(_parse_fixture(fixture))
+
+        # All three edits must be present — none collapsed.
+        assert len(summary.actions) == 3
+        assert summary.actions[0] == "Edited src/a.py"
+        assert summary.actions[1] == "Edited src/b.py"
+        assert summary.actions[2] == "Edited src/a.py"

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -258,3 +258,170 @@ class TestBuildSessionSummary:
         )
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.intent == "Session on myproject"
+
+
+class TestToolClassification:
+    """Tests for _classify_tool_use and _collect_tool_uses."""
+
+    def test_action_classification_edit_tools(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Edit, Write, and NotebookEdit each produce an 'edit' ActionRecord.
+
+        Each tool-use block should produce:
+        - type == "edit"
+        - raw_tool == the original tool name
+        - target == the file_path input value
+        - summary starting with "Edited "
+        """
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        def _make_tool_use(
+            uid: str, name: str, path: str
+        ) -> dict:
+            return {
+                "type": "tool_use",
+                "id": uid,
+                "name": name,
+                "input": {"file_path": path, "old_string": "a", "new_string": "b"},
+            }
+
+        fixture = tmp_path / "edit_tools.jsonl"
+        lines = [
+            json.dumps({
+                "type": "user",
+                "message": {"role": "user", "content": "Edit three files."},
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-edit",
+                "userType": "external",
+                "cwd": "/home/user/myproject",
+            }),
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        _make_tool_use("tu-001", "Edit", "src/a.py"),
+                    ],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 50, "output_tokens": 10,
+                              "cache_creation_input_tokens": 0,
+                              "cache_read_input_tokens": 0},
+                },
+                "uuid": "a-001",
+                "timestamp": "2026-04-20T09:00:01.000Z",
+                "sessionId": "sess-edit",
+            }),
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        _make_tool_use("tu-002", "Write", "src/b.py"),
+                    ],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 50, "output_tokens": 10,
+                              "cache_creation_input_tokens": 0,
+                              "cache_read_input_tokens": 0},
+                },
+                "uuid": "a-002",
+                "timestamp": "2026-04-20T09:00:02.000Z",
+                "sessionId": "sess-edit",
+            }),
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        _make_tool_use("tu-003", "NotebookEdit", "notebook.ipynb"),
+                    ],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 50, "output_tokens": 10,
+                              "cache_creation_input_tokens": 0,
+                              "cache_read_input_tokens": 0},
+                },
+                "uuid": "a-003",
+                "timestamp": "2026-04-20T09:00:03.000Z",
+                "sessionId": "sess-edit",
+            }),
+        ]
+        fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        summary = build_session_summary(_parse_fixture(fixture))
+
+        assert len(summary.actions) == 3
+        assert summary.actions[0] == "Edited src/a.py"
+        assert summary.actions[1] == "Edited src/b.py"
+        assert summary.actions[2] == "Edited notebook.ipynb"
+
+    def test_action_classification_skips_reads(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Read, Grep, Glob, WebFetch, WebSearch, Skill, and TodoWrite
+        tool uses are skipped — they are info-gathering or ceremony.
+
+        Result: actions list is empty.
+        """
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        skip_tools = [
+            ("Read", {"file_path": "foo.py"}),
+            ("Grep", {"pattern": "def ", "path": "."}),
+            ("Glob", {"pattern": "**/*.py"}),
+            ("WebFetch", {"url": "https://example.com"}),
+            ("WebSearch", {"query": "python"}),
+            ("Skill", {"skill": "python"}),
+            ("TodoWrite", {"todos": []}),
+        ]
+
+        lines = [
+            json.dumps({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "Look at things but do not change them.",
+                },
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-skip",
+                "userType": "external",
+                "cwd": "/home/user/myproject",
+            }),
+        ]
+        for i, (tool_name, inp) in enumerate(skip_tools, start=1):
+            lines.append(json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": f"tu-{i:03d}",
+                        "name": tool_name,
+                        "input": inp,
+                    }],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": (
+                        "tool_use" if i < len(skip_tools) else "end_turn"
+                    ),
+                    "usage": {"input_tokens": 20, "output_tokens": 5,
+                              "cache_creation_input_tokens": 0,
+                              "cache_read_input_tokens": 0},
+                },
+                "uuid": f"a-{i:03d}",
+                "timestamp": f"2026-04-20T09:00:{i:02d}.000Z",
+                "sessionId": "sess-skip",
+            }))
+
+        fixture = tmp_path / "skip_tools.jsonl"
+        fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.actions == []

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -1132,3 +1132,67 @@ class TestCollapseConsecutive:
         assert summary.actions[0] == "Edited src/a.py"
         assert summary.actions[1] == "Edited src/b.py"
         assert summary.actions[2] == "Edited src/a.py"
+
+
+class TestStoppedNaturally:
+    """Tests for _derive_stopped_naturally tri-state resolution."""
+
+    def test_stopped_naturally_true_on_end_turn(self) -> None:
+        """stop_reason 'end_turn' with no prevented-continuation → True."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/happy_path.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.stopped_naturally is True
+
+    def test_stopped_naturally_false_on_max_tokens(self) -> None:
+        """stop_reason 'max_tokens' → False (definitive interrupt)."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/max_tokens_stop.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.stopped_naturally is False
+
+    def test_stopped_naturally_false_on_prevented_continuation(self) -> None:
+        """preventedContinuation: true in stop_hook_summary → False."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/prevented_continuation.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.stopped_naturally is False
+
+    def test_stopped_naturally_null_on_no_assistant_turns(self) -> None:
+        """Zero assistant entries → None (nothing to judge)."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/no_assistant_entries.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.stopped_naturally is None
+
+    def test_stopped_naturally_null_on_missing_stop_reason(self) -> None:
+        """Last assistant entry has no stop_reason key → None (signal absent)."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/missing_stop_reason.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.stopped_naturally is None

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -864,4 +864,120 @@ class TestToolClassification:
 
         # Both normalize to the same target → collapse reduces to one.
         assert len(records) == 1
-        assert records[0].target == "github.create_issue"
+
+    def test_action_classification_skip_set_is_complete(self) -> None:
+        """The SKIPPED_TOOLS module constant contains all seven skip-list members.
+
+        This test is a contract assertion on the constant itself. If a new
+        tool is added to or removed from the skip list in the spec, this
+        test must be updated in lockstep.
+        """
+        from claude_usage.cli.session_summary import SKIPPED_TOOLS
+
+        expected = frozenset({
+            "Read",
+            "Grep",
+            "Glob",
+            "Skill",
+            "TodoWrite",
+            "WebFetch",
+            "WebSearch",
+        })
+        assert SKIPPED_TOOLS == expected
+
+    def test_action_classification_skips_mix_with_edit(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Seven skipped tool uses plus one Edit produces exactly one action.
+
+        Verifies that the skip-set check fires before any other dispatch,
+        that the Edit is still classified after skipped tools, and that the
+        resulting action list has exactly one entry.
+        """
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        skip_tools = [
+            ("Read", {"file_path": "foo.py"}),
+            ("Grep", {"pattern": "def ", "path": "."}),
+            ("Glob", {"pattern": "**/*.py"}),
+            ("WebFetch", {"url": "https://example.com"}),
+            ("WebSearch", {"query": "python"}),
+            ("Skill", {"skill": "python"}),
+            ("TodoWrite", {"todos": []}),
+        ]
+
+        lines = [
+            json.dumps({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "Look at things, then edit one.",
+                },
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-mix",
+                "userType": "external",
+                "cwd": "/home/user/myproject",
+            }),
+        ]
+        for i, (tool_name, inp) in enumerate(skip_tools, start=1):
+            lines.append(json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": f"tu-{i:03d}",
+                        "name": tool_name,
+                        "input": inp,
+                    }],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "tool_use",
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 5,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                },
+                "uuid": f"a-{i:03d}",
+                "timestamp": f"2026-04-20T09:00:{i:02d}.000Z",
+                "sessionId": "sess-mix",
+            }))
+        # One Edit at the end — must survive into the action list.
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-008",
+                    "name": "Edit",
+                    "input": {
+                        "file_path": "src/result.py",
+                        "old_string": "x",
+                        "new_string": "y",
+                    },
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-008",
+            "timestamp": "2026-04-20T09:00:08.000Z",
+            "sessionId": "sess-mix",
+        }))
+
+        fixture = tmp_path / "skip_mix.jsonl"
+        fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert len(summary.actions) == 1
+        assert summary.actions[0] == "Edited src/result.py"

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -603,3 +603,56 @@ class TestToolClassification:
         summary = build_session_summary(_parse_fixture(fixture))
         assert len(summary.actions) == 1
         assert summary.actions[0] == "Dispatched code-reviewer sub-agent"
+
+    def test_action_classification_agent_dispatch_record_fields(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Agent tool_use classifies to ActionRecord with correct field values.
+
+        Asserts all four ActionRecord fields explicitly:
+        - type == "agent_dispatch"
+        - raw_tool == "Agent"
+        - target == subagent_type value from input
+        - summary == "Dispatched <subagent_type> sub-agent"
+        """
+        from claude_usage.cli.session_summary import (
+            ActionRecord,
+            _collect_tool_uses,
+        )
+
+        # Minimal JSONL — one assistant entry with an Agent tool use.
+        entry = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-001",
+                    "name": "Agent",
+                    "input": {
+                        "subagent_type": "code-writer",
+                        "description": "Write the implementation",
+                    },
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 40,
+                    "output_tokens": 15,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-001",
+            "timestamp": "2026-04-20T09:00:01.000Z",
+            "sessionId": "sess-agent",
+        }
+        records = _collect_tool_uses([entry])
+
+        assert len(records) == 1
+        assert records[0] == ActionRecord(
+            type="agent_dispatch",
+            raw_tool="Agent",
+            target="code-writer",
+            summary="Dispatched code-writer sub-agent",
+        )

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -425,3 +425,181 @@ class TestToolClassification:
 
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.actions == []
+
+    def test_action_classification_bash_tools(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Bash and PowerShell tool uses produce 'bash' ActionRecords.
+
+        Three cases:
+        (a) Short command renders fully in summary.
+        (b) Command > 80 chars (after whitespace-collapse) is truncated
+            with a unicode ellipsis suffix.
+        (c) PowerShell tool name maps to the same "bash" action type.
+        """
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        short_cmd = "uv run pytest -x"
+        long_cmd = (
+            "uv run pytest tests/ --tb=short --no-header "
+            "-q --disable-warnings --timeout=60 "
+            "tests/test_session_summary.py tests/test_cli_subcommands.py "
+            "tests/test_dashboard_snapshot.py"
+        )
+        # Whitespace-collapsed long_cmd will exceed 80 chars.
+        ps_cmd = "Get-ChildItem -Recurse *.py"
+
+        lines = [
+            json.dumps({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "Run some bash commands.",
+                },
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-bash",
+                "userType": "external",
+                "cwd": "/home/user/myproject",
+            }),
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": "tu-001",
+                        "name": "Bash",
+                        "input": {
+                            "command": short_cmd,
+                            "description": "Run tests",
+                        },
+                    }],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 30, "output_tokens": 10,
+                              "cache_creation_input_tokens": 0,
+                              "cache_read_input_tokens": 0},
+                },
+                "uuid": "a-001",
+                "timestamp": "2026-04-20T09:00:01.000Z",
+                "sessionId": "sess-bash",
+            }),
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": "tu-002",
+                        "name": "Bash",
+                        "input": {
+                            "command": long_cmd,
+                            "description": "Run many tests",
+                        },
+                    }],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 30, "output_tokens": 10,
+                              "cache_creation_input_tokens": 0,
+                              "cache_read_input_tokens": 0},
+                },
+                "uuid": "a-002",
+                "timestamp": "2026-04-20T09:00:02.000Z",
+                "sessionId": "sess-bash",
+            }),
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": "tu-003",
+                        "name": "PowerShell",
+                        "input": {
+                            "command": ps_cmd,
+                        },
+                    }],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 30, "output_tokens": 10,
+                              "cache_creation_input_tokens": 0,
+                              "cache_read_input_tokens": 0},
+                },
+                "uuid": "a-003",
+                "timestamp": "2026-04-20T09:00:03.000Z",
+                "sessionId": "sess-bash",
+            }),
+        ]
+        fixture = tmp_path / "bash_tools.jsonl"
+        fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        summary = build_session_summary(_parse_fixture(fixture))
+
+        assert len(summary.actions) == 3
+
+        # (a) Short command — no truncation.
+        assert summary.actions[0] == f"Ran `{short_cmd}`"
+
+        # (b) Long command — truncated at 80 chars with ellipsis.
+        collapsed = " ".join(long_cmd.split())
+        expected_long = f"Ran `{collapsed[:80]}…`"
+        assert summary.actions[1] == expected_long
+
+        # (c) PowerShell uses same "bash" type.
+        assert summary.actions[2] == f"Ran `{ps_cmd}`"
+
+    def test_action_classification_agent_dispatch(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Agent tool use produces an 'agent_dispatch' ActionRecord."""
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = tmp_path / "agent_dispatch.jsonl"
+        fixture.write_text(
+            "\n".join([
+                json.dumps({
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "Review the code.",
+                    },
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-agent",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }),
+                json.dumps({
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{
+                            "type": "tool_use",
+                            "id": "tu-001",
+                            "name": "Agent",
+                            "input": {
+                                "subagent_type": "code-reviewer",
+                                "description": "Review session_summary.py",
+                            },
+                        }],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "end_turn",
+                        "usage": {"input_tokens": 40, "output_tokens": 15,
+                                  "cache_creation_input_tokens": 0,
+                                  "cache_read_input_tokens": 0},
+                    },
+                    "uuid": "a-001",
+                    "timestamp": "2026-04-20T09:00:01.000Z",
+                    "sessionId": "sess-agent",
+                }),
+            ]) + "\n",
+            encoding="utf-8",
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert len(summary.actions) == 1
+        assert summary.actions[0] == "Dispatched code-reviewer sub-agent"

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import dataclasses
+import json as _json
+from pathlib import Path as _Path
 
 import pytest
 
@@ -14,6 +16,31 @@ from claude_usage.cli.session_summary import (
     ActionRecord,
     SessionSummary,
 )
+
+
+def _parse_fixture(fixture_path: _Path) -> list[dict]:
+    """Read and parse a JSONL fixture into a list of dicts.
+
+    Skips blank lines and lines that fail json.loads, matching the
+    same tolerance as read_transcript in session_summary.py.
+
+    Args:
+        fixture_path: Path to a JSONL fixture file.
+
+    Returns:
+        List of successfully parsed entry dicts in file order.
+    """
+    entries: list[dict] = []
+    with fixture_path.open(encoding="utf-8") as fh:
+        for raw in fh:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                entries.append(_json.loads(stripped))
+            except _json.JSONDecodeError:
+                pass
+    return entries
 
 
 class TestDataclasses:
@@ -51,3 +78,36 @@ class TestDataclasses:
         assert EXIT_IO_FAILURE == 1
         assert EXIT_NO_USER_TURNS == 2
         assert EXIT_NOT_JSONL == 3
+
+
+class TestBuildSessionSummary:
+    """Tests for build_session_summary and the full derivation pipeline."""
+
+    def test_happy_path_emits_contract(self) -> None:
+        """build_session_summary on happy_path.jsonl returns a correctly
+        populated SessionSummary.
+
+        Asserts:
+        - project == "claude-usage" (from cwd field)
+        - intent contains the user's first sentence
+        - actions is a non-empty list of strings
+        - stopped_naturally is True (final stop_reason == "end_turn")
+        """
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/happy_path.jsonl"
+        )
+        entries = _parse_fixture(fixture)
+        summary = build_session_summary(
+            entries,
+            project_slug_fallback=fixture.parent.name,
+        )
+
+        assert summary.project == "claude-usage"
+        assert "session-summary" in summary.intent.lower()
+        assert isinstance(summary.actions, list)
+        assert len(summary.actions) > 0
+        assert summary.stopped_naturally is True

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -981,3 +981,54 @@ class TestToolClassification:
         summary = build_session_summary(_parse_fixture(fixture))
         assert len(summary.actions) == 1
         assert summary.actions[0] == "Edited src/result.py"
+
+    def test_action_classification_unknown_tool_defaults_to_other(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """An unrecognised tool name produces an 'other'-type ActionRecord.
+
+        This verifies the forward-compatibility catch-all: any tool that
+        does not match the skip list, edit family, bash family, Agent, or
+        MCP prefix produces:
+        - type == "other"
+        - raw_tool == the original tool name
+        - target == the original tool name
+        - summary == "Used <tool_name> tool"
+        """
+        from claude_usage.cli.session_summary import (
+            ActionRecord,
+            _collect_tool_uses,
+        )
+
+        entry = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-001",
+                    "name": "BrandNewTool",
+                    "input": {"some_param": "some_value"},
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-001",
+            "timestamp": "2026-04-20T09:00:01.000Z",
+            "sessionId": "sess-unknown",
+        }
+        records = _collect_tool_uses([entry])
+
+        assert len(records) == 1
+        assert records[0] == ActionRecord(
+            type="other",
+            raw_tool="BrandNewTool",
+            target="BrandNewTool",
+            summary="Used BrandNewTool tool",
+        )

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -1196,3 +1196,62 @@ class TestStoppedNaturally:
         )
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.stopped_naturally is None
+
+
+class TestMaxActionsCap:
+    """Tests for _apply_max_actions_cap sentinel truncation."""
+
+    def test_actions_truncated_at_default_cap(self) -> None:
+        """Fixture with 55 distinct actions truncates to 50 at default cap.
+
+        The last element must be the sentinel string matching the pattern
+        '… (<K> additional actions omitted)' where K == 55 - 49 == 6.
+        """
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/over_fifty_actions.jsonl"
+        )
+        # Default max_actions == 50.
+        summary = build_session_summary(_parse_fixture(fixture))
+
+        assert len(summary.actions) == 50
+        assert summary.actions[-1].startswith("… (")
+        assert summary.actions[-1].endswith("additional actions omitted)")
+
+    def test_actions_respects_max_actions_override(self) -> None:
+        """max_actions=5 keeps 4 real actions plus the sentinel."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/over_fifty_actions.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture), max_actions=5)
+
+        assert len(summary.actions) == 5
+        assert summary.actions[-1].startswith("… (")
+        assert summary.actions[-1].endswith("additional actions omitted)")
+        # Sentinel must count the correct number of dropped actions.
+        # 55 total, kept 4 = 49 + 1 sentinel → dropped = 55 - 4 = 51.
+        assert "51" in summary.actions[-1]
+
+    def test_actions_cap_zero_disables_truncation(self) -> None:
+        """max_actions=0 disables the cap — all 55 actions are returned."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/over_fifty_actions.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture), max_actions=0)
+
+        assert len(summary.actions) == 55
+        # No sentinel — every element is a real action string.
+        assert not any(
+            a.startswith("… (") for a in summary.actions
+        )

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -164,3 +164,97 @@ class TestBuildSessionSummary:
             project_slug_fallback=None,
         )
         assert summary.project == "unknown"
+
+    def test_intent_plain_text_user_turn(self, tmp_path: pytest.TempPathFactory) -> None:
+        """A plain-text user turn returns the first sentence as intent."""
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = tmp_path / "plain_text.jsonl"
+        fixture.write_text(
+            json.dumps({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": (
+                        "Implement the login feature. "
+                        "Make it work with OAuth."
+                    ),
+                },
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-plain",
+                "userType": "external",
+                "cwd": "/home/user/myproject",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.intent == "Implement the login feature"
+
+    def test_intent_strips_system_reminder_wrapper(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """system-reminder XML wrapper is stripped; surviving text becomes intent."""
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = tmp_path / "reminder.jsonl"
+        content = (
+            "<system-reminder>You are an assistant.</system-reminder>"
+            "Fix the parser bug in parser.py. It crashes on empty input."
+        )
+        fixture.write_text(
+            json.dumps({
+                "type": "user",
+                "message": {"role": "user", "content": content},
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-remind",
+                "userType": "external",
+                "cwd": "/home/user/myproject",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.intent == "Fix the parser bug in parser.py"
+
+    def test_intent_falls_back_for_slash_command_only(self) -> None:
+        """Pure slash-command session produces intent 'Ran /project-review'."""
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/slash_command_only.jsonl"
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.intent == "Ran /project-review"
+
+    def test_intent_empty_session_fallback(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """When there is a user turn but content is entirely whitespace after
+        stripping, intent falls back to 'Session on <project>'.
+        """
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = tmp_path / "empty_intent.jsonl"
+        fixture.write_text(
+            json.dumps({
+                "type": "user",
+                "message": {"role": "user", "content": "   "},
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-empty-intent",
+                "userType": "external",
+                "cwd": "/home/user/myproject",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        summary = build_session_summary(_parse_fixture(fixture))
+        assert summary.intent == "Session on myproject"

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -111,3 +111,56 @@ class TestBuildSessionSummary:
         assert isinstance(summary.actions, list)
         assert len(summary.actions) > 0
         assert summary.stopped_naturally is True
+
+    def test_project_derived_from_cwd_field(self) -> None:
+        """project is the basename of the cwd field on the first entry
+        that has one.
+
+        The happy_path fixture has cwd="/home/user/claude-usage" so the
+        derived project name must be "claude-usage".
+        """
+        from pathlib import Path
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        fixture = Path(
+            "tests/fixtures/session_summaries/happy_path.jsonl"
+        )
+        summary = build_session_summary(
+            _parse_fixture(fixture),
+            project_slug_fallback=fixture.parent.name,
+        )
+        assert summary.project == "claude-usage"
+
+    def test_project_falls_back_to_unknown(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """When no cwd is present and the path slug is not decodable,
+        project falls back to "unknown".
+        """
+        import json
+
+        from claude_usage.cli.session_summary import build_session_summary
+
+        # Fixture with no cwd field anywhere and a non-project-hash path.
+        fixture = tmp_path / "no_cwd.jsonl"
+        fixture.write_text(
+            json.dumps({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "Hello with no cwd.",
+                },
+                "uuid": "u-001",
+                "timestamp": "2026-04-20T09:00:00.000Z",
+                "sessionId": "sess-nocwd",
+                "userType": "external",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        # Pass None as slug_fallback to exercise the final "unknown" path.
+        summary = build_session_summary(
+            _parse_fixture(fixture),
+            project_slug_fallback=None,
+        )
+        assert summary.project == "unknown"

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -656,3 +656,212 @@ class TestToolClassification:
             target="code-writer",
             summary="Dispatched code-writer sub-agent",
         )
+
+    def test_action_classification_mcp_plugin_scoped(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Plugin-scoped MCP name normalizes to 'github.create_issue'.
+
+        Raw: mcp__plugin_github_github__create_issue
+        Expected target: "github.create_issue"
+        Expected summary: "Called `github.create_issue` (MCP)"
+        """
+        from claude_usage.cli.session_summary import (
+            ActionRecord,
+            _collect_tool_uses,
+        )
+
+        raw_name = "mcp__plugin_github_github__create_issue"
+        entry = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-001",
+                    "name": raw_name,
+                    "input": {"title": "Test issue", "body": "body"},
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 60,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-001",
+            "timestamp": "2026-04-20T09:00:01.000Z",
+            "sessionId": "sess-mcp",
+        }
+        records = _collect_tool_uses([entry])
+
+        assert len(records) == 1
+        assert records[0] == ActionRecord(
+            type="mcp",
+            raw_tool=raw_name,
+            target="github.create_issue",
+            summary="Called `github.create_issue` (MCP)",
+        )
+
+    def test_action_classification_mcp_direct(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Direct MCP name normalizes to 'azure.storage'.
+
+        Raw: mcp__azure__storage
+        Expected target: "azure.storage"
+        Expected summary: "Called `azure.storage` (MCP)"
+        """
+        from claude_usage.cli.session_summary import (
+            ActionRecord,
+            _collect_tool_uses,
+        )
+
+        raw_name = "mcp__azure__storage"
+        entry = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-001",
+                    "name": raw_name,
+                    "input": {"container": "my-bucket"},
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 40,
+                    "output_tokens": 10,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-001",
+            "timestamp": "2026-04-20T09:00:01.000Z",
+            "sessionId": "sess-mcp-direct",
+        }
+        records = _collect_tool_uses([entry])
+
+        assert len(records) == 1
+        assert records[0] == ActionRecord(
+            type="mcp",
+            raw_tool=raw_name,
+            target="azure.storage",
+            summary="Called `azure.storage` (MCP)",
+        )
+
+    def test_action_classification_mcp_malformed_falls_back_to_other(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Malformed MCP name (no second __ separator) falls back to 'other'.
+
+        Raw: mcp__plugin_broken
+        The name starts with 'mcp__' and 'plugin_' but has no '__' after
+        the plugin segment, so normalization returns None. The forward-compat
+        fallback produces an 'other'-type ActionRecord.
+        """
+        from claude_usage.cli.session_summary import (
+            ActionRecord,
+            _collect_tool_uses,
+        )
+
+        raw_name = "mcp__plugin_broken"
+        entry = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-001",
+                    "name": raw_name,
+                    "input": {},
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-001",
+            "timestamp": "2026-04-20T09:00:01.000Z",
+            "sessionId": "sess-mcp-bad",
+        }
+        records = _collect_tool_uses([entry])
+
+        assert len(records) == 1
+        assert records[0] == ActionRecord(
+            type="other",
+            raw_tool=raw_name,
+            target=raw_name,
+            summary=f"Used {raw_name} tool",
+        )
+
+    def test_action_classification_mcp_collapse_unifies_forms(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Plugin-scoped and direct MCP forms for the same endpoint normalize
+        to an identical target string, so consecutive occurrences collapse.
+
+        Two consecutive tool uses — one plugin-scoped, one direct — both
+        resolve to target "github.create_issue". After _collect_tool_uses
+        (which includes collapse), only one ActionRecord is returned.
+        """
+        from claude_usage.cli.session_summary import _collect_tool_uses
+
+        plugin_entry = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-001",
+                    "name": "mcp__plugin_github_github__create_issue",
+                    "input": {"title": "First", "body": "b1"},
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 60,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-001",
+            "timestamp": "2026-04-20T09:00:01.000Z",
+            "sessionId": "sess-mcp-collapse",
+        }
+        direct_entry = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-002",
+                    "name": "mcp__github__create_issue",
+                    "input": {"title": "Second", "body": "b2"},
+                }],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "usage": {
+                    "input_tokens": 65,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "uuid": "a-002",
+            "timestamp": "2026-04-20T09:00:02.000Z",
+            "sessionId": "sess-mcp-collapse",
+        }
+        records = _collect_tool_uses([plugin_entry, direct_entry])
+
+        # Both normalize to the same target → collapse reduces to one.
+        assert len(records) == 1
+        assert records[0].target == "github.create_issue"


### PR DESCRIPTION
## Summary

Third merge slice of the `session-summary` subcommand. Covers all of Phase 3 of the implementation plan: the **pure-derivation layer** that converts parsed transcript entries into a fully-populated `SessionSummary` dataclass. No I/O changes — `run()` still raises `NotImplementedError` until Phase 4 wires it up.

**Part of #19** — does not close it. Phases 4 (error handling + exit codes) and 5 (output formats) land in follow-up PRs.

## What changed

All 12 Phase 3 tasks land here as 12 cohesive commits (each TDD: red → green → refactor). Every task replaces one stub helper (or adds a new discriminator test) while keeping the Task 3.1 happy-path contract test green throughout — proving the refactor-in-place preserved behavior.

| Commit | Task | Adds |
|---|---|---|
| `5548c5d` | 3.1 | Happy-path contract test + hardcoded internal stubs + real `_apply_max_actions_cap` |
| `d1dfbc9` | 3.2 | Real `_derive_project` (cwd → `decode_project_hash` → `"unknown"`) |
| `46000f2` | 3.3 | Real `_derive_intent` with XML-wrapper stripping + slash-command fallback |
| `3394602` | 3.4 | Edit-family classification + skip-list + `_collapse_consecutive` wired |
| `4d525d7` | 3.5 | Bash/PowerShell (with 80-char truncation) + Agent dispatch classification |
| `05b11b8` | 3.6 | Agent dispatch record-field regression anchor test |
| `6d41d5d` | 3.7 | MCP classification with dual-form normalization (`mcp__plugin_<p>_<s>__<m>` AND `mcp__<s>__<m>` → `<s>.<m>`), plus inline malformed→other fallback |
| `5eacd93` | 3.8 | `_SKIP_TOOLS` → public `SKIPPED_TOOLS` constant + completeness contract test |
| `15324a9` | 3.9 | `other` catch-all (replaces the final `return None` — forward-compat for unknown tools) |
| `4a01616` | 3.10 | Collapse contract tests (consecutive AND non-adjacent-preserve semantics) |
| `5afdc98` | 3.11 | Real `_derive_stopped_naturally` tri-state (`True`/`False`/`None` per spec resolution table) |
| `8568be4` | 3.12 | `_apply_max_actions_cap` refactored to operate on rendered strings; sentinel truncation contract tests |

## Resulting module surface

**Public:**
- `SKIPPED_TOOLS: frozenset[str]` — the 7-tool skip list, made public so tests and docs can introspect.
- `ActionRecord`, `SessionSummary` (dataclasses, unchanged from Phase 2)
- `DEFAULT_MAX_ACTIONS = 50`
- `EXIT_OK`, `EXIT_IO_FAILURE`, `EXIT_NO_USER_TURNS`, `EXIT_NOT_JSONL` (constants, unchanged)
- `build_parser`, `build_session_summary`, `render_json`, `render_text`, `run` (signatures unchanged; `run` still stubbed)

**Private helpers added this PR:**
- `_derive_project`, `_derive_intent`, `_collect_tool_uses`, `_derive_stopped_naturally`, `_apply_max_actions_cap` — the five pipeline stages.
- `_classify_tool_use`, `_normalize_mcp_tool_name`, `_collapse_consecutive`, `_extract_text_from_content`, `_first_sentence` — internal helpers.
- `_EDIT_TOOLS`, `_BASH_TOOLS`, `_MAX_COMMAND_CHARS`, `_XML_WRAPPER_RE`, `_SLASH_COMMAND_RE`, `_SENTENCE_SPLIT_RE` — private dispatch sets and compiled regexes.

## Test plan

- [x] `uv run pytest` — **131 passed / 0 failed / 0 skipped** (102 prior + 29 new Phase 3 tests)
- [x] `uv run ruff check .` — 10 pre-existing issues, 0 new
- [x] All Phase 3 test classes present: `TestBuildSessionSummary` (5 tests), `TestToolClassification` (10 tests), `TestCollapseConsecutive` (2 tests), `TestStoppedNaturally` (5 tests), `TestMaxActionsCap` (3 tests) — plus 4 legacy `TestDataclasses` tests from Phase 2
- [x] `run(args)` still raises `NotImplementedError` — **expected**; Phase 4 will implement it
- [x] Dashboard subcommand unaffected — `test_existing_dashboard_unchanged` regression still passes
- [x] Happy-path contract (Task 3.1) stayed green through all 11 subsequent refactor/replacement tasks

## Notes for reviewer

- **Breadth, not just depth**: 12 commits land in one PR because they form a single logical unit — the derivation layer. Splitting further would have meant merging PRs with internal stubs visible on `main`, which leaks incomplete state.
- **Minor plan drifts surfaced explicitly**:
  - Several test-body imports from the plan (`import json`, `from pathlib import Path`) were dropped when unused, to avoid new ruff F401 issues. Same pattern established in PR #29.
  - `SKIPPED_TOOLS` was renamed to public in Task 3.8 as planned; `_EDIT_TOOLS`/`_BASH_TOOLS` remain private (dispatch-set vs. contract-set distinction).
- **No change to the dashboard subcommand's public behavior.** Dashboard snapshot regression test (`tests/test_dashboard_snapshot.py` from PR #28) stays green.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*