### PR TITLE
chore: expand .gitignore for .claude/, tooling caches, coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,15 @@ Thumbs.db
 # Generated reports
 *.html
 !templates/*.html
+
+# Claude Code
+.claude/
+
+# Test & lint caches
+.pytest_cache/
+.ruff_cache/
+
+# Coverage
+.coverage
+htmlcov/
+coverage.xml


### PR DESCRIPTION
Closes #24

## Summary

Adds three labeled sections to `.gitignore` so contributors don't see noise in `git status`:

- **Claude Code** — `.claude/` (per-developer `settings.local.json` should never be committed; currently surfaces as untracked on a clean `main` checkout).
- **Test & lint caches** — `.pytest_cache/`, `.ruff_cache/` (only stayed quiet for the current maintainer because of a global `core.excludesfile`; other contributors would see them).
- **Coverage** — `.coverage`, `htmlcov/`, `coverage.xml` (defensive — harmless if coverage tooling is never run).

## Why

Each new contributor running `git status` after a Claude Code session or a test run should see a clean working tree. The repo-local `.gitignore` is the right place — global excludes are per-machine and don't ship with the repo.

## Acceptance criteria (from #24)

- [x] `.gitignore` ignores `.claude/`
- [x] `.gitignore` ignores `.pytest_cache/` and `.ruff_cache/`
- [x] `.gitignore` ignores `.coverage`, `htmlcov/`, `coverage.xml`
- [x] `git status` on a clean checkout reports a clean working tree
- [x] `uv.lock` remains tracked (verified — not in diff)

## Verification

Ran the same commands CI runs, against the pinned ruff (`~=0.6.0`):

- `ruff check .` — clean
- `ruff format --check .` — clean (24 files already formatted)
- `pytest` — 151 passed

## Out of scope

- Removing `uv.lock` or any tracked file
- `.mypy_cache/` (mypy not in use)
- Global git config changes

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*