### PR TITLE
ci: add lint + test GitHub Actions workflow (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dev extras
+        run: uv pip install --system -e ".[dev]"
+      - name: Ruff check
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dev extras
+        run: uv pip install --system -e ".[dev]"
+      - name: Pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -149,7 +149,33 @@ Reads JSONL session files from `~/.claude/projects/`. Each session file contains
 
 ## Development
 
+### Setup
+
 ```bash
-pip install -e ".[dev]"
-pytest
+git clone https://github.com/cbeaulieu-gt/claude-usage.git
+cd claude-usage
+uv pip install -e ".[dev]"   # installs runtime + ruff + pytest
 ```
+
+### Testing
+
+```bash
+pytest                # ~151 tests, typically finishes in under 5 seconds
+```
+
+### Linting & formatting
+
+```bash
+ruff check .          # lint
+ruff format .         # autoformat in-place
+ruff format --check . # format gate (used in CI — exits non-zero on drift)
+```
+
+### CI
+
+GitHub Actions runs on every PR and push to `main`:
+
+- **lint** (Ubuntu): `ruff check .` + `ruff format --check .`
+- **test** (Ubuntu + Windows, Python 3.10): `pytest`
+
+Both jobs must be green before a PR can merge.

--- a/claude_usage/aggregator.py
+++ b/claude_usage/aggregator.py
@@ -6,7 +6,12 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
-from claude_usage.models import MessageRecord, SessionRecord, SkillPassedEvent, SkillInvokedEvent
+from claude_usage.models import (
+    MessageRecord,
+    SessionRecord,
+    SkillPassedEvent,
+    SkillInvokedEvent,
+)
 
 
 @dataclass
@@ -31,8 +36,12 @@ def _add_tokens(bucket: dict, msg: MessageRecord) -> None:
     bucket["total_tokens"] = bucket.get("total_tokens", 0) + msg.total_tokens
     bucket["input_tokens"] = bucket.get("input_tokens", 0) + msg.input_tokens
     bucket["output_tokens"] = bucket.get("output_tokens", 0) + msg.output_tokens
-    bucket["cache_read_tokens"] = bucket.get("cache_read_tokens", 0) + msg.cache_read_tokens
-    bucket["cache_creation_tokens"] = bucket.get("cache_creation_tokens", 0) + msg.cache_creation_tokens
+    bucket["cache_read_tokens"] = (
+        bucket.get("cache_read_tokens", 0) + msg.cache_read_tokens
+    )
+    bucket["cache_creation_tokens"] = (
+        bucket.get("cache_creation_tokens", 0) + msg.cache_creation_tokens
+    )
     bucket["message_count"] = bucket.get("message_count", 0) + 1
 
 
@@ -82,17 +91,21 @@ def aggregate(
 
             agents_in_session = sorted(set(m.agent_type for m in session_messages))
 
-            result.sessions.append({
-                "session_id": session.session_id,
-                "project": session.project,
-                "start_time": min(m.timestamp for m in session_messages).isoformat(),
-                "root_agent": session.root_agent,
-                "agents": agents_in_session,
-                "total_tokens": sum(m.total_tokens for m in session_messages),
-                "model_split": dict(model_tokens),
-                "duration_minutes": session.duration_minutes,
-                "message_count": len(session_messages),
-            })
+            result.sessions.append(
+                {
+                    "session_id": session.session_id,
+                    "project": session.project,
+                    "start_time": min(
+                        m.timestamp for m in session_messages
+                    ).isoformat(),
+                    "root_agent": session.root_agent,
+                    "agents": agents_in_session,
+                    "total_tokens": sum(m.total_tokens for m in session_messages),
+                    "model_split": dict(model_tokens),
+                    "duration_minutes": session.duration_minutes,
+                    "message_count": len(session_messages),
+                }
+            )
 
     result.total_tokens = sum(m.total_tokens for m in filtered_messages)
     result.total_messages = len(filtered_messages)
@@ -119,7 +132,9 @@ def aggregate(
         for agent in session_summary["agents"]:
             agent_session_count[agent].add(session_summary["session_id"])
     for agent in result.by_agent:
-        result.by_agent[agent]["session_count"] = len(agent_session_count.get(agent, set()))
+        result.by_agent[agent]["session_count"] = len(
+            agent_session_count.get(agent, set())
+        )
 
     for msg in filtered_messages:
         if msg.skill is None:
@@ -133,7 +148,11 @@ def aggregate(
     for session_summary in result.sessions:
         proj = session_summary["project"]
         if proj not in result.by_project:
-            result.by_project[proj] = {"total_tokens": 0, "session_count": 0, "message_count": 0}
+            result.by_project[proj] = {
+                "total_tokens": 0,
+                "session_count": 0,
+                "message_count": 0,
+            }
         result.by_project[proj]["total_tokens"] += session_summary["total_tokens"]
         result.by_project[proj]["message_count"] += session_summary["message_count"]
     for proj, sess_ids in project_sessions.items():
@@ -184,12 +203,15 @@ def compute_skill_adoption(
     result: dict[str, dict] = {}
     for skill, pass_list in passed_by_skill.items():
         times_invoked = sum(
-            1 for evt in pass_list
+            1
+            for evt in pass_list
             if evt.session_id in invoked_sessions.get(skill, set())
         )
         times_passed = len(pass_list)
 
-        by_agent: dict[str, dict[str, int]] = defaultdict(lambda: {"passed": 0, "invoked": 0})
+        by_agent: dict[str, dict[str, int]] = defaultdict(
+            lambda: {"passed": 0, "invoked": 0}
+        )
         for evt in pass_list:
             by_agent[evt.target_agent]["passed"] += 1
             if evt.session_id in invoked_sessions.get(skill, set()):
@@ -198,7 +220,9 @@ def compute_skill_adoption(
         result[skill] = {
             "times_passed": times_passed,
             "times_invoked": times_invoked,
-            "adoption_rate": round(times_invoked / times_passed, 3) if times_passed > 0 else 0.0,
+            "adoption_rate": round(times_invoked / times_passed, 3)
+            if times_passed > 0
+            else 0.0,
             "by_target_agent": dict(by_agent),
         }
 

--- a/claude_usage/cli/dashboard.py
+++ b/claude_usage/cli/dashboard.py
@@ -27,9 +27,7 @@ def _parse_window(window_str: str) -> float:
     Raises:
         argparse.ArgumentTypeError: If the format is not recognised.
     """
-    match = re.match(
-        r"^(\d+(?:\.\d+)?)(h|d)$", window_str.strip().lower()
-    )
+    match = re.match(r"^(\d+(?:\.\d+)?)(h|d)$", window_str.strip().lower())
     if not match:
         raise argparse.ArgumentTypeError(
             f"Invalid window format: '{window_str}'. Use e.g. '5h' or '7d'."
@@ -79,49 +77,59 @@ def build_parser(parent: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--data-dir",
         type=Path,
         default=Path.home() / ".claude",
-        help=(
-            "Path to Claude Code data directory (default: ~/.claude)"
-        ),
+        help=("Path to Claude Code data directory (default: ~/.claude)"),
     )
     p.add_argument(
-        "--from", dest="from_date", type=_parse_date,
-        help=(
-            "Start date (YYYY-MM-DD). Only include data on or after this date."
-        ),
+        "--from",
+        dest="from_date",
+        type=_parse_date,
+        help=("Start date (YYYY-MM-DD). Only include data on or after this date."),
     )
     p.add_argument(
-        "--to", dest="to_date", type=_parse_date,
-        help=(
-            "End date (YYYY-MM-DD). Only include data before this date."
-        ),
+        "--to",
+        dest="to_date",
+        type=_parse_date,
+        help=("End date (YYYY-MM-DD). Only include data before this date."),
     )
     p.add_argument(
-        "--window", type=_parse_window,
+        "--window",
+        type=_parse_window,
         help="Rolling window (e.g. '5h', '7d'). Overrides --from.",
     )
     p.add_argument(
-        "--output", "-o", type=Path,
+        "--output",
+        "-o",
+        type=Path,
         help="Output file path. If omitted, writes to a temp file.",
     )
     p.add_argument(
-        "--no-open", action="store_true",
+        "--no-open",
+        action="store_true",
         help="Don't open the dashboard in a browser.",
     )
     p.add_argument(
-        "--limit-5h", type=int, default=None,
+        "--limit-5h",
+        type=int,
+        default=None,
         help="Token budget for 5-hour rolling window.",
     )
     p.add_argument(
-        "--limit-7d", type=int, default=None,
+        "--limit-7d",
+        type=int,
+        default=None,
         help="Token budget for 7-day rolling window.",
     )
     p.add_argument(
-        "--limit-sonnet-7d", type=int, default=None,
+        "--limit-sonnet-7d",
+        type=int,
+        default=None,
         help="Token budget for Sonnet-only 7-day window.",
     )
     p.add_argument(
-        "--format", dest="output_format",
-        choices=["html", "json"], default="html",
+        "--format",
+        dest="output_format",
+        choices=["html", "json"],
+        default="html",
         help=(
             "Output format: 'html' (default) opens a dashboard; "
             "'json' writes structured data to stdout."
@@ -161,6 +169,7 @@ def run(args: argparse.Namespace) -> int:
     passed_events, invoked_events = parse_skill_tracking(args.data_dir)
     if passed_events or invoked_events:
         from claude_usage.aggregator import compute_skill_adoption
+
         result.by_skill_adoption = compute_skill_adoption(
             passed_events,
             invoked_events,

--- a/claude_usage/cli/session_summary.py
+++ b/claude_usage/cli/session_summary.py
@@ -30,24 +30,24 @@ DEFAULT_MAX_ACTIONS: int = 50
 _EDIT_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "NotebookEdit"})
 _BASH_TOOLS: frozenset[str] = frozenset({"Bash", "PowerShell"})
 _MAX_COMMAND_CHARS: int = 80
-SKIPPED_TOOLS: frozenset[str] = frozenset({
-    "Read",
-    "Grep",
-    "Glob",
-    "WebFetch",
-    "WebSearch",
-    "Skill",
-    "TodoWrite",
-})
+SKIPPED_TOOLS: frozenset[str] = frozenset(
+    {
+        "Read",
+        "Grep",
+        "Glob",
+        "WebFetch",
+        "WebSearch",
+        "Skill",
+        "TodoWrite",
+    }
+)
 
 _XML_WRAPPER_RE = re.compile(
     r"<(system-reminder|command-message|command-name"
     r"|command-args|local-command-stdout)>.*?</\1>",
     flags=re.DOTALL,
 )
-_SLASH_COMMAND_RE = re.compile(
-    r"<command-name>(/[^<]+)</command-name>"
-)
+_SLASH_COMMAND_RE = re.compile(r"<command-name>(/[^<]+)</command-name>")
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[\.\!\?])\s|\n")
 
 
@@ -200,10 +200,7 @@ def _derive_intent(entries: list[dict], project: str) -> str:
         A non-empty intent string.
     """
     for entry in entries:
-        if not (
-            entry.get("type") == "user"
-            and entry.get("userType") == "external"
-        ):
+        if not (entry.get("type") == "user" and entry.get("userType") == "external"):
             continue
         msg = entry.get("message", {})
         raw_content = msg.get("content", "")
@@ -252,14 +249,14 @@ def _normalize_mcp_tool_name(raw: str) -> str | None:
     """
     if not raw.startswith("mcp__"):
         return None
-    remainder = raw[len("mcp__"):]
+    remainder = raw[len("mcp__") :]
 
     # Strip the plugin segment if present.
     # Plugin form: plugin_<plugin>_<server>__<method>
     # After stripping "plugin_", the next segment is "<plugin>_<server>"
     # which is separated from <method> by "__".
     if remainder.startswith("plugin_"):
-        after_plugin = remainder[len("plugin_"):]
+        after_plugin = remainder[len("plugin_") :]
         # after_plugin is "<plugin>_<server>__<method>" — split once on "_"
         # to skip the plugin label, leaving "<server>__<method>".
         parts = after_plugin.split("_", 1)
@@ -591,9 +588,7 @@ def build_session_summary(
 
     # Render ActionRecords to strings, then apply the cap.
     action_strings_full = [r.summary for r in records]
-    action_strings = _apply_max_actions_cap(
-        action_strings_full, max_actions
-    )
+    action_strings = _apply_max_actions_cap(action_strings_full, max_actions)
 
     return SessionSummary(
         project=project,
@@ -644,9 +639,7 @@ def render_json(summary: SessionSummary) -> str:
     Returns:
         A JSON string without a trailing newline.
     """
-    return json.dumps(
-        _summary_to_dict(summary), indent=2, ensure_ascii=False
-    )
+    return json.dumps(_summary_to_dict(summary), indent=2, ensure_ascii=False)
 
 
 def _tri_state_to_word(value: bool | None) -> str:
@@ -723,12 +716,16 @@ def build_parser(
         help="Path to the transcript JSONL file.",
     )
     p.add_argument(
-        "--format", dest="output_format",
-        choices=["json", "text"], default="json",
+        "--format",
+        dest="output_format",
+        choices=["json", "text"],
+        default="json",
         help="Output format: 'json' (default) or 'text' (debug view).",
     )
     p.add_argument(
-        "--max-actions", type=int, default=DEFAULT_MAX_ACTIONS,
+        "--max-actions",
+        type=int,
+        default=DEFAULT_MAX_ACTIONS,
         dest="max_actions",
         help=(
             "Soft cap on emitted actions. 0 disables the cap. "
@@ -781,8 +778,7 @@ def run(args: argparse.Namespace) -> int:
 
     # ── Phase 4.2: no user turns ─────────────────────────────────────
     has_user_turns = any(
-        entry.get("type") == "user"
-        and entry.get("userType") == "external"
+        entry.get("type") == "user" and entry.get("userType") == "external"
         for entry in entries
     )
     if not has_user_turns:
@@ -797,8 +793,7 @@ def run(args: argparse.Namespace) -> int:
     skipped = non_blank_lines - len(entries)
     if skipped > 0:
         print(
-            f"session-summary: skipped {skipped} malformed line(s)"
-            f" in '{path}'",
+            f"session-summary: skipped {skipped} malformed line(s)" f" in '{path}'",
             file=sys.stderr,
         )
 

--- a/claude_usage/parser.py
+++ b/claude_usage/parser.py
@@ -44,9 +44,7 @@ def _extract_skill(content: list[dict]) -> str | None:
     return None
 
 
-def _parse_jsonl_messages(
-    jsonl_path: Path, agent_type: str
-) -> list[MessageRecord]:
+def _parse_jsonl_messages(jsonl_path: Path, agent_type: str) -> list[MessageRecord]:
     """Parse assistant messages from a JSONL file, attributing to agent_type."""
     messages: list[MessageRecord] = []
     with open(jsonl_path, "r", encoding="utf-8") as f:
@@ -88,9 +86,7 @@ def _parse_jsonl_messages(
     return messages
 
 
-def _parse_session(
-    jsonl_path: Path, project_name: str
-) -> SessionRecord | None:
+def _parse_session(jsonl_path: Path, project_name: str) -> SessionRecord | None:
     """Parse a single session JSONL file and its subagents."""
     session_id = jsonl_path.stem
 

--- a/claude_usage/renderer.py
+++ b/claude_usage/renderer.py
@@ -59,7 +59,10 @@ def render(
 
     if output_path is None:
         tmp = NamedTemporaryFile(
-            suffix=".html", prefix="claude-usage-", delete=False, mode="w",
+            suffix=".html",
+            prefix="claude-usage-",
+            delete=False,
+            mode="w",
             encoding="utf-8",
         )
         tmp.write(html)

--- a/claude_usage/skill_tracking.py
+++ b/claude_usage/skill_tracking.py
@@ -44,21 +44,25 @@ def parse_skill_tracking(
         event_type = entry.get("event")
         if event_type == "skill_passed":
             try:
-                passed.append(SkillPassedEvent(
-                    skill=entry["skill"],
-                    target_agent=entry["target_agent"],
-                    timestamp=_parse_timestamp(entry["timestamp"]),
-                    session_id=entry["session_id"],
-                ))
+                passed.append(
+                    SkillPassedEvent(
+                        skill=entry["skill"],
+                        target_agent=entry["target_agent"],
+                        timestamp=_parse_timestamp(entry["timestamp"]),
+                        session_id=entry["session_id"],
+                    )
+                )
             except (KeyError, ValueError):
                 continue
         elif event_type == "skill_invoked":
             try:
-                invoked.append(SkillInvokedEvent(
-                    skill=entry["skill"],
-                    timestamp=_parse_timestamp(entry["timestamp"]),
-                    session_id=entry["session_id"],
-                ))
+                invoked.append(
+                    SkillInvokedEvent(
+                        skill=entry["skill"],
+                        timestamp=_parse_timestamp(entry["timestamp"]),
+                        session_id=entry["session_id"],
+                    )
+                )
             except (KeyError, ValueError):
                 continue
 
@@ -103,9 +107,7 @@ def build_skill_allowlist(claude_dir: Path) -> set[str]:
 
 
 # Patterns for extracting skill references from Agent dispatch prompts
-_BACKTICK_PATTERN = re.compile(
-    r"`([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)`"
-)
+_BACKTICK_PATTERN = re.compile(r"`([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)`")
 _PHRASE_PATTERNS = [
     re.compile(
         r"[Uu]se (?:the )?[\"']?"
@@ -120,9 +122,7 @@ _PHRASE_PATTERNS = [
         re.IGNORECASE,
     ),
     re.compile(
-        r"[Uu]se skill:?\s*[\"']?"
-        r"([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)"
-        r"[\"']?",
+        r"[Uu]se skill:?\s*[\"']?" r"([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)" r"[\"']?",
         re.IGNORECASE,
     ),
 ]

--- a/claude_usage/skill_tracking.py
+++ b/claude_usage/skill_tracking.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 from claude_usage.models import SkillInvokedEvent, SkillPassedEvent

--- a/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
+++ b/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
@@ -21,9 +21,9 @@
 - [x] **2.4** Full pytest suite — must pass (`151 passed`).
 
 ### Phase 3 — Format drift
-- [ ] **3.1** Run `ruff format .` — should touch exactly 16 files per pre-existing baseline. Commit as a single mechanical change so review diff is scannable.
-- [ ] **3.2** Re-run `ruff format --check .` — must exit 0.
-- [ ] **3.3** Full pytest suite — must pass.
+- [x] **3.1** Run `ruff format .` — should touch exactly 16 files per pre-existing baseline. Commit as a single mechanical change so review diff is scannable.
+- [x] **3.2** Re-run `ruff format --check .` — must exit 0.
+- [x] **3.3** Full pytest suite — must pass.
 
 ### Phase 4 — CI workflow
 - [ ] **4.1** Write `.github/workflows/ci.yml` with:

--- a/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
+++ b/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
@@ -15,10 +15,10 @@
 - [x] **1.2** Verify `uv pip install -e .[dev]` resolves cleanly in the worktree; capture the installed ruff + pytest versions in the commit message.
 
 ### Phase 2 — Lint cleanup (pre-existing errors)
-- [ ] **2.1** Run `ruff check .` to produce the baseline. Confirm 10 errors (F401 unused imports in tests + one E741 `l` in `test_e2e.py`).
-- [ ] **2.2** Fix each error with the minimum diff. Remove unused imports; rename `l` to something descriptive (`line` or `record` — pick based on usage).
-- [ ] **2.3** Re-run `ruff check .` — must exit 0.
-- [ ] **2.4** Full pytest suite — must pass (`151 passed`).
+- [x] **2.1** Run `ruff check .` to produce the baseline. Confirm 10 errors (F401 unused imports in tests + one E741 `l` in `test_e2e.py`).
+- [x] **2.2** Fix each error with the minimum diff. Remove unused imports; rename `l` to something descriptive (`line` or `record` — pick based on usage).
+- [x] **2.3** Re-run `ruff check .` — must exit 0.
+- [x] **2.4** Full pytest suite — must pass (`151 passed`).
 
 ### Phase 3 — Format drift
 - [ ] **3.1** Run `ruff format .` — should touch exactly 16 files per pre-existing baseline. Commit as a single mechanical change so review diff is scannable.

--- a/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
+++ b/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
@@ -1,0 +1,70 @@
+# Plan — Issue #32: CI lint + test GitHub Actions workflow
+
+**Branch:** `feature/ci` (worktree at `.worktrees/feature-ci`)
+**Base:** `main` @ `afff549`
+**Issue:** https://github.com/cbeaulieu-gt/claude-usage/issues/32
+**PR target:** one PR, six commits, closes #32
+**Version pinning:** compatible-release (`~=`) — picks up patch fixes, avoids surprise minor-release rule additions
+
+---
+
+## Task list
+
+### Phase 1 — Dependency declaration
+- [x] **1.1** Add `[project.optional-dependencies]` to `pyproject.toml` with `dev = ["ruff~=0.6.0", "pytest~=8.0"]` (match pytest's existing pin if one is present; otherwise introduce the compatible-release pin).
+- [x] **1.2** Verify `uv pip install -e .[dev]` resolves cleanly in the worktree; capture the installed ruff + pytest versions in the commit message.
+
+### Phase 2 — Lint cleanup (pre-existing errors)
+- [ ] **2.1** Run `ruff check .` to produce the baseline. Confirm 10 errors (F401 unused imports in tests + one E741 `l` in `test_e2e.py`).
+- [ ] **2.2** Fix each error with the minimum diff. Remove unused imports; rename `l` to something descriptive (`line` or `record` — pick based on usage).
+- [ ] **2.3** Re-run `ruff check .` — must exit 0.
+- [ ] **2.4** Full pytest suite — must pass (`151 passed`).
+
+### Phase 3 — Format drift
+- [ ] **3.1** Run `ruff format .` — should touch exactly 16 files per pre-existing baseline. Commit as a single mechanical change so review diff is scannable.
+- [ ] **3.2** Re-run `ruff format --check .` — must exit 0.
+- [ ] **3.3** Full pytest suite — must pass.
+
+### Phase 4 — CI workflow
+- [ ] **4.1** Write `.github/workflows/ci.yml` with:
+  - Triggers: `pull_request` and `push` on `main`.
+  - `permissions: contents: read`.
+  - `lint` job: `ubuntu-latest`, Python 3.10, `astral-sh/setup-uv@v5` with cache, `uv pip install -e .[dev]`, then `ruff check .` + `ruff format --check .`.
+  - `test` job: matrix `os: [ubuntu-latest, windows-latest]`, Python 3.10, same uv setup, `pytest`.
+- [ ] **4.2** Lint and test jobs are separate top-level jobs (not sequential steps in one job) — per `feedback_ci_split_lint_and_test.md`, distinct check entries make failure source obvious at a glance.
+- [ ] **4.3** Validate YAML syntax locally with `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`.
+
+### Phase 5 — README
+- [ ] **5.1** Add a "Development" section to `README.md` between "Subcommands" and wherever makes structural sense. Cover: `uv pip install -e .[dev]`, `pytest`, `ruff check`, `ruff format`.
+- [ ] **5.2** No other README sections modified.
+
+### Phase 6 — PR + verification
+- [ ] **6.1** Push `feature/ci` and open PR with body containing plain-text `Closes #32` (no backticks).
+- [ ] **6.2** Wait for first CI run. Both jobs green before requesting review.
+- [ ] **6.3** After merge, user manually enables branch protection on `main`: required checks = `lint`, `test (ubuntu-latest)`, `test (windows-latest)`.
+
+---
+
+## Verification (applied after EVERY commit)
+
+Full suite, mirroring CI — not just the file touched:
+
+```bash
+ruff check .
+ruff format --check .
+pytest
+```
+
+All three must exit 0 before moving to the next task.
+
+---
+
+## Out of scope (explicit)
+
+- `mypy` / `pyright` typecheck — deferred (user decision).
+- Coverage reporting (`pytest-cov` + codecov upload).
+- Pre-commit hooks.
+- Python 3.11 / 3.12 matrix expansion.
+- `uv.lock` commit (not using a lockfile strategy for this dev-only dependency).
+
+These may land as follow-up issues after #32 merges.

--- a/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
+++ b/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
@@ -35,8 +35,8 @@
 - [x] **4.3** Validate YAML syntax locally with `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`.
 
 ### Phase 5 — README
-- [ ] **5.1** Add a "Development" section to `README.md` between "Subcommands" and wherever makes structural sense. Cover: `uv pip install -e .[dev]`, `pytest`, `ruff check`, `ruff format`.
-- [ ] **5.2** No other README sections modified.
+- [x] **5.1** Add a "Development" section to `README.md` between "Subcommands" and wherever makes structural sense. Cover: `uv pip install -e .[dev]`, `pytest`, `ruff check`, `ruff format`.
+- [x] **5.2** No other README sections modified.
 
 ### Phase 6 — PR + verification
 - [ ] **6.1** Push `feature/ci` and open PR with body containing plain-text `Closes #32` (no backticks).

--- a/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
+++ b/docs/superpowers/plans/2026-04-24-ci-workflow-plan.md
@@ -26,13 +26,13 @@
 - [x] **3.3** Full pytest suite — must pass.
 
 ### Phase 4 — CI workflow
-- [ ] **4.1** Write `.github/workflows/ci.yml` with:
+- [x] **4.1** Write `.github/workflows/ci.yml` with:
   - Triggers: `pull_request` and `push` on `main`.
   - `permissions: contents: read`.
   - `lint` job: `ubuntu-latest`, Python 3.10, `astral-sh/setup-uv@v5` with cache, `uv pip install -e .[dev]`, then `ruff check .` + `ruff format --check .`.
   - `test` job: matrix `os: [ubuntu-latest, windows-latest]`, Python 3.10, same uv setup, `pytest`.
-- [ ] **4.2** Lint and test jobs are separate top-level jobs (not sequential steps in one job) — per `feedback_ci_split_lint_and_test.md`, distinct check entries make failure source obvious at a glance.
-- [ ] **4.3** Validate YAML syntax locally with `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`.
+- [x] **4.2** Lint and test jobs are separate top-level jobs (not sequential steps in one job) — per `feedback_ci_split_lint_and_test.md`, distinct check entries make failure source obvious at a glance.
+- [x] **4.3** Validate YAML syntax locally with `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`.
 
 ### Phase 5 — README
 - [ ] **5.1** Add a "Development" section to `README.md` between "Subcommands" and wherever makes structural sense. Cover: `uv pip install -e .[dev]`, `pytest`, `ruff check`, `ruff format`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
+    "ruff~=0.6.0",
+    "pytest~=8.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/fixtures/sanitize_transcript.py
+++ b/tests/fixtures/sanitize_transcript.py
@@ -43,10 +43,7 @@ def _sanitize_entry(entry: dict) -> dict:
     Returns:
         A new dict with identifying fields removed and content sanitized.
     """
-    result = {
-        k: v for k, v in entry.items()
-        if k not in _OMIT_TOP_LEVEL_KEYS
-    }
+    result = {k: v for k, v in entry.items() if k not in _OMIT_TOP_LEVEL_KEYS}
     msg = result.get("message")
     if isinstance(msg, dict):
         content = msg.get("content")

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -4,9 +4,16 @@ from claude_usage.aggregator import aggregate
 from claude_usage.models import MessageRecord, SessionRecord
 
 
-def _msg(model="claude-opus-4-6", agent="general-purpose", skill=None,
-         input_t=100, output_t=50, cache_read=0, cache_create=0,
-         ts=None):
+def _msg(
+    model="claude-opus-4-6",
+    agent="general-purpose",
+    skill=None,
+    input_t=100,
+    output_t=50,
+    cache_read=0,
+    cache_create=0,
+    ts=None,
+):
     return MessageRecord(
         timestamp=ts or datetime(2026, 4, 9, 12, 0, 0, tzinfo=timezone.utc),
         model=model,
@@ -19,9 +26,18 @@ def _msg(model="claude-opus-4-6", agent="general-purpose", skill=None,
     )
 
 
-def _session(messages, session_id="s1", project="proj", root_agent="general-purpose",
-             subagent_types=None):
-    start = min(m.timestamp for m in messages) if messages else datetime(2026, 4, 9, tzinfo=timezone.utc)
+def _session(
+    messages,
+    session_id="s1",
+    project="proj",
+    root_agent="general-purpose",
+    subagent_types=None,
+):
+    start = (
+        min(m.timestamp for m in messages)
+        if messages
+        else datetime(2026, 4, 9, tzinfo=timezone.utc)
+    )
     return SessionRecord(
         session_id=session_id,
         project=project,
@@ -34,21 +50,29 @@ def _session(messages, session_id="s1", project="proj", root_agent="general-purp
 
 class TestAggregateByModel:
     def test_groups_by_model_short(self):
-        sessions = [_session([
-            _msg(model="claude-opus-4-6", input_t=100, output_t=50),
-            _msg(model="claude-sonnet-4-6", input_t=200, output_t=100),
-            _msg(model="claude-opus-4-6", input_t=50, output_t=25),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(model="claude-opus-4-6", input_t=100, output_t=50),
+                    _msg(model="claude-sonnet-4-6", input_t=200, output_t=100),
+                    _msg(model="claude-opus-4-6", input_t=50, output_t=25),
+                ]
+            )
+        ]
         result = aggregate(sessions)
         assert result.by_model["opus"]["total_tokens"] == 225
         assert result.by_model["sonnet"]["total_tokens"] == 300
 
     def test_model_message_count(self):
-        sessions = [_session([
-            _msg(model="claude-opus-4-6"),
-            _msg(model="claude-opus-4-6"),
-            _msg(model="claude-sonnet-4-6"),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(model="claude-opus-4-6"),
+                    _msg(model="claude-opus-4-6"),
+                    _msg(model="claude-sonnet-4-6"),
+                ]
+            )
+        ]
         result = aggregate(sessions)
         assert result.by_model["opus"]["message_count"] == 2
         assert result.by_model["sonnet"]["message_count"] == 1
@@ -56,33 +80,54 @@ class TestAggregateByModel:
 
 class TestAggregateByAgent:
     def test_groups_by_agent_type(self):
-        sessions = [_session([
-            _msg(agent="general-purpose", input_t=100, output_t=50),
-            _msg(agent="code-writer", model="claude-sonnet-4-6", input_t=200, output_t=100),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(agent="general-purpose", input_t=100, output_t=50),
+                    _msg(
+                        agent="code-writer",
+                        model="claude-sonnet-4-6",
+                        input_t=200,
+                        output_t=100,
+                    ),
+                ]
+            )
+        ]
         result = aggregate(sessions)
         assert result.by_agent["general-purpose"]["total_tokens"] == 150
         assert result.by_agent["code-writer"]["total_tokens"] == 300
 
     def test_agent_includes_model(self):
-        sessions = [_session([
-            _msg(agent="general-purpose", model="claude-opus-4-6"),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(agent="general-purpose", model="claude-opus-4-6"),
+                ]
+            )
+        ]
         result = aggregate(sessions)
         assert result.by_agent["general-purpose"]["primary_model"] == "opus"
 
 
 class TestAggregateBySkill:
     def test_groups_by_skill(self):
-        sessions = [_session([
-            _msg(skill="superpowers:brainstorming", input_t=100, output_t=50),
-            _msg(skill="superpowers:brainstorming", input_t=200, output_t=100),
-            _msg(skill="commit-commands:commit-push-pr", input_t=50, output_t=25),
-            _msg(skill=None, input_t=1000, output_t=500),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(skill="superpowers:brainstorming", input_t=100, output_t=50),
+                    _msg(skill="superpowers:brainstorming", input_t=200, output_t=100),
+                    _msg(
+                        skill="commit-commands:commit-push-pr", input_t=50, output_t=25
+                    ),
+                    _msg(skill=None, input_t=1000, output_t=500),
+                ]
+            )
+        ]
         result = aggregate(sessions)
         assert result.by_skill["superpowers:brainstorming"]["invocation_count"] == 2
-        assert result.by_skill["commit-commands:commit-push-pr"]["invocation_count"] == 1
+        assert (
+            result.by_skill["commit-commands:commit-push-pr"]["invocation_count"] == 1
+        )
         assert None not in result.by_skill
 
 
@@ -90,7 +135,9 @@ class TestAggregateByProject:
     def test_groups_by_project(self):
         sessions = [
             _session([_msg(input_t=100, output_t=50)], project="proj-a"),
-            _session([_msg(input_t=200, output_t=100)], session_id="s2", project="proj-b"),
+            _session(
+                [_msg(input_t=200, output_t=100)], session_id="s2", project="proj-b"
+            ),
         ]
         result = aggregate(sessions)
         assert result.by_project["proj-a"]["total_tokens"] == 150
@@ -101,10 +148,14 @@ class TestAggregateDaily:
     def test_groups_by_day(self):
         day1 = datetime(2026, 4, 8, 10, 0, 0, tzinfo=timezone.utc)
         day2 = datetime(2026, 4, 9, 14, 0, 0, tzinfo=timezone.utc)
-        sessions = [_session([
-            _msg(ts=day1, input_t=100, output_t=50),
-            _msg(ts=day2, input_t=200, output_t=100),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(ts=day1, input_t=100, output_t=50),
+                    _msg(ts=day2, input_t=200, output_t=100),
+                ]
+            )
+        ]
         result = aggregate(sessions)
         assert "2026-04-08" in result.by_day
         assert "2026-04-09" in result.by_day
@@ -116,10 +167,14 @@ class TestAggregateTimeFilter:
     def test_filter_by_date_range(self):
         old = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
         recent = datetime(2026, 4, 9, 12, 0, 0, tzinfo=timezone.utc)
-        sessions = [_session([
-            _msg(ts=old, input_t=100, output_t=50),
-            _msg(ts=recent, input_t=200, output_t=100),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(ts=old, input_t=100, output_t=50),
+                    _msg(ts=recent, input_t=200, output_t=100),
+                ]
+            )
+        ]
         from_date = datetime(2026, 4, 5, tzinfo=timezone.utc)
         result = aggregate(sessions, from_date=from_date)
         assert result.total_tokens == 300
@@ -128,9 +183,13 @@ class TestAggregateTimeFilter:
         now = datetime.now(timezone.utc)
         old = now - timedelta(hours=10)
         recent = now - timedelta(hours=2)
-        sessions = [_session([
-            _msg(ts=old, input_t=100, output_t=50),
-            _msg(ts=recent, input_t=200, output_t=100),
-        ])]
+        sessions = [
+            _session(
+                [
+                    _msg(ts=old, input_t=100, output_t=50),
+                    _msg(ts=recent, input_t=200, output_t=100),
+                ]
+            )
+        ]
         result = aggregate(sessions, window_hours=5)
         assert result.total_tokens == 300

--- a/tests/test_aggregator_adoption.py
+++ b/tests/test_aggregator_adoption.py
@@ -15,8 +15,12 @@ class TestComputeSkillAdoption:
 
     def test_passed_but_never_invoked(self):
         passed = [
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
-            SkillPassedEvent("python", "debugger", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
+            SkillPassedEvent(
+                "python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
+            SkillPassedEvent(
+                "python", "debugger", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
         ]
         result = compute_skill_adoption(passed, [])
         assert result["python"]["times_passed"] == 2
@@ -27,17 +31,26 @@ class TestComputeSkillAdoption:
 
     def test_invoked_without_pass(self):
         invoked = [
-            SkillInvokedEvent("python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
         ]
         result = compute_skill_adoption([], invoked)
         assert result == {}
 
     def test_full_adoption(self):
         passed = [
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc), "s1"),
+            SkillPassedEvent(
+                "python",
+                "code-writer",
+                datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc),
+                "s1",
+            ),
         ]
         invoked = [
-            SkillInvokedEvent("python", datetime(2026, 4, 9, 12, 1, tzinfo=timezone.utc), "s1"),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, 12, 1, tzinfo=timezone.utc), "s1"
+            ),
         ]
         result = compute_skill_adoption(passed, invoked)
         assert result["python"]["times_passed"] == 1
@@ -46,13 +59,23 @@ class TestComputeSkillAdoption:
 
     def test_partial_adoption(self):
         passed = [
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s2"),
-            SkillPassedEvent("python", "debugger", datetime(2026, 4, 9, tzinfo=timezone.utc), "s3"),
+            SkillPassedEvent(
+                "python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
+            SkillPassedEvent(
+                "python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s2"
+            ),
+            SkillPassedEvent(
+                "python", "debugger", datetime(2026, 4, 9, tzinfo=timezone.utc), "s3"
+            ),
         ]
         invoked = [
-            SkillInvokedEvent("python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
-            SkillInvokedEvent("python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s2"),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s2"
+            ),
         ]
         result = compute_skill_adoption(passed, invoked)
         assert result["python"]["times_passed"] == 3
@@ -61,11 +84,20 @@ class TestComputeSkillAdoption:
 
     def test_multiple_skills(self):
         passed = [
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
-            SkillPassedEvent("powershell", "debugger", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
+            SkillPassedEvent(
+                "python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
+            SkillPassedEvent(
+                "powershell",
+                "debugger",
+                datetime(2026, 4, 9, tzinfo=timezone.utc),
+                "s1",
+            ),
         ]
         invoked = [
-            SkillInvokedEvent("python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
         ]
         result = compute_skill_adoption(passed, invoked)
         assert result["python"]["adoption_rate"] == 1.0
@@ -73,13 +105,23 @@ class TestComputeSkillAdoption:
 
     def test_per_agent_breakdown(self):
         passed = [
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s2"),
-            SkillPassedEvent("python", "debugger", datetime(2026, 4, 9, tzinfo=timezone.utc), "s3"),
+            SkillPassedEvent(
+                "python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
+            SkillPassedEvent(
+                "python", "code-writer", datetime(2026, 4, 9, tzinfo=timezone.utc), "s2"
+            ),
+            SkillPassedEvent(
+                "python", "debugger", datetime(2026, 4, 9, tzinfo=timezone.utc), "s3"
+            ),
         ]
         invoked = [
-            SkillInvokedEvent("python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"),
-            SkillInvokedEvent("python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s3"),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s1"
+            ),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, tzinfo=timezone.utc), "s3"
+            ),
         ]
         result = compute_skill_adoption(passed, invoked)
         agents = result["python"]["by_target_agent"]
@@ -91,12 +133,26 @@ class TestComputeSkillAdoption:
     def test_time_filtering(self):
         cutoff = datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc)
         passed = [
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, 11, 0, tzinfo=timezone.utc), "s1"),
-            SkillPassedEvent("python", "code-writer", datetime(2026, 4, 9, 13, 0, tzinfo=timezone.utc), "s2"),
+            SkillPassedEvent(
+                "python",
+                "code-writer",
+                datetime(2026, 4, 9, 11, 0, tzinfo=timezone.utc),
+                "s1",
+            ),
+            SkillPassedEvent(
+                "python",
+                "code-writer",
+                datetime(2026, 4, 9, 13, 0, tzinfo=timezone.utc),
+                "s2",
+            ),
         ]
         invoked = [
-            SkillInvokedEvent("python", datetime(2026, 4, 9, 11, 1, tzinfo=timezone.utc), "s1"),
-            SkillInvokedEvent("python", datetime(2026, 4, 9, 13, 1, tzinfo=timezone.utc), "s2"),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, 11, 1, tzinfo=timezone.utc), "s1"
+            ),
+            SkillInvokedEvent(
+                "python", datetime(2026, 4, 9, 13, 1, tzinfo=timezone.utc), "s2"
+            ),
         ]
         result = compute_skill_adoption(passed, invoked, from_date=cutoff)
         assert result["python"]["times_passed"] == 1

--- a/tests/test_aggregator_adoption.py
+++ b/tests/test_aggregator_adoption.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-import pytest
-
 from claude_usage.aggregator import compute_skill_adoption
 from claude_usage.models import SkillInvokedEvent, SkillPassedEvent
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,9 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-
 def run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
     """Helper: run `python -m claude_usage` with the given args."""
     return subprocess.run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 def run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
     """Helper: run `python -m claude_usage` with the given args."""
     return subprocess.run(
@@ -38,7 +39,14 @@ class TestFormatJson:
     def test_outputs_valid_json(self, sample_session_dir: Path):
         """dashboard --format json must write parseable JSON to stdout."""
         result = run_cli(
-            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            [
+                "dashboard",
+                "--format",
+                "json",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+            ],
             cwd=WORKTREE_ROOT,
         )
         assert result.returncode == 0, f"CLI failed:\n{result.stderr}"
@@ -48,7 +56,14 @@ class TestFormatJson:
     def test_has_expected_top_level_keys(self, sample_session_dir: Path):
         """JSON output must contain all expected top-level keys."""
         result = run_cli(
-            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            [
+                "dashboard",
+                "--format",
+                "json",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+            ],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
@@ -57,7 +72,14 @@ class TestFormatJson:
     def test_contains_aggregated_data(self, sample_session_dir: Path):
         """JSON output must reflect the parsed session data."""
         result = run_cli(
-            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            [
+                "dashboard",
+                "--format",
+                "json",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+            ],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
@@ -70,8 +92,16 @@ class TestFormatJson:
     def test_generated_at_is_iso8601(self, sample_session_dir: Path):
         """generated_at must be a valid ISO-8601 datetime string."""
         from datetime import datetime
+
         result = run_cli(
-            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            [
+                "dashboard",
+                "--format",
+                "json",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+            ],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
@@ -84,11 +114,15 @@ class TestFormatJson:
         result = run_cli(
             [
                 "dashboard",
-                "--format", "json",
+                "--format",
+                "json",
                 "--no-open",
-                "--data-dir", str(sample_session_dir),
-                "--limit-5h", "600000",
-                "--limit-7d", "4000000",
+                "--data-dir",
+                str(sample_session_dir),
+                "--limit-5h",
+                "600000",
+                "--limit-7d",
+                "4000000",
             ],
             cwd=WORKTREE_ROOT,
         )
@@ -102,7 +136,14 @@ class TestFormatJson:
     def test_limits_null_when_not_set(self, sample_session_dir: Path):
         """When no limit flags are passed, limits key is null."""
         result = run_cli(
-            ["dashboard", "--format", "json", "--no-open", "--data-dir", str(sample_session_dir)],
+            [
+                "dashboard",
+                "--format",
+                "json",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+            ],
             cwd=WORKTREE_ROOT,
         )
         data = json.loads(result.stdout)
@@ -125,15 +166,20 @@ class TestFormatJson:
         result = run_cli(
             [
                 "dashboard",
-                "--format", "json",
+                "--format",
+                "json",
                 "--no-open",
-                "--data-dir", str(sample_session_dir),
-                "--output", str(tmp_path / "out.html"),
+                "--data-dir",
+                str(sample_session_dir),
+                "--output",
+                str(tmp_path / "out.html"),
             ],
             cwd=WORKTREE_ROOT,
         )
         assert result.returncode == 0
-        assert not (tmp_path / "out.html").exists(), "HTML file should not be written in json mode"
+        assert not (
+            tmp_path / "out.html"
+        ).exists(), "HTML file should not be written in json mode"
 
 
 class TestFormatHtmlDefault:
@@ -144,8 +190,10 @@ class TestFormatHtmlDefault:
             [
                 "dashboard",
                 "--no-open",
-                "--data-dir", str(sample_session_dir),
-                "--output", str(output_path),
+                "--data-dir",
+                str(sample_session_dir),
+                "--output",
+                str(output_path),
             ],
             cwd=WORKTREE_ROOT,
         )
@@ -158,10 +206,13 @@ class TestFormatHtmlDefault:
         result = run_cli(
             [
                 "dashboard",
-                "--format", "html",
+                "--format",
+                "html",
                 "--no-open",
-                "--data-dir", str(sample_session_dir),
-                "--output", str(output_path),
+                "--data-dir",
+                str(sample_session_dir),
+                "--output",
+                str(output_path),
             ],
             cwd=WORKTREE_ROOT,
         )

--- a/tests/test_dashboard_snapshot.py
+++ b/tests/test_dashboard_snapshot.py
@@ -18,9 +18,7 @@ FIXTURE_DIR = (
     / "dashboard_baseline_input"
 )
 SNAPSHOT_FILE = (
-    Path(__file__).parent
-    / "fixtures"
-    / "dashboard_snapshot_pre_refactor.json"
+    Path(__file__).parent / "fixtures" / "dashboard_snapshot_pre_refactor.json"
 )
 
 
@@ -38,19 +36,25 @@ def test_existing_dashboard_unchanged() -> None:
     """
     result = subprocess.run(
         [
-            sys.executable, "-m", "claude_usage",
+            sys.executable,
+            "-m",
+            "claude_usage",
             "dashboard",
-            "--from", "2026-01-01",
-            "--to", "2026-12-31",
-            "--format", "json",
-            "--data-dir", str(FIXTURE_DIR),
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-12-31",
+            "--format",
+            "json",
+            "--data-dir",
+            str(FIXTURE_DIR),
         ],
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"dashboard exited {result.returncode}.\nstderr: {result.stderr}"
-    )
+    assert (
+        result.returncode == 0
+    ), f"dashboard exited {result.returncode}.\nstderr: {result.stderr}"
 
     actual = json.loads(result.stdout)
     expected = json.loads(SNAPSHOT_FILE.read_text(encoding="utf-8"))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -34,7 +34,9 @@ class TestEndToEnd:
 
         limits = {"limit_5h": 600000, "limit_7d": 4000000, "limit_sonnet_7d": 2000000}
         output_path = tmp_path / "dashboard-limits.html"
-        rendered = render(result, output_path=output_path, open_browser=False, limits=limits)
+        rendered = render(
+            result, output_path=output_path, open_browser=False, limits=limits
+        )
         assert rendered.exists()
 
         html = rendered.read_text(encoding="utf-8")
@@ -51,15 +53,32 @@ class TestEndToEnd:
 
 
 class TestSkillAdoptionE2E:
-    def test_adoption_data_in_rendered_html(self, sample_session_dir: Path, tmp_path: Path):
+    def test_adoption_data_in_rendered_html(
+        self, sample_session_dir: Path, tmp_path: Path
+    ):
         """Verify skill adoption data appears in the rendered dashboard."""
         from claude_usage.aggregator import compute_skill_adoption
         from claude_usage.skill_tracking import parse_skill_tracking
 
         tracking_file = sample_session_dir / "skill-tracking.jsonl"
         lines = [
-            json.dumps({"event": "skill_passed", "skill": "python", "target_agent": "code-writer", "timestamp": "2026-04-09T21:00:00Z", "session_id": "test-1"}),
-            json.dumps({"event": "skill_invoked", "skill": "python", "timestamp": "2026-04-09T21:01:00Z", "session_id": "test-1"}),
+            json.dumps(
+                {
+                    "event": "skill_passed",
+                    "skill": "python",
+                    "target_agent": "code-writer",
+                    "timestamp": "2026-04-09T21:00:00Z",
+                    "session_id": "test-1",
+                }
+            ),
+            json.dumps(
+                {
+                    "event": "skill_invoked",
+                    "skill": "python",
+                    "timestamp": "2026-04-09T21:01:00Z",
+                    "session_id": "test-1",
+                }
+            ),
         ]
         tracking_file.write_text("\n".join(lines) + "\n")
 
@@ -142,7 +161,9 @@ class TestSubagentModelAttribution:
 
         # debugger subagent metadata
         (subagent_dir / "agent-debugger1.meta.json").write_text(
-            json.dumps({"agentType": "debugger", "description": "Debug the auth module"}),
+            json.dumps(
+                {"agentType": "debugger", "description": "Debug the auth module"}
+            ),
             encoding="utf-8",
         )
 
@@ -201,11 +222,13 @@ class TestSubagentModelAttribution:
             "debugger ran on claude-sonnet-4-6; primary_model must be 'sonnet', "
             f"got {result.by_agent['debugger']['primary_model']!r}"
         )
-        assert result.by_agent["general-purpose"]["primary_model"] == "opus", (
-            "general-purpose ran on claude-opus-4-6; primary_model must be 'opus'"
-        )
+        assert (
+            result.by_agent["general-purpose"]["primary_model"] == "opus"
+        ), "general-purpose ran on claude-opus-4-6; primary_model must be 'opus'"
 
-    def test_rendered_html_embeds_correct_primary_model_for_subagent(self, tmp_path: Path):
+    def test_rendered_html_embeds_correct_primary_model_for_subagent(
+        self, tmp_path: Path
+    ):
         """Rendered HTML must embed primary_model='sonnet' for debugger in DATA.by_agent.
 
         The dashboard JavaScript reads DATA.by_agent[agent].primary_model to

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -133,7 +133,7 @@ class TestSubagentModelAttribution:
         ]
 
         (project_dir / f"{session_id}.jsonl").write_text(
-            "\n".join(json.dumps(l) for l in parent_lines), encoding="utf-8"
+            "\n".join(json.dumps(rec) for rec in parent_lines), encoding="utf-8"
         )
 
         # Subagent directory
@@ -177,7 +177,7 @@ class TestSubagentModelAttribution:
         ]
 
         (subagent_dir / "agent-debugger1.jsonl").write_text(
-            "\n".join(json.dumps(l) for l in sub_lines), encoding="utf-8"
+            "\n".join(json.dumps(rec) for rec in sub_lines), encoding="utf-8"
         )
 
         return tmp_path

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,12 @@
 # tests/test_models.py
 from datetime import datetime, timezone
 
-from claude_usage.models import MessageRecord, SessionRecord, SkillPassedEvent, SkillInvokedEvent
+from claude_usage.models import (
+    MessageRecord,
+    SessionRecord,
+    SkillPassedEvent,
+    SkillInvokedEvent,
+)
 
 
 class TestMessageRecord:
@@ -37,7 +42,10 @@ class TestMessageRecord:
             model="claude-opus-4-6",
             agent_type="general-purpose",
             skill=None,
-            input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
         )
         assert msg.model_short == "opus"
 
@@ -47,7 +55,10 @@ class TestMessageRecord:
             model="claude-sonnet-4-6",
             agent_type="code-writer",
             skill=None,
-            input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
         )
         assert msg.model_short == "sonnet"
 
@@ -57,7 +68,10 @@ class TestMessageRecord:
             model="claude-haiku-4-5-20251001",
             agent_type="ops",
             skill=None,
-            input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
         )
         assert msg.model_short == "haiku"
 
@@ -67,15 +81,26 @@ class TestMessageRecord:
             model="claude-future-model-9",
             agent_type="general-purpose",
             skill=None,
-            input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0,
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
         )
         assert msg.model_short == "claude-future-model-9"
 
 
 class TestSessionRecord:
-    def _make_msg(self, model="claude-opus-4-6", agent="general-purpose",
-                  input_t=100, output_t=50, cache_read=0, cache_create=0,
-                  skill=None, ts=None):
+    def _make_msg(
+        self,
+        model="claude-opus-4-6",
+        agent="general-purpose",
+        input_t=100,
+        output_t=50,
+        cache_read=0,
+        cache_create=0,
+        skill=None,
+        ts=None,
+    ):
         return MessageRecord(
             timestamp=ts or datetime(2026, 4, 9, 12, 0, 0, tzinfo=timezone.utc),
             model=model,
@@ -166,6 +191,7 @@ class TestSkillPassedEvent:
 
     def test_frozen(self):
         import pytest
+
         evt = SkillPassedEvent(
             skill="python",
             target_agent="code-writer",
@@ -188,6 +214,7 @@ class TestSkillInvokedEvent:
 
     def test_frozen(self):
         import pytest
+
         evt = SkillInvokedEvent(
             skill="python",
             timestamp=datetime(2026, 4, 9, tzinfo=timezone.utc),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,13 +9,19 @@ class TestDecodeProjectHash:
         assert decode_project_hash("C--Users-chris--claude") == "claude"
 
     def test_windows_path_shallow(self):
-        assert decode_project_hash("i--games-raid-rsl-rule-generator") == "games-raid-rsl-rule-generator"
+        assert (
+            decode_project_hash("i--games-raid-rsl-rule-generator")
+            == "games-raid-rsl-rule-generator"
+        )
 
     def test_single_segment(self):
         assert decode_project_hash("myproject") == "myproject"
 
     def test_three_segments(self):
-        assert decode_project_hash("C--Users-chris--code-deep-nested--project") == "project"
+        assert (
+            decode_project_hash("C--Users-chris--code-deep-nested--project")
+            == "project"
+        )
 
     def test_empty_string(self):
         assert decode_project_hash("") == ""

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -53,12 +53,12 @@ class TestResponsiveness:
         desktop view.
         """
         html = _render_html(tmp_path)
-        assert 'name="viewport"' in html, (
-            "Rendered HTML must contain a viewport meta tag."
-        )
-        assert "width=device-width" in html, (
-            "Viewport meta tag must include width=device-width."
-        )
+        assert (
+            'name="viewport"' in html
+        ), "Rendered HTML must contain a viewport meta tag."
+        assert (
+            "width=device-width" in html
+        ), "Viewport meta tag must include width=device-width."
 
     def test_gauge_grid_uses_auto_fill(self, tmp_path: Path) -> None:
         """Gauge grid must use auto-fill or responsive grid-template-columns.

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -101,9 +101,7 @@ class TestBuildSessionSummary:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/happy_path.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/happy_path.jsonl")
         entries = _parse_fixture(fixture)
         summary = build_session_summary(
             entries,
@@ -127,9 +125,7 @@ class TestBuildSessionSummary:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/happy_path.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/happy_path.jsonl")
         summary = build_session_summary(
             _parse_fixture(fixture),
             project_slug_fallback=fixture.parent.name,
@@ -149,17 +145,20 @@ class TestBuildSessionSummary:
         # Fixture with no cwd field anywhere and a non-project-hash path.
         fixture = tmp_path / "no_cwd.jsonl"
         fixture.write_text(
-            json.dumps({
-                "type": "user",
-                "message": {
-                    "role": "user",
-                    "content": "Hello with no cwd.",
-                },
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-nocwd",
-                "userType": "external",
-            }) + "\n",
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "Hello with no cwd.",
+                    },
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-nocwd",
+                    "userType": "external",
+                }
+            )
+            + "\n",
             encoding="utf-8",
         )
         # Pass None as slug_fallback to exercise the final "unknown" path.
@@ -169,7 +168,9 @@ class TestBuildSessionSummary:
         )
         assert summary.project == "unknown"
 
-    def test_intent_plain_text_user_turn(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_intent_plain_text_user_turn(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
         """A plain-text user turn returns the first sentence as intent."""
         import json
 
@@ -177,21 +178,23 @@ class TestBuildSessionSummary:
 
         fixture = tmp_path / "plain_text.jsonl"
         fixture.write_text(
-            json.dumps({
-                "type": "user",
-                "message": {
-                    "role": "user",
-                    "content": (
-                        "Implement the login feature. "
-                        "Make it work with OAuth."
-                    ),
-                },
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-plain",
-                "userType": "external",
-                "cwd": "/home/user/myproject",
-            }) + "\n",
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": (
+                            "Implement the login feature. " "Make it work with OAuth."
+                        ),
+                    },
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-plain",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }
+            )
+            + "\n",
             encoding="utf-8",
         )
         summary = build_session_summary(_parse_fixture(fixture))
@@ -211,15 +214,18 @@ class TestBuildSessionSummary:
             "Fix the parser bug in parser.py. It crashes on empty input."
         )
         fixture.write_text(
-            json.dumps({
-                "type": "user",
-                "message": {"role": "user", "content": content},
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-remind",
-                "userType": "external",
-                "cwd": "/home/user/myproject",
-            }) + "\n",
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": content},
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-remind",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }
+            )
+            + "\n",
             encoding="utf-8",
         )
         summary = build_session_summary(_parse_fixture(fixture))
@@ -231,9 +237,7 @@ class TestBuildSessionSummary:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/slash_command_only.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/slash_command_only.jsonl")
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.intent == "Ran /project-review"
 
@@ -249,15 +253,18 @@ class TestBuildSessionSummary:
 
         fixture = tmp_path / "empty_intent.jsonl"
         fixture.write_text(
-            json.dumps({
-                "type": "user",
-                "message": {"role": "user", "content": "   "},
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-empty-intent",
-                "userType": "external",
-                "cwd": "/home/user/myproject",
-            }) + "\n",
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "   "},
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-empty-intent",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }
+            )
+            + "\n",
             encoding="utf-8",
         )
         summary = build_session_summary(_parse_fixture(fixture))
@@ -282,9 +289,7 @@ class TestToolClassification:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        def _make_tool_use(
-            uid: str, name: str, path: str
-        ) -> dict:
+        def _make_tool_use(uid: str, name: str, path: str) -> dict:
             return {
                 "type": "tool_use",
                 "id": uid,
@@ -294,66 +299,83 @@ class TestToolClassification:
 
         fixture = tmp_path / "edit_tools.jsonl"
         lines = [
-            json.dumps({
-                "type": "user",
-                "message": {"role": "user", "content": "Edit three files."},
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-edit",
-                "userType": "external",
-                "cwd": "/home/user/myproject",
-            }),
-            json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [
-                        _make_tool_use("tu-001", "Edit", "src/a.py"),
-                    ],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": "tool_use",
-                    "usage": {"input_tokens": 50, "output_tokens": 10,
-                              "cache_creation_input_tokens": 0,
-                              "cache_read_input_tokens": 0},
-                },
-                "uuid": "a-001",
-                "timestamp": "2026-04-20T09:00:01.000Z",
-                "sessionId": "sess-edit",
-            }),
-            json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [
-                        _make_tool_use("tu-002", "Write", "src/b.py"),
-                    ],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": "tool_use",
-                    "usage": {"input_tokens": 50, "output_tokens": 10,
-                              "cache_creation_input_tokens": 0,
-                              "cache_read_input_tokens": 0},
-                },
-                "uuid": "a-002",
-                "timestamp": "2026-04-20T09:00:02.000Z",
-                "sessionId": "sess-edit",
-            }),
-            json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [
-                        _make_tool_use("tu-003", "NotebookEdit", "notebook.ipynb"),
-                    ],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": "end_turn",
-                    "usage": {"input_tokens": 50, "output_tokens": 10,
-                              "cache_creation_input_tokens": 0,
-                              "cache_read_input_tokens": 0},
-                },
-                "uuid": "a-003",
-                "timestamp": "2026-04-20T09:00:03.000Z",
-                "sessionId": "sess-edit",
-            }),
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Edit three files."},
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-edit",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            _make_tool_use("tu-001", "Edit", "src/a.py"),
+                        ],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "tool_use",
+                        "usage": {
+                            "input_tokens": 50,
+                            "output_tokens": 10,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                        },
+                    },
+                    "uuid": "a-001",
+                    "timestamp": "2026-04-20T09:00:01.000Z",
+                    "sessionId": "sess-edit",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            _make_tool_use("tu-002", "Write", "src/b.py"),
+                        ],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "tool_use",
+                        "usage": {
+                            "input_tokens": 50,
+                            "output_tokens": 10,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                        },
+                    },
+                    "uuid": "a-002",
+                    "timestamp": "2026-04-20T09:00:02.000Z",
+                    "sessionId": "sess-edit",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            _make_tool_use("tu-003", "NotebookEdit", "notebook.ipynb"),
+                        ],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "end_turn",
+                        "usage": {
+                            "input_tokens": 50,
+                            "output_tokens": 10,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                        },
+                    },
+                    "uuid": "a-003",
+                    "timestamp": "2026-04-20T09:00:03.000Z",
+                    "sessionId": "sess-edit",
+                }
+            ),
         ]
         fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -387,42 +409,53 @@ class TestToolClassification:
         ]
 
         lines = [
-            json.dumps({
-                "type": "user",
-                "message": {
-                    "role": "user",
-                    "content": "Look at things but do not change them.",
-                },
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-skip",
-                "userType": "external",
-                "cwd": "/home/user/myproject",
-            }),
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "Look at things but do not change them.",
+                    },
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-skip",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }
+            ),
         ]
         for i, (tool_name, inp) in enumerate(skip_tools, start=1):
-            lines.append(json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [{
-                        "type": "tool_use",
-                        "id": f"tu-{i:03d}",
-                        "name": tool_name,
-                        "input": inp,
-                    }],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": (
-                        "tool_use" if i < len(skip_tools) else "end_turn"
-                    ),
-                    "usage": {"input_tokens": 20, "output_tokens": 5,
-                              "cache_creation_input_tokens": 0,
-                              "cache_read_input_tokens": 0},
-                },
-                "uuid": f"a-{i:03d}",
-                "timestamp": f"2026-04-20T09:00:{i:02d}.000Z",
-                "sessionId": "sess-skip",
-            }))
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": f"tu-{i:03d}",
+                                    "name": tool_name,
+                                    "input": inp,
+                                }
+                            ],
+                            "model": "claude-sonnet-4-6",
+                            "stop_reason": (
+                                "tool_use" if i < len(skip_tools) else "end_turn"
+                            ),
+                            "usage": {
+                                "input_tokens": 20,
+                                "output_tokens": 5,
+                                "cache_creation_input_tokens": 0,
+                                "cache_read_input_tokens": 0,
+                            },
+                        },
+                        "uuid": f"a-{i:03d}",
+                        "timestamp": f"2026-04-20T09:00:{i:02d}.000Z",
+                        "sessionId": "sess-skip",
+                    }
+                )
+            )
 
         fixture = tmp_path / "skip_tools.jsonl"
         fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -456,86 +489,109 @@ class TestToolClassification:
         ps_cmd = "Get-ChildItem -Recurse *.py"
 
         lines = [
-            json.dumps({
-                "type": "user",
-                "message": {
-                    "role": "user",
-                    "content": "Run some bash commands.",
-                },
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-bash",
-                "userType": "external",
-                "cwd": "/home/user/myproject",
-            }),
-            json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [{
-                        "type": "tool_use",
-                        "id": "tu-001",
-                        "name": "Bash",
-                        "input": {
-                            "command": short_cmd,
-                            "description": "Run tests",
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "Run some bash commands.",
+                    },
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-bash",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "tu-001",
+                                "name": "Bash",
+                                "input": {
+                                    "command": short_cmd,
+                                    "description": "Run tests",
+                                },
+                            }
+                        ],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "tool_use",
+                        "usage": {
+                            "input_tokens": 30,
+                            "output_tokens": 10,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
                         },
-                    }],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": "tool_use",
-                    "usage": {"input_tokens": 30, "output_tokens": 10,
-                              "cache_creation_input_tokens": 0,
-                              "cache_read_input_tokens": 0},
-                },
-                "uuid": "a-001",
-                "timestamp": "2026-04-20T09:00:01.000Z",
-                "sessionId": "sess-bash",
-            }),
-            json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [{
-                        "type": "tool_use",
-                        "id": "tu-002",
-                        "name": "Bash",
-                        "input": {
-                            "command": long_cmd,
-                            "description": "Run many tests",
+                    },
+                    "uuid": "a-001",
+                    "timestamp": "2026-04-20T09:00:01.000Z",
+                    "sessionId": "sess-bash",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "tu-002",
+                                "name": "Bash",
+                                "input": {
+                                    "command": long_cmd,
+                                    "description": "Run many tests",
+                                },
+                            }
+                        ],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "tool_use",
+                        "usage": {
+                            "input_tokens": 30,
+                            "output_tokens": 10,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
                         },
-                    }],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": "tool_use",
-                    "usage": {"input_tokens": 30, "output_tokens": 10,
-                              "cache_creation_input_tokens": 0,
-                              "cache_read_input_tokens": 0},
-                },
-                "uuid": "a-002",
-                "timestamp": "2026-04-20T09:00:02.000Z",
-                "sessionId": "sess-bash",
-            }),
-            json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [{
-                        "type": "tool_use",
-                        "id": "tu-003",
-                        "name": "PowerShell",
-                        "input": {
-                            "command": ps_cmd,
+                    },
+                    "uuid": "a-002",
+                    "timestamp": "2026-04-20T09:00:02.000Z",
+                    "sessionId": "sess-bash",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "tu-003",
+                                "name": "PowerShell",
+                                "input": {
+                                    "command": ps_cmd,
+                                },
+                            }
+                        ],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "end_turn",
+                        "usage": {
+                            "input_tokens": 30,
+                            "output_tokens": 10,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
                         },
-                    }],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": "end_turn",
-                    "usage": {"input_tokens": 30, "output_tokens": 10,
-                              "cache_creation_input_tokens": 0,
-                              "cache_read_input_tokens": 0},
-                },
-                "uuid": "a-003",
-                "timestamp": "2026-04-20T09:00:03.000Z",
-                "sessionId": "sess-bash",
-            }),
+                    },
+                    "uuid": "a-003",
+                    "timestamp": "2026-04-20T09:00:03.000Z",
+                    "sessionId": "sess-bash",
+                }
+            ),
         ]
         fixture = tmp_path / "bash_tools.jsonl"
         fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -565,43 +621,55 @@ class TestToolClassification:
 
         fixture = tmp_path / "agent_dispatch.jsonl"
         fixture.write_text(
-            "\n".join([
-                json.dumps({
-                    "type": "user",
-                    "message": {
-                        "role": "user",
-                        "content": "Review the code.",
-                    },
-                    "uuid": "u-001",
-                    "timestamp": "2026-04-20T09:00:00.000Z",
-                    "sessionId": "sess-agent",
-                    "userType": "external",
-                    "cwd": "/home/user/myproject",
-                }),
-                json.dumps({
-                    "type": "assistant",
-                    "message": {
-                        "role": "assistant",
-                        "content": [{
-                            "type": "tool_use",
-                            "id": "tu-001",
-                            "name": "Agent",
-                            "input": {
-                                "subagent_type": "code-reviewer",
-                                "description": "Review session_summary.py",
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "user",
+                            "message": {
+                                "role": "user",
+                                "content": "Review the code.",
                             },
-                        }],
-                        "model": "claude-sonnet-4-6",
-                        "stop_reason": "end_turn",
-                        "usage": {"input_tokens": 40, "output_tokens": 15,
-                                  "cache_creation_input_tokens": 0,
-                                  "cache_read_input_tokens": 0},
-                    },
-                    "uuid": "a-001",
-                    "timestamp": "2026-04-20T09:00:01.000Z",
-                    "sessionId": "sess-agent",
-                }),
-            ]) + "\n",
+                            "uuid": "u-001",
+                            "timestamp": "2026-04-20T09:00:00.000Z",
+                            "sessionId": "sess-agent",
+                            "userType": "external",
+                            "cwd": "/home/user/myproject",
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {
+                                "role": "assistant",
+                                "content": [
+                                    {
+                                        "type": "tool_use",
+                                        "id": "tu-001",
+                                        "name": "Agent",
+                                        "input": {
+                                            "subagent_type": "code-reviewer",
+                                            "description": "Review session_summary.py",
+                                        },
+                                    }
+                                ],
+                                "model": "claude-sonnet-4-6",
+                                "stop_reason": "end_turn",
+                                "usage": {
+                                    "input_tokens": 40,
+                                    "output_tokens": 15,
+                                    "cache_creation_input_tokens": 0,
+                                    "cache_read_input_tokens": 0,
+                                },
+                            },
+                            "uuid": "a-001",
+                            "timestamp": "2026-04-20T09:00:01.000Z",
+                            "sessionId": "sess-agent",
+                        }
+                    ),
+                ]
+            )
+            + "\n",
             encoding="utf-8",
         )
         summary = build_session_summary(_parse_fixture(fixture))
@@ -629,15 +697,17 @@ class TestToolClassification:
             "type": "assistant",
             "message": {
                 "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-001",
-                    "name": "Agent",
-                    "input": {
-                        "subagent_type": "code-writer",
-                        "description": "Write the implementation",
-                    },
-                }],
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-001",
+                        "name": "Agent",
+                        "input": {
+                            "subagent_type": "code-writer",
+                            "description": "Write the implementation",
+                        },
+                    }
+                ],
                 "model": "claude-sonnet-4-6",
                 "stop_reason": "tool_use",
                 "usage": {
@@ -680,12 +750,14 @@ class TestToolClassification:
             "type": "assistant",
             "message": {
                 "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-001",
-                    "name": raw_name,
-                    "input": {"title": "Test issue", "body": "body"},
-                }],
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-001",
+                        "name": raw_name,
+                        "input": {"title": "Test issue", "body": "body"},
+                    }
+                ],
                 "model": "claude-sonnet-4-6",
                 "stop_reason": "tool_use",
                 "usage": {
@@ -728,12 +800,14 @@ class TestToolClassification:
             "type": "assistant",
             "message": {
                 "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-001",
-                    "name": raw_name,
-                    "input": {"container": "my-bucket"},
-                }],
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-001",
+                        "name": raw_name,
+                        "input": {"container": "my-bucket"},
+                    }
+                ],
                 "model": "claude-sonnet-4-6",
                 "stop_reason": "tool_use",
                 "usage": {
@@ -777,12 +851,14 @@ class TestToolClassification:
             "type": "assistant",
             "message": {
                 "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-001",
-                    "name": raw_name,
-                    "input": {},
-                }],
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-001",
+                        "name": raw_name,
+                        "input": {},
+                    }
+                ],
                 "model": "claude-sonnet-4-6",
                 "stop_reason": "tool_use",
                 "usage": {
@@ -822,12 +898,14 @@ class TestToolClassification:
             "type": "assistant",
             "message": {
                 "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-001",
-                    "name": "mcp__plugin_github_github__create_issue",
-                    "input": {"title": "First", "body": "b1"},
-                }],
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-001",
+                        "name": "mcp__plugin_github_github__create_issue",
+                        "input": {"title": "First", "body": "b1"},
+                    }
+                ],
                 "model": "claude-sonnet-4-6",
                 "stop_reason": "tool_use",
                 "usage": {
@@ -845,12 +923,14 @@ class TestToolClassification:
             "type": "assistant",
             "message": {
                 "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-002",
-                    "name": "mcp__github__create_issue",
-                    "input": {"title": "Second", "body": "b2"},
-                }],
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-002",
+                        "name": "mcp__github__create_issue",
+                        "input": {"title": "Second", "body": "b2"},
+                    }
+                ],
                 "model": "claude-sonnet-4-6",
                 "stop_reason": "tool_use",
                 "usage": {
@@ -878,15 +958,17 @@ class TestToolClassification:
         """
         from claude_usage.cli.session_summary import SKIPPED_TOOLS
 
-        expected = frozenset({
-            "Read",
-            "Grep",
-            "Glob",
-            "Skill",
-            "TodoWrite",
-            "WebFetch",
-            "WebSearch",
-        })
+        expected = frozenset(
+            {
+                "Read",
+                "Grep",
+                "Glob",
+                "Skill",
+                "TodoWrite",
+                "WebFetch",
+                "WebSearch",
+            }
+        )
         assert SKIPPED_TOOLS == expected
 
     def test_action_classification_skips_mix_with_edit(
@@ -913,71 +995,85 @@ class TestToolClassification:
         ]
 
         lines = [
-            json.dumps({
-                "type": "user",
-                "message": {
-                    "role": "user",
-                    "content": "Look at things, then edit one.",
-                },
-                "uuid": "u-001",
-                "timestamp": "2026-04-20T09:00:00.000Z",
-                "sessionId": "sess-mix",
-                "userType": "external",
-                "cwd": "/home/user/myproject",
-            }),
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "Look at things, then edit one.",
+                    },
+                    "uuid": "u-001",
+                    "timestamp": "2026-04-20T09:00:00.000Z",
+                    "sessionId": "sess-mix",
+                    "userType": "external",
+                    "cwd": "/home/user/myproject",
+                }
+            ),
         ]
         for i, (tool_name, inp) in enumerate(skip_tools, start=1):
-            lines.append(json.dumps({
-                "type": "assistant",
-                "message": {
-                    "role": "assistant",
-                    "content": [{
-                        "type": "tool_use",
-                        "id": f"tu-{i:03d}",
-                        "name": tool_name,
-                        "input": inp,
-                    }],
-                    "model": "claude-sonnet-4-6",
-                    "stop_reason": "tool_use",
-                    "usage": {
-                        "input_tokens": 20,
-                        "output_tokens": 5,
-                        "cache_creation_input_tokens": 0,
-                        "cache_read_input_tokens": 0,
-                    },
-                },
-                "uuid": f"a-{i:03d}",
-                "timestamp": f"2026-04-20T09:00:{i:02d}.000Z",
-                "sessionId": "sess-mix",
-            }))
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": f"tu-{i:03d}",
+                                    "name": tool_name,
+                                    "input": inp,
+                                }
+                            ],
+                            "model": "claude-sonnet-4-6",
+                            "stop_reason": "tool_use",
+                            "usage": {
+                                "input_tokens": 20,
+                                "output_tokens": 5,
+                                "cache_creation_input_tokens": 0,
+                                "cache_read_input_tokens": 0,
+                            },
+                        },
+                        "uuid": f"a-{i:03d}",
+                        "timestamp": f"2026-04-20T09:00:{i:02d}.000Z",
+                        "sessionId": "sess-mix",
+                    }
+                )
+            )
         # One Edit at the end — must survive into the action list.
-        lines.append(json.dumps({
-            "type": "assistant",
-            "message": {
-                "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-008",
-                    "name": "Edit",
-                    "input": {
-                        "file_path": "src/result.py",
-                        "old_string": "x",
-                        "new_string": "y",
+        lines.append(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "tu-008",
+                                "name": "Edit",
+                                "input": {
+                                    "file_path": "src/result.py",
+                                    "old_string": "x",
+                                    "new_string": "y",
+                                },
+                            }
+                        ],
+                        "model": "claude-sonnet-4-6",
+                        "stop_reason": "end_turn",
+                        "usage": {
+                            "input_tokens": 20,
+                            "output_tokens": 5,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                        },
                     },
-                }],
-                "model": "claude-sonnet-4-6",
-                "stop_reason": "end_turn",
-                "usage": {
-                    "input_tokens": 20,
-                    "output_tokens": 5,
-                    "cache_creation_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
-                },
-            },
-            "uuid": "a-008",
-            "timestamp": "2026-04-20T09:00:08.000Z",
-            "sessionId": "sess-mix",
-        }))
+                    "uuid": "a-008",
+                    "timestamp": "2026-04-20T09:00:08.000Z",
+                    "sessionId": "sess-mix",
+                }
+            )
+        )
 
         fixture = tmp_path / "skip_mix.jsonl"
         fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -1008,12 +1104,14 @@ class TestToolClassification:
             "type": "assistant",
             "message": {
                 "role": "assistant",
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-001",
-                    "name": "BrandNewTool",
-                    "input": {"some_param": "some_value"},
-                }],
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-001",
+                        "name": "BrandNewTool",
+                        "input": {"some_param": "some_value"},
+                    }
+                ],
                 "model": "claude-sonnet-4-6",
                 "stop_reason": "tool_use",
                 "usage": {
@@ -1054,8 +1152,7 @@ class TestCollapseConsecutive:
         from claude_usage.cli.session_summary import build_session_summary
 
         fixture = Path(
-            "tests/fixtures/session_summaries/"
-            "consecutive_edits_same_file.jsonl"
+            "tests/fixtures/session_summaries/" "consecutive_edits_same_file.jsonl"
         )
         summary = build_session_summary(_parse_fixture(fixture))
 
@@ -1081,20 +1178,20 @@ class TestCollapseConsecutive:
                 "type": "assistant",
                 "message": {
                     "role": "assistant",
-                    "content": [{
-                        "type": "tool_use",
-                        "id": f"tu-{seq:03d}",
-                        "name": "Edit",
-                        "input": {
-                            "file_path": file_path,
-                            "old_string": f"old{seq}",
-                            "new_string": f"new{seq}",
-                        },
-                    }],
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"tu-{seq:03d}",
+                            "name": "Edit",
+                            "input": {
+                                "file_path": file_path,
+                                "old_string": f"old{seq}",
+                                "new_string": f"new{seq}",
+                            },
+                        }
+                    ],
                     "model": "claude-sonnet-4-6",
-                    "stop_reason": (
-                        "end_turn" if seq == 3 else "tool_use"
-                    ),
+                    "stop_reason": ("end_turn" if seq == 3 else "tool_use"),
                     "usage": {
                         "input_tokens": 30,
                         "output_tokens": 10,
@@ -1147,9 +1244,7 @@ class TestStoppedNaturally:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/happy_path.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/happy_path.jsonl")
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.stopped_naturally is True
 
@@ -1159,9 +1254,7 @@ class TestStoppedNaturally:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/max_tokens_stop.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/max_tokens_stop.jsonl")
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.stopped_naturally is False
 
@@ -1171,9 +1264,7 @@ class TestStoppedNaturally:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/prevented_continuation.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/prevented_continuation.jsonl")
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.stopped_naturally is False
 
@@ -1183,9 +1274,7 @@ class TestStoppedNaturally:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/no_assistant_entries.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/no_assistant_entries.jsonl")
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.stopped_naturally is None
 
@@ -1195,9 +1284,7 @@ class TestStoppedNaturally:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/missing_stop_reason.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/missing_stop_reason.jsonl")
         summary = build_session_summary(_parse_fixture(fixture))
         assert summary.stopped_naturally is None
 
@@ -1215,9 +1302,7 @@ class TestMaxActionsCap:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/over_fifty_actions.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/over_fifty_actions.jsonl")
         # Default max_actions == 50.
         summary = build_session_summary(_parse_fixture(fixture))
 
@@ -1231,9 +1316,7 @@ class TestMaxActionsCap:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/over_fifty_actions.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/over_fifty_actions.jsonl")
         summary = build_session_summary(_parse_fixture(fixture), max_actions=5)
 
         assert len(summary.actions) == 5
@@ -1249,16 +1332,12 @@ class TestMaxActionsCap:
 
         from claude_usage.cli.session_summary import build_session_summary
 
-        fixture = Path(
-            "tests/fixtures/session_summaries/over_fifty_actions.jsonl"
-        )
+        fixture = Path("tests/fixtures/session_summaries/over_fifty_actions.jsonl")
         summary = build_session_summary(_parse_fixture(fixture), max_actions=0)
 
         assert len(summary.actions) == 55
         # No sentinel — every element is a real action string.
-        assert not any(
-            a.startswith("… (") for a in summary.actions
-        )
+        assert not any(a.startswith("… (") for a in summary.actions)
 
 
 class TestExitNoUserTurns:
@@ -1267,14 +1346,16 @@ class TestExitNoUserTurns:
     def test_empty_session_exits_2(self) -> None:
         """Agent-setting / system-only transcript → exit 2."""
         fixture = (
-            _Path("tests/fixtures/session_summaries")
-            / "empty_no_user_turns.jsonl"
+            _Path("tests/fixtures/session_summaries") / "empty_no_user_turns.jsonl"
         )
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(fixture),
+                "--path",
+                str(fixture),
             ],
             capture_output=True,
             text=True,
@@ -1289,9 +1370,12 @@ class TestExitNoUserTurns:
         zero_byte.write_text("")
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(zero_byte),
+                "--path",
+                str(zero_byte),
             ],
             capture_output=True,
             text=True,
@@ -1308,9 +1392,12 @@ class TestExitNoUserTurns:
         ws_only.write_text("\n   \n\t\n")
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(ws_only),
+                "--path",
+                str(ws_only),
             ],
             capture_output=True,
             text=True,
@@ -1331,15 +1418,16 @@ class TestExitNotJsonl:
         """
         malformed = tmp_path / "all_malformed.jsonl"
         malformed.write_text(
-            "this is not json\n"
-            "{also not json\n"
-            "definitely: not: json: either\n"
+            "this is not json\n" "{also not json\n" "definitely: not: json: either\n"
         )
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(malformed),
+                "--path",
+                str(malformed),
             ],
             capture_output=True,
             text=True,
@@ -1357,9 +1445,12 @@ class TestExitNotJsonl:
         empty.write_text("")
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(empty),
+                "--path",
+                str(empty),
             ],
             capture_output=True,
             text=True,
@@ -1382,9 +1473,12 @@ class TestErrorPaths:
         nonexistent = tmp_path / "nonexistent.jsonl"
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(nonexistent),
+                "--path",
+                str(nonexistent),
             ],
             capture_output=True,
             text=True,
@@ -1416,18 +1510,19 @@ class TestStdoutStderrDiscipline:
         nonexistent = tmp_path / "missing.jsonl"
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(nonexistent),
+                "--path",
+                str(nonexistent),
             ],
             capture_output=True,
             text=True,
         )
         assert result.stdout == ""
         # stderr must be exactly one non-empty line
-        stderr_lines = [
-            ln for ln in result.stderr.splitlines() if ln.strip()
-        ]
+        stderr_lines = [ln for ln in result.stderr.splitlines() if ln.strip()]
         assert len(stderr_lines) == 1
 
     def test_stdout_on_success_is_pure_json(self) -> None:
@@ -1439,15 +1534,17 @@ class TestStdoutStderrDiscipline:
             no progress banners, no leading whitespace).
           - All four contract keys are present.
         """
-        fixture = (
-            _Path("tests/fixtures/session_summaries") / "happy_path.jsonl"
-        )
+        fixture = _Path("tests/fixtures/session_summaries") / "happy_path.jsonl"
         result = subprocess.run(
             [
-                sys.executable, "-m", "claude_usage",
+                sys.executable,
+                "-m",
+                "claude_usage",
                 "session-summary",
-                "--path", str(fixture),
-                "--format", "json",
+                "--path",
+                str(fixture),
+                "--format",
+                "json",
             ],
             capture_output=True,
             text=True,
@@ -1456,7 +1553,10 @@ class TestStdoutStderrDiscipline:
         # Must parse cleanly — no leading/trailing non-JSON text
         parsed = _json.loads(result.stdout)
         assert set(parsed.keys()) >= {
-            "project", "intent", "actions", "stoppedNaturally"
+            "project",
+            "intent",
+            "actions",
+            "stoppedNaturally",
         }
         # Exactly one trailing newline — the JSON document ends cleanly
         assert result.stdout.endswith("\n")
@@ -1499,9 +1599,7 @@ class TestRenderJson:
         summary = self._make_summary()
         output = render_json(summary)
         for line in output.splitlines():
-            assert line == line.rstrip(), (
-                f"Trailing whitespace on line: {line!r}"
-            )
+            assert line == line.rstrip(), f"Trailing whitespace on line: {line!r}"
 
     def test_render_json_handles_tri_state_true(self) -> None:
         """stopped_naturally=True → JSON literal ``true``."""
@@ -1536,8 +1634,7 @@ class TestRenderText:
         return SessionSummary(
             project="my-project",
             intent="Build something useful",
-            actions=actions if actions is not None
-                else ["Edited foo.py", "Ran pytest"],
+            actions=actions if actions is not None else ["Edited foo.py", "Ran pytest"],
             stopped_naturally=stopped_naturally,
         )
 

--- a/tests/test_skill_tracking.py
+++ b/tests/test_skill_tracking.py
@@ -20,12 +20,17 @@ class TestParseSkillTracking:
 
     def test_parses_skill_invoked_event(self, tmp_path: Path):
         log = tmp_path / "skill-tracking.jsonl"
-        log.write_text(json.dumps({
-            "event": "skill_invoked",
-            "skill": "python",
-            "timestamp": "2026-04-09T21:00:00Z",
-            "session_id": "sess-001",
-        }) + "\n")
+        log.write_text(
+            json.dumps(
+                {
+                    "event": "skill_invoked",
+                    "skill": "python",
+                    "timestamp": "2026-04-09T21:00:00Z",
+                    "session_id": "sess-001",
+                }
+            )
+            + "\n"
+        )
         passed, invoked = parse_skill_tracking(tmp_path)
         assert len(passed) == 0
         assert len(invoked) == 1
@@ -34,13 +39,18 @@ class TestParseSkillTracking:
 
     def test_parses_skill_passed_event(self, tmp_path: Path):
         log = tmp_path / "skill-tracking.jsonl"
-        log.write_text(json.dumps({
-            "event": "skill_passed",
-            "skill": "superpowers:test-driven-development",
-            "target_agent": "code-writer",
-            "timestamp": "2026-04-09T21:00:00Z",
-            "session_id": "sess-001",
-        }) + "\n")
+        log.write_text(
+            json.dumps(
+                {
+                    "event": "skill_passed",
+                    "skill": "superpowers:test-driven-development",
+                    "target_agent": "code-writer",
+                    "timestamp": "2026-04-09T21:00:00Z",
+                    "session_id": "sess-001",
+                }
+            )
+            + "\n"
+        )
         passed, invoked = parse_skill_tracking(tmp_path)
         assert len(passed) == 1
         assert passed[0].skill == "superpowers:test-driven-development"
@@ -50,9 +60,32 @@ class TestParseSkillTracking:
     def test_parses_mixed_events(self, tmp_path: Path):
         log = tmp_path / "skill-tracking.jsonl"
         lines = [
-            json.dumps({"event": "skill_passed", "skill": "python", "target_agent": "code-writer", "timestamp": "2026-04-09T21:00:00Z", "session_id": "s1"}),
-            json.dumps({"event": "skill_invoked", "skill": "python", "timestamp": "2026-04-09T21:01:00Z", "session_id": "s1"}),
-            json.dumps({"event": "skill_passed", "skill": "powershell", "target_agent": "debugger", "timestamp": "2026-04-09T21:02:00Z", "session_id": "s1"}),
+            json.dumps(
+                {
+                    "event": "skill_passed",
+                    "skill": "python",
+                    "target_agent": "code-writer",
+                    "timestamp": "2026-04-09T21:00:00Z",
+                    "session_id": "s1",
+                }
+            ),
+            json.dumps(
+                {
+                    "event": "skill_invoked",
+                    "skill": "python",
+                    "timestamp": "2026-04-09T21:01:00Z",
+                    "session_id": "s1",
+                }
+            ),
+            json.dumps(
+                {
+                    "event": "skill_passed",
+                    "skill": "powershell",
+                    "target_agent": "debugger",
+                    "timestamp": "2026-04-09T21:02:00Z",
+                    "session_id": "s1",
+                }
+            ),
         ]
         log.write_text("\n".join(lines) + "\n")
         passed, invoked = parse_skill_tracking(tmp_path)
@@ -63,7 +96,14 @@ class TestParseSkillTracking:
         log = tmp_path / "skill-tracking.jsonl"
         lines = [
             "not valid json",
-            json.dumps({"event": "skill_invoked", "skill": "python", "timestamp": "2026-04-09T21:00:00Z", "session_id": "s1"}),
+            json.dumps(
+                {
+                    "event": "skill_invoked",
+                    "skill": "python",
+                    "timestamp": "2026-04-09T21:00:00Z",
+                    "session_id": "s1",
+                }
+            ),
             json.dumps({"event": "unknown_event", "skill": "x"}),
         ]
         log.write_text("\n".join(lines) + "\n")
@@ -75,9 +115,12 @@ class TestParseSkillTracking:
 class TestExtractSkillsFromPrompt:
     def setup_method(self):
         self.allowlist = {
-            "python", "powershell", "git",
+            "python",
+            "powershell",
+            "git",
             "superpowers:test-driven-development",
-            "superpowers:brainstorming", "commit-commands:commit",
+            "superpowers:brainstorming",
+            "commit-commands:commit",
         }
 
     def test_backtick_quoted_skill(self):
@@ -102,8 +145,7 @@ class TestExtractSkillsFromPrompt:
 
     def test_multiple_skills_in_prompt(self):
         prompt = (
-            "Use the `python` skill and invoke "
-            "`superpowers:brainstorming` first."
+            "Use the `python` skill and invoke " "`superpowers:brainstorming` first."
         )
         result = extract_skills_from_prompt(prompt, self.allowlist)
         assert result == ["python", "superpowers:brainstorming"]
@@ -144,9 +186,7 @@ class TestExtractSkillsFromPrompt:
     def test_namespaced_backtick_always_accepted(self):
         """Namespaced skills in backticks need no 'skill' word nearby —
         the colon makes them unambiguous."""
-        prompt = (
-            "Use `superpowers:test-driven-development` before coding"
-        )
+        prompt = "Use `superpowers:test-driven-development` before coding"
         result = extract_skills_from_prompt(prompt, self.allowlist)
         assert result == ["superpowers:test-driven-development"]
 
@@ -189,7 +229,15 @@ class TestBuildSkillAllowlist:
         assert "powershell" in result
 
     def test_reads_plugin_skills_with_prefix(self, tmp_path: Path):
-        plugin_skills = tmp_path / "plugins" / "cache" / "official" / "superpowers" / "5.0.7" / "skills"
+        plugin_skills = (
+            tmp_path
+            / "plugins"
+            / "cache"
+            / "official"
+            / "superpowers"
+            / "5.0.7"
+            / "skills"
+        )
         (plugin_skills / "brainstorming").mkdir(parents=True)
         (plugin_skills / "test-driven-development").mkdir(parents=True)
         result = build_skill_allowlist(tmp_path)

--- a/tests/test_skill_tracking.py
+++ b/tests/test_skill_tracking.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
-
-from claude_usage.models import SkillInvokedEvent, SkillPassedEvent
 from claude_usage.skill_tracking import (
     parse_skill_tracking,
     extract_skills_from_prompt,

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "claude-usage"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -14,13 +14,15 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "~=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.6.0" },
 ]
 provides-extras = ["dev"]
 
@@ -180,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -191,9 +193,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -258,6 +260,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.6.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/0d/6148a48dab5662ca1d5a93b7c0d13c03abd3cc7e2f35db08410e47cef15d/ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2", size = 3095355, upload-time = "2024-10-04T13:40:28.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/8f/f7a0a0ef1818662efb32ed6df16078c95da7a0a3248d64c2410c1e27799f/ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd", size = 10440526, upload-time = "2024-10-04T13:39:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/69/b179a5faf936a9e2ab45bb412a668e4661eded964ccfa19d533f29463ef6/ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec", size = 10034612, upload-time = "2024-10-04T13:39:26.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/fd1b4be979c579d191eeac37b5cfc0ec906de72c8bcd8595e2c81bb700c1/ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c", size = 9706197, upload-time = "2024-10-04T13:39:29.297Z" },
+    { url = "https://files.pythonhosted.org/packages/29/61/b376d775deb5851cb48d893c568b511a6d3625ef2c129ad5698b64fb523c/ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e", size = 10751855, upload-time = "2024-10-04T13:39:33.175Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d7/def9e5f446d75b9a9c19b24231a3a658c075d79163b08582e56fa5dcfa38/ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577", size = 10200889, upload-time = "2024-10-04T13:39:36.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d6/7f34160818bcb6e84ce293a5966cba368d9112ff0289b273fbb689046047/ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829", size = 11038678, upload-time = "2024-10-04T13:39:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/13/34/a40ff8ae62fb1b26fb8e6fa7e64bc0e0a834b47317880de22edd6bfb54fb/ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5", size = 11808682, upload-time = "2024-10-04T13:39:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6d/25a4386ae4009fc798bd10ba48c942d1b0b3e459b5403028f1214b6dd161/ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7", size = 11330446, upload-time = "2024-10-04T13:39:55.783Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/f6/bdf891a9200d692c94ebcd06ae5a2fa5894e522f2c66c2a12dd5d8cb2654/ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f", size = 12483048, upload-time = "2024-10-04T13:39:58.845Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/86/96f4252f41840e325b3fa6c48297e661abb9f564bd7dcc0572398c8daa42/ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa", size = 10936855, upload-time = "2024-10-04T13:40:01.818Z" },
+    { url = "https://files.pythonhosted.org/packages/45/87/801a52d26c8dbf73424238e9908b9ceac430d903c8ef35eab1b44fcfa2bd/ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb", size = 10713007, upload-time = "2024-10-04T13:40:05.384Z" },
+    { url = "https://files.pythonhosted.org/packages/be/27/6f7161d90320a389695e32b6ebdbfbedde28ccbf52451e4b723d7ce744ad/ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0", size = 10274594, upload-time = "2024-10-04T13:40:08.801Z" },
+    { url = "https://files.pythonhosted.org/packages/00/52/dc311775e7b5f5b19831563cb1572ecce63e62681bccc609867711fae317/ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625", size = 10608024, upload-time = "2024-10-04T13:40:11.923Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b6/be0a1ddcbac65a30c985cf7224c4fce786ba2c51e7efeb5178fe410ed3cf/ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039", size = 10982085, upload-time = "2024-10-04T13:40:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a4/c84bc13d0b573cf7bb7d17b16d6d29f84267c92d79b2f478d4ce322e8e72/ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d", size = 8522088, upload-time = "2024-10-04T13:40:19.168Z" },
+    { url = "https://files.pythonhosted.org/packages/74/be/fc352bd8ca40daae8740b54c1c3e905a7efe470d420a268cd62150248c91/ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117", size = 9359275, upload-time = "2024-10-04T13:40:22.852Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/14/fd026bc74ded05e2351681545a5f626e78ef831f8edce064d61acd2e6ec7/ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93", size = 8679879, upload-time = "2024-10-04T13:40:25.797Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #32

## Summary

Wires up GitHub Actions CI for the project. After this lands, every PR and push to `main` runs ruff (lint + format check) and pytest on Ubuntu + Windows.

## Changes (5 commits)

| Commit | Phase | What |
|---|---|---|
| `de68f01` | 1 | Add `[project.optional-dependencies].dev = ["ruff~=0.6.0", "pytest~=8.0"]` to `pyproject.toml` (compatible-release pins) |
| `6b63ea9` | 2 | Fix 10 pre-existing ruff errors — 8 × F401 unused imports across `claude_usage/skill_tracking.py` + tests; 2 × E741 (`l` → `rec`) in `tests/test_e2e.py` |
| `64bfa83` | 3 | Mechanical `ruff format .` sweep — 17 files reformatted, no logic changes |
| `0c4f824` | 4 | Add `.github/workflows/ci.yml` — separate `lint` (Ubuntu) + `test` (Ubuntu × Windows matrix) jobs, Python 3.10, `astral-sh/setup-uv@v5` with caching |
| `e746860` | 5 | Expand README "Development" section with install / test / lint / CI commands |

## Why separate lint and test jobs

Splitting them into two top-level jobs (rather than sequential steps) means the GitHub PR UI shows distinct check entries — a lint failure is visually distinct from a test failure at a glance, and you can re-run them independently.

## Pinning strategy

`~=0.6.0` (compatible-release) for both ruff and pytest — patch-level fixes float, minor-release rule additions require a deliberate bump. Avoids "CI went red overnight" while still picking up bug fixes.

## Verification

All three gates pass locally on `feature/ci`:
- `ruff check .` — clean
- `ruff format --check .` — clean
- `pytest` — 151 passed in ~3.5s

## Post-merge manual step

Branch protection on `main` needs to be configured by hand in GitHub settings to require these checks:
- `Lint`
- `Test (ubuntu-latest)`
- `Test (windows-latest)`

(Can't be done from this PR — repo settings only.)

## Out of scope

`mypy`/`pyright` typecheck, coverage reporting, pre-commit hooks, Python 3.11/3.12 matrix expansion. Each can be a follow-up issue if desired.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*