### PR TITLE
docs(session-summary): Phase 6 — README + v0.2.0 bump; closes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,101 @@ python -m claude_usage --data-dir "D:\other\.claude"
 python -m claude_usage --limit-5h 600000 --limit-7d 4000000 --limit-sonnet-7d 2000000
 ```
 
+## Subcommands
+
+After the subparser refactor, all functionality is accessed through named
+subcommands. Bare `claude-usage` prints help and exits 0.
+
+### `dashboard` — interactive HTML dashboard
+
+```bash
+# Default: last 7 days, opens in browser
+claude-usage dashboard
+
+# Rolling window matching Claude billing buckets
+claude-usage dashboard --window 5h
+claude-usage dashboard --window 7d
+
+# Custom date range
+claude-usage dashboard --from 2026-04-01 --to 2026-04-09
+
+# Output to file instead of opening browser
+claude-usage dashboard --output report.html --no-open
+
+# Custom Claude data directory
+claude-usage dashboard --data-dir "D:\other\.claude"
+
+# Set budget limits for gauge percentages
+claude-usage dashboard --limit-5h 600000 --limit-7d 4000000 \
+    --limit-sonnet-7d 2000000
+
+# Emit JSON (for scripting / CI)
+claude-usage dashboard --format json
+```
+
+All flags are unchanged from the pre-refactor form — only their location
+moved (now under the `dashboard` subparser).
+
+### `session-summary` — deterministic session recap (new in v0.2.0)
+
+Reads a single Claude Code transcript JSONL file and emits a structured
+JSON summary suitable for consumption by the `/whats-next` skill or any
+other tool that needs to know what a session did.
+
+```bash
+claude-usage session-summary --path ~/.claude/projects/<hash>/<session>.jsonl
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--path PATH` | *(required)* | Path to the transcript JSONL file |
+| `--format {json,text}` | `json` | Output format. `json` is the machine-readable contract; `text` is a human-readable debug view |
+| `--max-actions N` | `50` | Cap on emitted actions. `0` disables the cap |
+
+**Sample output (`--format json`):**
+
+```json
+{
+  "project": "claude-usage",
+  "intent": "Implement the session-summary subcommand for the /whats-next skill",
+  "actions": [
+    "Edited claude_usage/cli/session_summary.py",
+    "Created tests/test_session_summary.py",
+    "Ran pytest tests/test_session_summary.py -x",
+    "Dispatched code-reviewer sub-agent"
+  ],
+  "stoppedNaturally": true
+}
+```
+
+**Exit codes:**
+
+| Code | Meaning | stderr |
+|---|---|---|
+| `0` | Success — JSON written to stdout | *(silent)* |
+| `1` | IO failure reading `--path` (file missing, permission denied, etc.) | `session-summary: cannot read transcript at '<path>': <OSError class>: <message>` |
+| `2` | File readable but contains no external user turns (empty session, zero-byte file, whitespace-only file) | `session-summary: transcript '<path>' contains no user turns` |
+| `3` | File has content but none of it parses as JSONL | `session-summary: transcript '<path>' is not valid JSONL` |
+
+On any non-zero exit, stdout is empty and stderr contains exactly one line.
+
+### Migration note
+
+The old flag-only form **no longer works** after v0.2.0:
+
+```bash
+# REMOVED — will print help and exit 0, not run the dashboard
+claude-usage --format json
+
+# CORRECT — migrate all callers to:
+claude-usage dashboard --format json
+```
+
+Any script, skill, or CI step that invokes `claude-usage` with bare flags
+(no subcommand) must be updated to use `claude-usage dashboard [flags]`.
+
 ## Dashboard
 
 The generated HTML dashboard includes:

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -5642,7 +5642,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Run the full test suite.**
+- [x] **Step 1: Run the full test suite.**
 
   ```bash
   uv run pytest -v
@@ -5656,7 +5656,7 @@ where `K` is the count of dropped entries — is appended. Setting
   the fix touches implementation files, commit with:
   `fix(session-summary): <description> (part of #19)`.
 
-- [ ] **Step 2: Lint check.**
+- [x] **Step 2: Lint check.**
 
   ```bash
   uv run ruff check .
@@ -5676,7 +5676,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
   ```
 
-- [ ] **Step 3: Format check.**
+- [x] **Step 3: Format check.**
 
   ```bash
   uv run ruff format --check .
@@ -5696,7 +5696,7 @@ where `K` is the count of dropped entries — is appended. Setting
   Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
   ```
 
-- [ ] **Step 4: Manual CLI sanity check.**
+- [x] **Step 4: Manual CLI sanity check.**
 
   Run each of the following and confirm the described output:
 
@@ -5727,7 +5727,7 @@ where `K` is the count of dropped entries — is appended. Setting
   # "cannot read transcript at '/tmp/nonexistent.jsonl'". Exit 1.
   ```
 
-- [ ] **Step 5: No-op commit gate.**
+- [x] **Step 5: No-op commit gate.**
 
   If Steps 1–3 required no fixes, no commit is needed. If fixes were made,
   they are already committed per Steps 2–3 above. Either way, run a final

--- a/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-23-session-summary-implementation-plan.md
@@ -5497,7 +5497,7 @@ where `K` is the count of dropped entries — is appended. Setting
 
 ---
 
-- [ ] **Step 1: Read the current README and identify the Usage section.**
+- [x] **Step 1: Read the current README and identify the Usage section.**
 
   The current README (as of plan authoring) has a `## Usage` section showing
   `python -m claude_usage` invocations with bare flags. After the Phase 1
@@ -5603,7 +5603,7 @@ where `K` is the count of dropped entries — is appended. Setting
   (no subcommand) must be updated to use `claude-usage dashboard [flags]`.
   ````
 
-- [ ] **Step 2: Version bump in `pyproject.toml`.**
+- [x] **Step 2: Version bump in `pyproject.toml`.**
 
   The project currently has `version = "0.1.0"`. The subparser refactor and
   new subcommand constitute a minor-version change (new public interface,
@@ -5613,7 +5613,7 @@ where `K` is the count of dropped entries — is appended. Setting
   version = "0.2.0"
   ```
 
-- [ ] **Step 3: Commit.**
+- [x] **Step 3: Commit.**
 
   ```bash
   git -C /i/other/claude-usage/.worktrees/docs-session-summary-plan \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-usage"
-version = "0.1.0"
+version = "0.2.0"
 description = "Parse Claude Code session data and generate an interactive HTML usage dashboard"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Final slice of the `session-summary` subcommand — Phase 6 (polish). Updates the README with a Subcommands section, bumps the package version to `0.2.0` to signal the breaking CLI change, and closes out Issue #19.

Closes #19

## What changed

### Task 6.1 — README + version bump (`dbbd6b7`)

- **`README.md`** — new `## Subcommands` section inserted between `## Usage` and `## Dashboard`. Covers:
  - `dashboard` subcommand invocations (same flags, now nested under the subcommand)
  - `session-summary` subcommand: flags table, sample JSON output, exit-code contract table
  - **Migration note**: `claude-usage --format json` (bare flag form) no longer works; callers must use `claude-usage dashboard --format json`
- **`pyproject.toml`** — `version = "0.1.0"` → `version = "0.2.0"` to signal the breaking CLI change per SemVer minor bump

### Task 6.2 — Final verification checkpoints (`9eabf24`)

Verification-only commit (no code changed):
- ✅ `uv run pytest` → **151 passed / 0 failed / 0 skipped**
- ✅ CLI sanity — all 5 commands pass (bare help, `dashboard --help`, `session-summary --help`, happy-path JSON, missing-file exit 1)
- ℹ️ `uv run ruff check .` → 10 pre-existing errors (unchanged; no new errors introduced this PR)
- ℹ️ `uv run ruff format --check .` → 16 files would be reformatted (pre-existing drift; no new drift introduced)

**Pre-existing lint/format issues are deferred to Issue #32**, which scopes adding GitHub Actions CI and cleaning up these baseline issues as a single unit. This PR intentionally does not touch them.

## Breaking change (same as PR #28, restated here for release-notes visibility)

`claude-usage --format json` (top-level bare flag form) no longer works. After upgrading to 0.2.0, callers must migrate:

```bash
# OLD (no longer works — will print help and exit 0)
claude-usage --format json

# NEW (0.2.0+)
claude-usage dashboard --format json
```

The README's migration note surfaces this prominently.

## Test plan

- [x] `uv run pytest` — 151 passed
- [x] End-to-end `claude-usage session-summary --path tests/fixtures/session_summaries/happy_path.jsonl` → valid JSON with all four contract keys
- [x] `claude-usage session-summary --path /tmp/nonexistent.jsonl` → exit 1 with single stderr diagnostic line
- [x] Bare `claude-usage` → help text listing both subcommands, exit 0
- [x] Dashboard subcommand regression unchanged (PR #28's snapshot test still green)

## Issue #19 closure

This PR is the **closing PR for Issue #19**. The closing keyword `Closes #19` appears in plain text at the top of this body (not backticks) so GitHub's parser recognizes it and auto-closes the issue on merge.

**Full #19 delivery timeline** (6 phases / 5 PRs):

| PR | Phase(s) | Landing commit |
|---|---|---|
| #28 | Phase 0 (baseline) + Phase 1 (subparser refactor) | `0f378b5` |
| #29 | Phase 2 (fixtures + scaffolding) | `c47c639` |
| #30 | Phase 3 (core derivation, TDD) | `947e58b` |
| #31 | Phase 4 (error paths) + Phase 5 (renderers) | `722596d` |
| this | Phase 6 (README + version) | — |

Final test count: 151 passing. All 17 spec-level test IDs implemented. All 7 Issue #19 acceptance criteria satisfied.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*