### PR TITLE
feat(session-summary): Phases 4+5 — run() wiring + renderers (#19)

### DIFF
--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -14,7 +14,9 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import json
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -518,6 +520,47 @@ def _apply_max_actions_cap(
     return [*kept, sentinel]
 
 
+def read_transcript(
+    path: Path,
+) -> tuple[list[dict], int]:
+    """Read and parse a JSONL transcript file.
+
+    Opens *path*, iterates its lines, skips blanks, silently skips
+    individual lines that fail ``json.loads``, and returns the
+    successfully parsed entries together with the total non-blank
+    line count.
+
+    The non-blank count is used by ``run`` to distinguish an
+    empty/whitespace-only file (exit 2) from a file that has content
+    but none of it parses (exit 3).
+
+    Args:
+        path: Absolute or relative path to the JSONL transcript file.
+
+    Returns:
+        A 2-tuple ``(entries, non_blank_lines)`` where *entries* is
+        the list of successfully parsed dicts and *non_blank_lines*
+        is the count of non-empty, non-whitespace lines seen.
+
+    Raises:
+        OSError: Any subclass raised by ``open()`` or line iteration
+            (``FileNotFoundError``, ``PermissionError``, etc.).
+    """
+    entries: list[dict] = []
+    non_blank_lines = 0
+    with path.open(encoding="utf-8") as fh:
+        for raw in fh:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            non_blank_lines += 1
+            try:
+                entries.append(json.loads(stripped))
+            except json.JSONDecodeError:
+                pass  # tolerate individual-line failures
+    return entries, non_blank_lines
+
+
 def build_session_summary(
     entries: list[dict],
     *,
@@ -640,19 +683,35 @@ def build_parser(
 
 
 def run(args: argparse.Namespace) -> int:
-    """Execute the session-summary subcommand.
+    """Entry point for the session-summary subcommand.
+
+    Dispatches ``--path`` through the full parse → summarise → render
+    pipeline, printing JSON (or text) to stdout on success and a
+    single diagnostic line to stderr on failure.
 
     Args:
-        args: Parsed argument namespace from the session-summary subparser.
+        args: Parsed CLI namespace.  Expected attributes:
+            ``args.path`` (str), ``args.output_format`` (str),
+            ``args.max_actions`` (int).
 
     Returns:
-        Integer exit code (EXIT_OK, EXIT_IO_FAILURE, EXIT_NO_USER_TURNS,
-        or EXIT_NOT_JSONL).
-
-    Raises:
-        NotImplementedError: Temporarily, until Phase 3 fills this in.
+        Integer exit code (one of ``EXIT_OK``, ``EXIT_IO_FAILURE``,
+        ``EXIT_NO_USER_TURNS``, ``EXIT_NOT_JSONL``).
     """
+    path = Path(args.path)
+
+    # ── Phase 4.1: IO failure ────────────────────────────────────────
+    try:
+        entries, non_blank_lines = read_transcript(path)
+    except OSError as exc:
+        print(
+            f"session-summary: cannot read transcript at '{path}': "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_IO_FAILURE
+
+    # Remaining logic lands in Tasks 4.2, 4.3, 4.4.
     raise NotImplementedError(
-        "session-summary is not yet implemented. "
-        "Full implementation arrives in Phase 3."
+        "remaining logic lands in Tasks 4.2, 4.3, 4.4"
     )

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -607,14 +607,16 @@ def _summary_to_dict(summary: SessionSummary) -> dict:
     """Convert a SessionSummary to an ordered dict matching the JSON contract.
 
     Key order matches the spec: project → intent → actions →
-    stoppedNaturally.  Python 3.7+ preserves insertion order, so
-    ``json.dumps`` will emit keys in this sequence.
+    stoppedNaturally.  Python 3.7+ preserves dict insertion order,
+    making ``json.dumps`` output deterministic across runs.
 
     Args:
-        summary: The session summary to convert.
+        summary: The session summary dataclass instance to convert.
 
     Returns:
         An ordered dict with camelCase keys ready for ``json.dumps``.
+        Keys: ``project``, ``intent``, ``actions``,
+        ``stoppedNaturally``.
     """
     return {
         "project": summary.project,
@@ -627,16 +629,20 @@ def _summary_to_dict(summary: SessionSummary) -> dict:
 def render_json(summary: SessionSummary) -> str:
     """Render a SessionSummary as a pretty-printed JSON string.
 
-    Uses ``indent=2`` and ``ensure_ascii=False`` per the output
-    contract. Key order is deterministic: project, intent, actions,
+    Produces the exact wire format consumed by the ``/whats-next``
+    skill.  Uses ``indent=2`` and ``ensure_ascii=False`` per spec.
+    Key order is deterministic: project, intent, actions,
     stoppedNaturally.
+
+    Does **not** append a trailing newline — the caller (``run``)
+    adds exactly one before printing to stdout, ensuring the
+    stdout/stderr discipline invariant.
 
     Args:
         summary: The session summary dataclass instance.
 
     Returns:
-        A JSON string, not terminated with a newline (the caller
-        adds exactly one trailing newline before printing to stdout).
+        A JSON string without a trailing newline.
     """
     return json.dumps(
         _summary_to_dict(summary), indent=2, ensure_ascii=False

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -649,19 +649,57 @@ def render_json(summary: SessionSummary) -> str:
     )
 
 
+def _tri_state_to_word(value: bool | None) -> str:
+    """Convert a tri-state boolean to a display word.
+
+    Args:
+        value: ``True``, ``False``, or ``None``.
+
+    Returns:
+        ``"yes"`` for ``True``, ``"no"`` for ``False``,
+        ``"unknown"`` for ``None``.
+    """
+    if value is True:
+        return "yes"
+    if value is False:
+        return "no"
+    return "unknown"
+
+
 def render_text(summary: SessionSummary) -> str:
     """Render a SessionSummary as a human-readable debug string.
+
+    Intended for ``--format text`` — not consumed by ``/whats-next``.
+    Useful for manual inspection and debugging.
+
+    Output template::
+
+        Project: {project}
+        Intent: {intent}
+        Stopped naturally: {yes|no|unknown}
+
+        Actions:
+          - {action 1}
+          - {action 2}
+          ...
 
     Args:
         summary: The session summary dataclass instance.
 
     Returns:
-        Multi-line human-readable string.
-
-    Raises:
-        NotImplementedError: Until Task 5.2 is implemented.
+        Multi-line string.  Does not end with a trailing newline —
+        the caller (``run``) adds exactly one.
     """
-    raise NotImplementedError("implemented in Task 5.2")
+    lines = [
+        f"Project: {summary.project}",
+        f"Intent: {summary.intent}",
+        f"Stopped naturally: {_tri_state_to_word(summary.stopped_naturally)}",
+        "",
+        "Actions:",
+    ]
+    for action in summary.actions:
+        lines.append(f"  - {action}")
+    return "\n".join(lines)
 
 
 def build_parser(

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -711,7 +711,20 @@ def run(args: argparse.Namespace) -> int:
         )
         return EXIT_IO_FAILURE
 
-    # Remaining logic lands in Tasks 4.2, 4.3, 4.4.
+    # ── Phase 4.2: no user turns ─────────────────────────────────────
+    has_user_turns = any(
+        entry.get("type") == "user"
+        and entry.get("userType") == "external"
+        for entry in entries
+    )
+    if not has_user_turns:
+        print(
+            f"session-summary: transcript '{path}' contains no user turns",
+            file=sys.stderr,
+        )
+        return EXIT_NO_USER_TURNS
+
+    # Remaining logic lands in Tasks 4.3, 4.4.
     raise NotImplementedError(
-        "remaining logic lands in Tasks 4.2, 4.3, 4.4"
+        "remaining logic lands in Tasks 4.3, 4.4"
     )

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -603,47 +603,59 @@ def build_session_summary(
     )
 
 
+def _summary_to_dict(summary: SessionSummary) -> dict:
+    """Convert a SessionSummary to an ordered dict matching the JSON contract.
+
+    Key order matches the spec: project → intent → actions →
+    stoppedNaturally.  Python 3.7+ preserves insertion order, so
+    ``json.dumps`` will emit keys in this sequence.
+
+    Args:
+        summary: The session summary to convert.
+
+    Returns:
+        An ordered dict with camelCase keys ready for ``json.dumps``.
+    """
+    return {
+        "project": summary.project,
+        "intent": summary.intent,
+        "actions": summary.actions,
+        "stoppedNaturally": summary.stopped_naturally,
+    }
+
+
 def render_json(summary: SessionSummary) -> str:
     """Render a SessionSummary as a pretty-printed JSON string.
 
-    Key order matches the output contract: project, intent, actions,
-    stoppedNaturally. Uses json.dumps with indent=2 and ensure_ascii=False.
+    Uses ``indent=2`` and ``ensure_ascii=False`` per the output
+    contract. Key order is deterministic: project, intent, actions,
+    stoppedNaturally.
 
     Args:
-        summary: The session summary to serialise.
+        summary: The session summary dataclass instance.
 
     Returns:
-        A JSON string ending with a trailing newline.
-
-    Raises:
-        NotImplementedError: Temporarily, until Phase 3 fills this in.
+        A JSON string, not terminated with a newline (the caller
+        adds exactly one trailing newline before printing to stdout).
     """
-    raise NotImplementedError("render_json — implemented in Phase 3")
+    return json.dumps(
+        _summary_to_dict(summary), indent=2, ensure_ascii=False
+    )
 
 
 def render_text(summary: SessionSummary) -> str:
     """Render a SessionSummary as a human-readable debug string.
 
-    Output format::
-
-        Project: <project>
-        Intent: <intent>
-        Stopped naturally: yes | no | unknown
-
-        Actions:
-          - <action 1>
-          - <action 2>
-
     Args:
-        summary: The session summary to render.
+        summary: The session summary dataclass instance.
 
     Returns:
-        A multi-line string suitable for writing to stdout.
+        Multi-line human-readable string.
 
     Raises:
-        NotImplementedError: Temporarily, until Phase 3 fills this in.
+        NotImplementedError: Until Task 5.2 is implemented.
     """
-    raise NotImplementedError("render_text — implemented in Phase 3")
+    raise NotImplementedError("implemented in Task 5.2")
 
 
 def build_parser(
@@ -736,5 +748,30 @@ def run(args: argparse.Namespace) -> int:
         )
         return EXIT_NO_USER_TURNS
 
-    # Remaining logic lands in Task 4.4.
-    raise NotImplementedError("remaining logic lands in Task 4.4")
+    # ── Success path (exit 0) ────────────────────────────────────────
+    # Non-fatal warning: malformed lines were skipped.
+    skipped = non_blank_lines - len(entries)
+    if skipped > 0:
+        print(
+            f"session-summary: skipped {skipped} malformed line(s)"
+            f" in '{path}'",
+            file=sys.stderr,
+        )
+
+    # run() is the single I/O site. Pass already-parsed entries so
+    # build_session_summary performs no file I/O.
+    slug = path.parent.name if path.parent.name else None
+    summary = build_session_summary(
+        entries,
+        project_slug_fallback=slug,
+        max_actions=args.max_actions,
+    )
+
+    if args.output_format == "json":
+        output = render_json(summary)
+    else:
+        output = render_text(summary)
+
+    # Exactly one trailing newline — the JSON/text contract.
+    print(output, flush=True)
+    return EXIT_OK

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -711,6 +711,18 @@ def run(args: argparse.Namespace) -> int:
         )
         return EXIT_IO_FAILURE
 
+    # ── Phase 4.3: not JSONL ─────────────────────────────────────────
+    # Condition: file had parseable-attempt content (non_blank_lines > 0)
+    # but zero entries survived json.loads.
+    # NOTE: non_blank_lines == 0 means empty/whitespace-only → fall
+    # through to the no-user-turns check (exit 2), not here.
+    if not entries and non_blank_lines > 0:
+        print(
+            f"session-summary: transcript '{path}' is not valid JSONL",
+            file=sys.stderr,
+        )
+        return EXIT_NOT_JSONL
+
     # ── Phase 4.2: no user turns ─────────────────────────────────────
     has_user_turns = any(
         entry.get("type") == "user"
@@ -724,7 +736,5 @@ def run(args: argparse.Namespace) -> int:
         )
         return EXIT_NO_USER_TURNS
 
-    # Remaining logic lands in Tasks 4.3, 4.4.
-    raise NotImplementedError(
-        "remaining logic lands in Tasks 4.3, 4.4"
-    )
+    # Remaining logic lands in Task 4.4.
+    raise NotImplementedError("remaining logic lands in Task 4.4")

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -4900,7 +4900,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Write the failing tests.**
+- [x] **Step 1: Write the failing tests.**
 
   ```python
   class TestStdoutStderrDiscipline:
@@ -4962,7 +4962,7 @@ where `K` is the count of dropped entries — is appended. Setting
           assert not result.stdout.endswith("\n\n")
   ```
 
-- [ ] **Step 2: Run → confirm both tests fail.**
+- [x] **Step 2: Run → confirm both tests fail.**
 
   ```bash
   uv run pytest \
@@ -4972,7 +4972,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Expected: `test_stdout_on_success_is_pure_json` fails because the success
   path still hits `NotImplementedError`.
 
-- [ ] **Step 3: Wire the success path and implement `render_json` minimally.**
+- [x] **Step 3: Wire the success path and implement `render_json` minimally.**
 
   First, implement `render_json` and its private helper. The helper produces an
   explicitly ordered dict so key order in the JSON output is deterministic
@@ -5122,7 +5122,7 @@ where `K` is the count of dropped entries — is appended. Setting
       return EXIT_OK
   ```
 
-- [ ] **Step 4: Run → both new tests pass; run the full test file.**
+- [x] **Step 4: Run → both new tests pass; run the full test file.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -v
@@ -5131,7 +5131,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Expected: all tests pass, including all prior error-path tests and the two
   new discipline tests.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -4379,7 +4379,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
   Add to `tests/test_session_summary.py` (inside `class TestErrorPaths` or at
   module level — implementer chooses; be consistent):
@@ -4425,7 +4425,7 @@ where `K` is the count of dropped entries — is appended. Setting
           )
   ```
 
-- [ ] **Step 2: Run → confirm it fails.**
+- [x] **Step 2: Run → confirm it fails.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestErrorPaths::test_missing_file_exits_1 -v
@@ -4434,7 +4434,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Expected failure reason: `session-summary` subcommand does not exist yet, or
   `run()` raises `NotImplementedError`. Either way the exit code is not 1.
 
-- [ ] **Step 3: Implement `read_transcript` + partial `run`.**
+- [x] **Step 3: Implement `read_transcript` + partial `run`.**
 
   In `claude_usage/cli/session_summary.py`, add the following helper and wire it
   into a partial `run`. The function returns a tuple so Task 4.3 can extend it
@@ -4544,7 +4544,7 @@ where `K` is the count of dropped entries — is appended. Setting
   ss_parser.set_defaults(func=ss_mod.run)
   ```
 
-- [ ] **Step 4: Run → confirm the test passes.**
+- [x] **Step 4: Run → confirm the test passes.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestErrorPaths::test_missing_file_exits_1 -v
@@ -4553,7 +4553,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Expected: PASSED. The `OSError` from opening a nonexistent path propagates
   up through `read_transcript`, is caught, and the function returns exit code 1.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -4737,7 +4737,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Write the failing test.**
+- [x] **Step 1: Write the failing test.**
 
   ```python
   class TestExitNotJsonl:
@@ -4788,7 +4788,7 @@ where `K` is the count of dropped entries — is appended. Setting
           assert result.returncode == 2
   ```
 
-- [ ] **Step 2: Run → confirm both tests fail.**
+- [x] **Step 2: Run → confirm both tests fail.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestExitNotJsonl -v
@@ -4798,7 +4798,7 @@ where `K` is the count of dropped entries — is appended. Setting
   `NotImplementedError` (not code 3); `test_empty_is_not_exit_3` may already
   pass (exit 2 is wired), but confirm.
 
-- [ ] **Step 3: Add the exit-3 branch to `run`.**
+- [x] **Step 3: Add the exit-3 branch to `run`.**
 
   The `read_transcript` signature already returns `non_blank_lines`. Insert the
   exit-3 check between the IO catch and the exit-2 check. The critical ordering
@@ -4855,7 +4855,7 @@ where `K` is the count of dropped entries — is appended. Setting
   This matches the spec's explicit amendment: "Zero-byte and whitespace-only
   files fall under exit 2, not exit 3."
 
-- [ ] **Step 4: Run → both new tests pass; re-run full test class suite.**
+- [x] **Step 4: Run → both new tests pass; re-run full test class suite.**
 
   ```bash
   uv run pytest \
@@ -4868,7 +4868,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Expected: all six tests PASSED. Specifically confirm `test_empty_is_not_exit_3`
   exits 2 and `test_zero_byte_file_exits_2` still exits 2.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -4584,7 +4584,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Write the failing tests.**
+- [x] **Step 1: Write the failing tests.**
 
   The three sub-cases each require a fixture file. Add fixture creation inline
   in the tests using `tmp_path` so no checked-in fixture is required (the
@@ -4654,7 +4654,7 @@ where `K` is the count of dropped entries — is appended. Setting
           assert "contains no user turns" in result.stderr
   ```
 
-- [ ] **Step 2: Run → confirm all three fail.**
+- [x] **Step 2: Run → confirm all three fail.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestExitNoUserTurns -v
@@ -4664,7 +4664,7 @@ where `K` is the count of dropped entries — is appended. Setting
   traceback, which produces a non-zero exit code (likely 1 from the exception),
   not exit code 2.
 
-- [ ] **Step 3: Add the exit-2 branch to `run`.**
+- [x] **Step 3: Add the exit-2 branch to `run`.**
 
   Replace the `NotImplementedError` sentinel in `run` with the exit-2 check,
   leaving a new sentinel for the remaining path:
@@ -4695,7 +4695,7 @@ where `K` is the count of dropped entries — is appended. Setting
   exits 2. The system-entries-only fixture also has no `userType == "external"`
   entries → same path.
 
-- [ ] **Step 4: Run → confirm all three pass; re-run Task 4.1 test to confirm
+- [x] **Step 4: Run → confirm all three pass; re-run Task 4.1 test to confirm
   no regression.**
 
   ```bash
@@ -4705,7 +4705,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
   Expected: all four tests PASSED.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -5337,7 +5337,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Write the failing tests.**
+- [x] **Step 1: Write the failing tests.**
 
   ```python
   class TestRenderText:
@@ -5391,7 +5391,7 @@ where `K` is the count of dropped entries — is appended. Setting
           assert "  - " not in output
   ```
 
-- [ ] **Step 2: Run → confirm all five tests fail.**
+- [x] **Step 2: Run → confirm all five tests fail.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestRenderText -v
@@ -5399,7 +5399,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
   Expected: all fail with `NotImplementedError` from the Task 4.4 stub.
 
-- [ ] **Step 3: Implement `render_text` and `_tri_state_to_word`.**
+- [x] **Step 3: Implement `render_text` and `_tri_state_to_word`.**
 
   ```python
   def _tri_state_to_word(value: bool | None) -> str:
@@ -5455,7 +5455,7 @@ where `K` is the count of dropped entries — is appended. Setting
       return "\n".join(lines)
   ```
 
-- [ ] **Step 4: Run → all five tests pass; run full suite.**
+- [x] **Step 4: Run → all five tests pass; run full suite.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -v
@@ -5463,7 +5463,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
   Expected: all tests pass.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -5167,7 +5167,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Write the tests.**
+- [x] **Step 1: Write the tests.**
 
   ```python
   class TestRenderJson:
@@ -5231,7 +5231,7 @@ where `K` is the count of dropped entries — is appended. Setting
           assert not output.endswith("\n")
   ```
 
-- [ ] **Step 2: Run → confirm results.**
+- [x] **Step 2: Run → confirm results.**
 
   ```bash
   uv run pytest tests/test_session_summary.py::TestRenderJson -v
@@ -5241,7 +5241,7 @@ where `K` is the count of dropped entries — is appended. Setting
   If all pass, the tests still serve their purpose: they lock down the
   invariants so a future refactor cannot break them silently.
 
-- [ ] **Step 3: Formalize `render_json` and `_summary_to_dict`.**
+- [x] **Step 3: Formalize `render_json` and `_summary_to_dict`.**
 
   The implementations written in Task 4.4 are already correct. Confirm the
   functions have full Google-style docstrings (added in Task 4.4). If any
@@ -5297,7 +5297,7 @@ where `K` is the count of dropped entries — is appended. Setting
       )
   ```
 
-- [ ] **Step 4: Run → all `TestRenderJson` tests pass; run full suite.**
+- [x] **Step 4: Run → all `TestRenderJson` tests pass; run full suite.**
 
   ```bash
   uv run pytest tests/test_session_summary.py -v
@@ -5305,7 +5305,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
   Expected: all tests pass.
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -1400,3 +1400,62 @@ class TestErrorPaths:
                 "No such file or directory",
             )
         )
+
+
+class TestStdoutStderrDiscipline:
+    """stdout/stderr contract: errors → stderr only; success → stdout only."""
+
+    def test_stdout_on_error_is_empty(self, tmp_path: pytest.fixture) -> None:
+        """Any error path must emit nothing to stdout.
+
+        Uses the missing-file path (exit 1) as a representative error.
+        Asserts stdout is completely empty and stderr is exactly one line.
+        """
+        nonexistent = tmp_path / "missing.jsonl"
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(nonexistent),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout == ""
+        # stderr must be exactly one non-empty line
+        stderr_lines = [
+            ln for ln in result.stderr.splitlines() if ln.strip()
+        ]
+        assert len(stderr_lines) == 1
+
+    def test_stdout_on_success_is_pure_json(self) -> None:
+        """Success path stdout is a parseable JSON document, nothing else.
+
+        Asserts:
+          - ``json.loads(stdout)`` succeeds without error.
+          - stdout has exactly one trailing newline (no header text,
+            no progress banners, no leading whitespace).
+          - All four contract keys are present.
+        """
+        fixture = (
+            _Path("tests/fixtures/session_summaries") / "happy_path.jsonl"
+        )
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(fixture),
+                "--format", "json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        # Must parse cleanly — no leading/trailing non-JSON text
+        parsed = _json.loads(result.stdout)
+        assert set(parsed.keys()) >= {
+            "project", "intent", "actions", "stoppedNaturally"
+        }
+        # Exactly one trailing newline — the JSON document ends cleanly
+        assert result.stdout.endswith("\n")
+        assert not result.stdout.endswith("\n\n")

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -1318,6 +1318,54 @@ class TestExitNoUserTurns:
         assert "contains no user turns" in result.stderr
 
 
+class TestExitNotJsonl:
+    """Exit 3 when the file has content but none parses as JSONL."""
+
+    def test_malformed_file_exits_3(self, tmp_path: pytest.fixture) -> None:
+        """File with non-blank, non-JSON lines → exit 3.
+
+        This is distinct from exit 2: bytes are present, attempted,
+        and rejected — not an empty/whitespace file.
+        """
+        malformed = tmp_path / "all_malformed.jsonl"
+        malformed.write_text(
+            "this is not json\n"
+            "{also not json\n"
+            "definitely: not: json: either\n"
+        )
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(malformed),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 3
+        assert result.stdout == ""
+        assert "is not valid JSONL" in result.stderr
+
+    def test_empty_is_not_exit_3(self, tmp_path: pytest.fixture) -> None:
+        """Zero-byte file must exit 2, not 3 — spec requirement.
+
+        Exit 3 requires at least one non-blank line that was attempted.
+        """
+        empty = tmp_path / "empty.jsonl"
+        empty.write_text("")
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(empty),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        # Must be 2, not 3.
+        assert result.returncode == 2
+
+
 class TestErrorPaths:
     """Tests for non-zero exit codes and stdout/stderr discipline."""
 

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -1259,6 +1259,65 @@ class TestMaxActionsCap:
         )
 
 
+class TestExitNoUserTurns:
+    """Exit 2 when readable transcript has no external user turns."""
+
+    def test_empty_session_exits_2(self) -> None:
+        """Agent-setting / system-only transcript → exit 2."""
+        fixture = (
+            _Path("tests/fixtures/session_summaries")
+            / "empty_no_user_turns.jsonl"
+        )
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(fixture),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert result.stdout == ""
+        assert "contains no user turns" in result.stderr
+
+    def test_zero_byte_file_exits_2(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Zero-byte file → exit 2 (not exit 3)."""
+        zero_byte = tmp_path / "zero_byte.jsonl"
+        zero_byte.write_text("")
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(zero_byte),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert result.stdout == ""
+        assert "contains no user turns" in result.stderr
+
+    def test_whitespace_only_file_exits_2(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """File with only blank lines → exit 2 (not exit 3)."""
+        ws_only = tmp_path / "whitespace_only.jsonl"
+        ws_only.write_text("\n   \n\t\n")
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(ws_only),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert result.stdout == ""
+        assert "contains no user turns" in result.stderr
+
+
 class TestErrorPaths:
     """Tests for non-zero exit codes and stdout/stderr discipline."""
 

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -17,6 +17,7 @@ from claude_usage.cli.session_summary import (
     EXIT_OK,
     ActionRecord,
     SessionSummary,
+    render_json,
 )
 
 
@@ -1459,3 +1460,64 @@ class TestStdoutStderrDiscipline:
         # Exactly one trailing newline — the JSON document ends cleanly
         assert result.stdout.endswith("\n")
         assert not result.stdout.endswith("\n\n")
+
+
+class TestRenderJson:
+    """Unit tests for render_json() and _summary_to_dict()."""
+
+    def _make_summary(
+        self,
+        stopped_naturally: bool | None = True,
+    ) -> SessionSummary:
+        """Factory for a minimal SessionSummary for render tests."""
+        return SessionSummary(
+            project="my-project",
+            intent="Test the renderer",
+            actions=["Edited foo.py", "Ran pytest"],
+            stopped_naturally=stopped_naturally,
+        )
+
+    def test_render_json_key_order_and_camelcase(self) -> None:
+        """Keys appear in contract order: project, intent, actions,
+        stoppedNaturally; camelCase is used for stoppedNaturally."""
+        summary = self._make_summary(stopped_naturally=True)
+        output = render_json(summary)
+        parsed = _json.loads(output)
+        keys = list(parsed.keys())
+        assert keys == ["project", "intent", "actions", "stoppedNaturally"]
+
+    def test_render_json_indented_two_spaces(self) -> None:
+        """Output uses indent=2 (spec: pretty-printed)."""
+        summary = self._make_summary()
+        output = render_json(summary)
+        # A two-space-indented JSON will have lines like '  "project"'
+        assert '  "project"' in output
+
+    def test_render_json_no_trailing_whitespace_per_line(self) -> None:
+        """No line ends with trailing whitespace."""
+        summary = self._make_summary()
+        output = render_json(summary)
+        for line in output.splitlines():
+            assert line == line.rstrip(), (
+                f"Trailing whitespace on line: {line!r}"
+            )
+
+    def test_render_json_handles_tri_state_true(self) -> None:
+        """stopped_naturally=True → JSON literal ``true``."""
+        output = render_json(self._make_summary(stopped_naturally=True))
+        assert '"stoppedNaturally": true' in output
+
+    def test_render_json_handles_tri_state_false(self) -> None:
+        """stopped_naturally=False → JSON literal ``false``."""
+        output = render_json(self._make_summary(stopped_naturally=False))
+        assert '"stoppedNaturally": false' in output
+
+    def test_render_json_handles_tri_state_none(self) -> None:
+        """stopped_naturally=None → JSON literal ``null``."""
+        output = render_json(self._make_summary(stopped_naturally=None))
+        assert '"stoppedNaturally": null' in output
+
+    def test_render_json_does_not_add_trailing_newline(self) -> None:
+        """render_json returns the bare document; run() adds the newline."""
+        output = render_json(self._make_summary())
+        assert not output.endswith("\n")

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -18,6 +18,7 @@ from claude_usage.cli.session_summary import (
     ActionRecord,
     SessionSummary,
     render_json,
+    render_text,
 )
 
 
@@ -1521,3 +1522,54 @@ class TestRenderJson:
         """render_json returns the bare document; run() adds the newline."""
         output = render_json(self._make_summary())
         assert not output.endswith("\n")
+
+
+class TestRenderText:
+    """Unit tests for render_text() human-readable debug view."""
+
+    def _make_summary(
+        self,
+        stopped_naturally: bool | None = True,
+        actions: list[str] | None = None,
+    ) -> SessionSummary:
+        """Factory for SessionSummary instances used in render_text tests."""
+        return SessionSummary(
+            project="my-project",
+            intent="Build something useful",
+            actions=actions if actions is not None
+                else ["Edited foo.py", "Ran pytest"],
+            stopped_naturally=stopped_naturally,
+        )
+
+    def test_render_text_happy_path(self) -> None:
+        """Full debug-view string matches expected template."""
+        summary = self._make_summary(stopped_naturally=True)
+        output = render_text(summary)
+        assert "Project: my-project" in output
+        assert "Intent: Build something useful" in output
+        assert "Stopped naturally: yes" in output
+        assert "Actions:" in output
+        assert "  - Edited foo.py" in output
+        assert "  - Ran pytest" in output
+
+    def test_render_text_stopped_naturally_true(self) -> None:
+        """True → 'yes'."""
+        output = render_text(self._make_summary(stopped_naturally=True))
+        assert "Stopped naturally: yes" in output
+
+    def test_render_text_stopped_naturally_false(self) -> None:
+        """False → 'no'."""
+        output = render_text(self._make_summary(stopped_naturally=False))
+        assert "Stopped naturally: no" in output
+
+    def test_render_text_stopped_naturally_none(self) -> None:
+        """None → 'unknown'."""
+        output = render_text(self._make_summary(stopped_naturally=None))
+        assert "Stopped naturally: unknown" in output
+
+    def test_render_text_empty_actions(self) -> None:
+        """Empty actions list → 'Actions:' section present, no bullets."""
+        summary = self._make_summary(actions=[])
+        output = render_text(summary)
+        assert "Actions:" in output
+        assert "  - " not in output

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import dataclasses
 import json as _json
+import subprocess
+import sys
 from pathlib import Path as _Path
 
 import pytest
@@ -1254,4 +1256,40 @@ class TestMaxActionsCap:
         # No sentinel — every element is a real action string.
         assert not any(
             a.startswith("… (") for a in summary.actions
+        )
+
+
+class TestErrorPaths:
+    """Tests for non-zero exit codes and stdout/stderr discipline."""
+
+    def test_missing_file_exits_1(self, tmp_path) -> None:
+        """Exit 1 when --path points to a non-existent file.
+
+        Asserts:
+          - Exit code is EXIT_IO_FAILURE (1).
+          - stdout is empty (no partial output).
+          - stderr contains the expected message fragments.
+        """
+        nonexistent = tmp_path / "nonexistent.jsonl"
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "claude_usage",
+                "session-summary",
+                "--path", str(nonexistent),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert "cannot read transcript at" in result.stderr
+        assert str(nonexistent) in result.stderr
+        # stderr should name one of the OSError subclass names
+        assert any(
+            name in result.stderr
+            for name in (
+                "FileNotFoundError",
+                "OSError",
+                "No such file or directory",
+            )
         )


### PR DESCRIPTION
## Summary

Fourth merge slice of the `session-summary` subcommand. Covers **Phase 4** (error handling + exit codes — 4 tasks) and **Phase 5** (output formats — 2 tasks). After this PR, the subcommand is fully functional end-to-end for both `--format json` and `--format text`.

**Part of #19** — does not close it. Phase 6 (polish — README update + version bump to 0.2.0) lands in the next (and final) PR.

## What changed

### Phase 4 — run() error/success wiring (4 commits)

Each task replaces a sentinel `NotImplementedError` with one exit path, preserving strict ordering: IO → not-JSONL → no-user-turns → success.

| Commit | Task | Adds |
|---|---|---|
| `20799b0` | 4.1 | `read_transcript()` helper + exit-1 IO-failure catch |
| `7b7fc85` | 4.2 | Exit-2 path: three sub-cases (empty file, whitespace-only, system-entries-only) all → `EXIT_NO_USER_TURNS` |
| `7137ad7` | 4.3 | Exit-3 path: `non_blank_lines > 0 AND entries == []` → `EXIT_NOT_JSONL`. Ordering check proved: empty files still route to exit 2, not 3 |
| `dd2ae56` | 4.4 | Success path wired + minimal `render_json()` + non-fatal "skipped malformed lines" warning |

### Phase 5 — renderers (2 commits)

| Commit | Task | Adds |
|---|---|---|
| `dfd530c` | 5.1 | `TestRenderJson` contract tests (7 tests: key order, indent, no trailing whitespace, tri-state literals, no trailing newline). All passed first run — lockdown, not new behavior |
| `45d160f` | 5.2 | Real `render_text()` + `_tri_state_to_word()` helper. Produces human-readable debug view with `yes`/`no`/`unknown` tri-state words |

## End-to-end output

With `happy_path.jsonl` and `--format json`:
```json
{
  "project": "claude-usage",
  "intent": "Implement the session-summary subcommand for the /whats-next skill",
  "actions": [
    "Edited claude_usage/cli/session_summary.py",
    "Ran `uv run pytest tests/test_session_summary.py -x`",
    "Dispatched code-reviewer sub-agent"
  ],
  "stoppedNaturally": true
}
```

Same input, `--format text`:
```
Project: claude-usage
Intent: Implement the session-summary subcommand for the /whats-next skill
Stopped naturally: yes

Actions:
  - Edited claude_usage/cli/session_summary.py
  - Ran `uv run pytest tests/test_session_summary.py -x`
  - Dispatched code-reviewer sub-agent
```

## Exit-code contract (now enforced by tests)

| Code | Condition | stderr |
|---|---|---|
| `0` | Success — JSON/text written to stdout | *(silent, unless non-fatal "skipped N malformed lines" warning)* |
| `1` | IO failure (FileNotFoundError, PermissionError, etc.) | `session-summary: cannot read transcript at '<path>': <class>: <message>` |
| `2` | Readable file, no external user turns (empty file, whitespace-only, system-only) | `session-summary: transcript '<path>' contains no user turns` |
| `3` | File has content but every non-blank line fails `json.loads` | `session-summary: transcript '<path>' is not valid JSONL` |

On any non-zero exit, stdout is empty and stderr is exactly one line.

## Plan-bug fix surfaced

Plan line 5115 wrote `args.format`, but the subparser registered the `--format` argument with `dest="output_format"` (Task 1.2 / Task 2.2). The subagent caught this at dispatch time; the commit uses the correct `args.output_format`.

## Test plan

- [x] `uv run pytest` — **151 passed / 0 failed / 0 skipped** (131 pre-Phase-4 + 6 error-path + 7 render_json lockdown + 5 render_text + 2 stdout-discipline)
- [x] `uv run ruff check .` — 10 pre-existing issues, 0 new
- [x] End-to-end smoke test `python -m claude_usage session-summary --path tests/fixtures/session_summaries/happy_path.jsonl` returns valid JSON with all 4 contract keys (`project`, `intent`, `actions`, `stoppedNaturally`)
- [x] `--format text` renders the debug view correctly
- [x] Dashboard subcommand unaffected — `test_existing_dashboard_unchanged` snapshot still green
- [x] All 4 exit codes path-tested with subprocess-level assertions

## Notes for reviewer

- **6 commits for 6 tasks** — each one a narrow, reviewable step in the incremental wiring pattern. The `NotImplementedError` sentinel between tasks is deliberate scaffolding (documented in commit messages).
- **`run()` is the single I/O site by design** — `build_session_summary` takes `list[dict]`, never touches files. This is what the late plan decision (Phase 2) encoded in the pure-function signature.
- **`render_text` vs. `render_json` vocabulary split** is deliberate: JSON emits `true`/`false`/`null` (JSON literals); text emits `yes`/`no`/`unknown` (English words). `_tri_state_to_word` uses explicit `is True` / `is False` identity checks to avoid integer-truthy misroutes.
- **Two regression-anchor tasks** (5.1 render_json lockdown, 3.6-style) went green on first run — documented in commits as "anchor tests, not new behavior." They lock the surface area against silent future drift.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*