### PR TITLE
fix(parser): scan first N lines for agent-setting; fallback to general-purpose when subagents/ exists

### DIFF
--- a/claude_usage/parser.py
+++ b/claude_usage/parser.py
@@ -86,28 +86,56 @@ def _parse_jsonl_messages(jsonl_path: Path, agent_type: str) -> list[MessageReco
     return messages
 
 
+_AGENT_SETTING_SCAN_LINES = 5
+
+
 def _parse_session(jsonl_path: Path, project_name: str) -> SessionRecord | None:
-    """Parse a single session JSONL file and its subagents."""
+    """Parse a single session JSONL file and its subagents.
+
+    Agent-setting resolution uses a three-branch strategy to handle recent
+    Claude Code versions that prepend a ``last-prompt`` line before the
+    ``agent-setting`` line:
+
+    1. **Bounded scan**: read the first ``_AGENT_SETTING_SCAN_LINES`` lines;
+       use the ``agentSetting`` value from the first ``agent-setting`` entry.
+    2. **Subagents fallback**: if no ``agent-setting`` was found and the
+       ``<session_id>/subagents/`` directory exists (only the router spawns
+       sub-agents, implying general-purpose), set ``root_agent`` to
+       ``"general-purpose"``.
+    3. **Unknown preserved**: otherwise leave ``root_agent`` as ``"unknown"``.
+    """
     session_id = jsonl_path.stem
 
-    # Read agent-setting from first line
+    # Resolve the subagent directory early — needed for the fallback branch.
+    subagent_dir = jsonl_path.parent / session_id / "subagents"
+
+    # Branch 1: bounded scan for agent-setting in the first N lines.
     root_agent = "unknown"
     with open(jsonl_path, "r", encoding="utf-8") as f:
-        first_line = f.readline().strip()
-        if first_line:
+        for _ in range(_AGENT_SETTING_SCAN_LINES):
+            raw = f.readline()
+            if not raw:
+                break
+            line = raw.strip()
+            if not line:
+                continue
             try:
-                first = json.loads(first_line)
-                if first.get("type") == "agent-setting":
-                    root_agent = first.get("agentSetting", "unknown")
+                entry = json.loads(line)
             except json.JSONDecodeError:
-                pass
+                continue
+            if entry.get("type") == "agent-setting":
+                root_agent = entry.get("agentSetting", "unknown")
+                break
+
+    # Branch 2: subagents-directory fallback when no agent-setting found.
+    if root_agent == "unknown" and subagent_dir.is_dir():
+        root_agent = "general-purpose"
 
     # Parse parent session messages
     messages = _parse_jsonl_messages(jsonl_path, root_agent)
 
     # Parse subagent messages
     subagent_types: list[str] = []
-    subagent_dir = jsonl_path.parent / session_id / "subagents"
     if subagent_dir.is_dir():
         for meta_path in subagent_dir.glob("*.meta.json"):
             try:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,8 @@
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-from claude_usage.parser import decode_project_hash, parse_sessions
+from claude_usage.parser import decode_project_hash, parse_sessions, _parse_session
 
 
 class TestDecodeProjectHash:
@@ -86,3 +87,156 @@ class TestParseSessions:
     def test_no_projects_dir(self, tmp_path: Path):
         sessions = parse_sessions(tmp_path)
         assert sessions == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers for agent-setting resolution tests
+# ---------------------------------------------------------------------------
+
+
+def _make_assistant_line(session_id: str) -> dict:
+    """Return a minimal assistant message dict for JSONL."""
+    return {
+        "type": "assistant",
+        "timestamp": "2026-04-09T12:00:05.000Z",
+        "sessionId": session_id,
+        "message": {
+            "model": "claude-opus-4-6",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            },
+        },
+    }
+
+
+def _make_agent_setting_line(session_id: str, value: str) -> dict:
+    """Return an agent-setting dict for JSONL."""
+    return {
+        "type": "agent-setting",
+        "agentSetting": value,
+        "sessionId": session_id,
+    }
+
+
+def _make_last_prompt_line(session_id: str) -> dict:
+    """Return a last-prompt dict (prepended by recent Claude Code versions)."""
+    return {
+        "type": "last-prompt",
+        "sessionId": session_id,
+        "content": "some prior prompt text",
+    }
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    """Write a list of dicts as JSONL to *path*."""
+    path.write_text(
+        "\n".join(json.dumps(line) for line in lines),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestAgentSettingResolution
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSettingResolution:
+    """Tests for the bounded agent-setting scan in _parse_session."""
+
+    def test_agent_setting_on_line_0(self, tmp_path: Path):
+        """agent-setting on the first line resolves root_agent correctly."""
+        session_id = "sess-line0"
+        project_dir = tmp_path / "projects" / "proj"
+        project_dir.mkdir(parents=True)
+        jsonl = project_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                _make_agent_setting_line(session_id, "general-purpose"),
+                _make_assistant_line(session_id),
+            ],
+        )
+
+        session = _parse_session(jsonl, "proj")
+        assert session is not None
+        assert session.root_agent == "general-purpose"
+
+    def test_agent_setting_on_line_1_after_last_prompt(self, tmp_path: Path):
+        """agent-setting on line 1 (after last-prompt) is found by bounded scan."""
+        session_id = "sess-line1"
+        project_dir = tmp_path / "projects" / "proj"
+        project_dir.mkdir(parents=True)
+        jsonl = project_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                _make_last_prompt_line(session_id),
+                _make_agent_setting_line(session_id, "general-purpose"),
+                _make_assistant_line(session_id),
+            ],
+        )
+
+        session = _parse_session(jsonl, "proj")
+        assert session is not None
+        assert session.root_agent == "general-purpose"
+
+    def test_no_agent_setting_with_subagents_dir(self, tmp_path: Path):
+        """No agent-setting in first 5 lines + subagents/ dir → general-purpose."""
+        session_id = "sess-subagents"
+        project_dir = tmp_path / "projects" / "proj"
+        project_dir.mkdir(parents=True)
+        jsonl = project_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                _make_assistant_line(session_id),
+            ],
+        )
+        # Create the subagents directory (no metadata files needed)
+        (project_dir / session_id / "subagents").mkdir(parents=True)
+
+        session = _parse_session(jsonl, "proj")
+        assert session is not None
+        assert session.root_agent == "general-purpose"
+
+    def test_no_agent_setting_no_subagents_dir(self, tmp_path: Path):
+        """No agent-setting in first 5 lines + no subagents/ dir → unknown."""
+        session_id = "sess-unknown"
+        project_dir = tmp_path / "projects" / "proj"
+        project_dir.mkdir(parents=True)
+        jsonl = project_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                _make_assistant_line(session_id),
+            ],
+        )
+
+        session = _parse_session(jsonl, "proj")
+        assert session is not None
+        assert session.root_agent == "unknown"
+
+    def test_malformed_json_in_first_5_lines_does_not_crash(self, tmp_path: Path):
+        """Malformed JSON lines in the scan window are skipped; scan continues."""
+        session_id = "sess-malformed"
+        project_dir = tmp_path / "projects" / "proj"
+        project_dir.mkdir(parents=True)
+        jsonl = project_dir / f"{session_id}.jsonl"
+        # Write raw text: line 0 bad JSON, line 1 valid agent-setting
+        content = (
+            "this is not json\n"
+            + json.dumps(_make_agent_setting_line(session_id, "ops"))
+            + "\n"
+            + json.dumps(_make_assistant_line(session_id))
+            + "\n"
+        )
+        jsonl.write_text(content, encoding="utf-8")
+
+        session = _parse_session(jsonl, "proj")
+        assert session is not None
+        assert session.root_agent == "ops"


### PR DESCRIPTION
## Problem

Recent Claude Code versions prepend a `last-prompt` line before `agent-setting` in session JSONL files. The previous parser read only the first line, so any session where `agent-setting` appeared on line 1 (instead of line 0) fell through to `root_agent = "unknown"`. This mis-bucketed ~35% of recent sessions (1.59B tokens / 40 sessions in a 7-day window).

## Solution

Replace the single-line read with a three-branch resolution in `_parse_session()`:

1. **Bounded scan** — read the first 5 lines; use `agentSetting` from the first `agent-setting` entry found. Malformed JSON lines are silently skipped so the scan continues to the next line.
2. **Subagents fallback** — if no `agent-setting` was found AND the `<session_id>/subagents/` directory exists (only the router spawns sub-agents, implying general-purpose), set `root_agent = "general-purpose"`.
3. **Unknown preserved** — otherwise leave `root_agent = "unknown"`.

The `subagent_dir` path is now computed once at the top of the function and reused by both the fallback branch and the existing subagent-parsing block, eliminating a duplicate path construction.

## Tests

Added 5 new tests in `tests/test_parser.py` covering all three branches plus a regression guard for malformed-JSON-before-valid-agent-setting. Full suite: 151 → 156 tests, all passing.

- `test_agent_setting_on_line_0` — existing behavior preserved
- `test_agent_setting_on_line_1_after_last_prompt` — the primary bug case
- `test_no_agent_setting_with_subagents_dir` — subagents fallback
- `test_no_agent_setting_no_subagents_dir` — unknown preserved
- `test_malformed_json_in_first_5_lines_does_not_crash` — resilience guard

## Verification

```
ruff check claude_usage tests   → All checks passed
ruff format --check ...         → 24 files already formatted
pytest tests/                   → 156 passed
```

Closes #37
Closes #36

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_