### PR TITLE
refactor(constants): extract AGENT_PATH_SEPARATOR to shared module

### DIFF
--- a/claude_usage/aggregator.py
+++ b/claude_usage/aggregator.py
@@ -6,6 +6,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
+from claude_usage.constants import AGENT_PATH_SEPARATOR as _AGENT_PATH_SEPARATOR
 from claude_usage.models import (
     MessageRecord,
     SessionRecord,
@@ -14,9 +15,10 @@ from claude_usage.models import (
 )
 
 #: Delimiter joining agent_path segments into a by_agent key string.
-#: U+2192 RIGHTWARDS ARROW — round-trips through json.dumps as the
-#: JSON Unicode escape ``→`` (decoded by JSON.parse client-side).
-AGENT_PATH_SEPARATOR = "→"
+#: Sourced from :mod:`claude_usage.constants`; re-exported here so
+#: existing callers that import this name from ``aggregator`` continue
+#: to work unchanged.
+AGENT_PATH_SEPARATOR: str = _AGENT_PATH_SEPARATOR
 
 
 def _path_key(msg: MessageRecord) -> str:

--- a/claude_usage/constants.py
+++ b/claude_usage/constants.py
@@ -1,0 +1,17 @@
+"""Shared constants for the claude_usage package.
+
+Centralises values that must be identical across multiple modules so
+there is a single source of truth for each.
+"""
+
+from __future__ import annotations
+
+#: Delimiter joining agent_path segments into a by_agent key string.
+#: U+2192 RIGHTWARDS ARROW — round-trips through json.dumps as the
+#: JSON Unicode escape ``→`` (decoded by JSON.parse client-side).
+AGENT_PATH_SEPARATOR: str = "→"
+
+#: Replacement character used when an agent name contains the path
+#: separator.  U+FE56 SMALL QUESTION MARK — visually distinct and will
+#: not collide with normal agent names.
+SANITIZED_SEPARATOR_REPLACEMENT: str = "﹖"

--- a/claude_usage/parser.py
+++ b/claude_usage/parser.py
@@ -7,10 +7,13 @@ import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 
+from claude_usage.constants import (
+    AGENT_PATH_SEPARATOR as _PATH_SEPARATOR,
+    SANITIZED_SEPARATOR_REPLACEMENT as _SANITIZED_SEPARATOR_REPLACEMENT,
+)
 from claude_usage.models import MessageRecord, SessionRecord
 
 _MAX_AGENT_DEPTH = 10
-_PATH_SEPARATOR = "→"  # U+2192 RIGHTWARDS ARROW
 
 
 def decode_project_hash(hash_name: str) -> str:
@@ -109,7 +112,7 @@ def _sanitize_agent_name(name: str) -> str:
         Sanitized agent name with all ``→`` replaced by ``﹖``.
     """
     if _PATH_SEPARATOR in name:
-        sanitized = name.replace(_PATH_SEPARATOR, "﹖")
+        sanitized = name.replace(_PATH_SEPARATOR, _SANITIZED_SEPARATOR_REPLACEMENT)
         warnings.warn(
             f"Agent name contains path separator; sanitized: {name!r} -> {sanitized!r}",
             UserWarning,


### PR DESCRIPTION
## Summary

Behavior-preserving refactor: extracts the duplicated `"→"` (U+2192) path separator and the `"﹖"` (U+FE56) sanitization replacement char from `parser.py` and `aggregator.py` into a new shared module `claude_usage/constants.py`, eliminating the drift risk between the two consumers.

## Changes

- **New** `claude_usage/constants.py` — exports `AGENT_PATH_SEPARATOR` and `SANITIZED_SEPARATOR_REPLACEMENT` as the single source of truth.
- `claude_usage/parser.py` — replaces inline `_PATH_SEPARATOR = "→"` literal and the hardcoded `"﹖"` in `_sanitize_agent_name()` with imports from `constants`.
- `claude_usage/aggregator.py` — replaces inline `AGENT_PATH_SEPARATOR = "→"` literal with an import; preserves the public name via module-level re-bind so existing `from claude_usage.aggregator import AGENT_PATH_SEPARATOR` consumers (notably `tests/test_aggregator.py`) keep working unchanged.

## Verification (matches CI)

- `uvx --from "ruff~=0.6.0" ruff check claude_usage tests` → All checks passed!
- `uvx --from "ruff~=0.6.0" ruff format --check claude_usage tests` → 26 files already formatted
- `./.venv/Scripts/python.exe -m pytest` → **210 passed** (unchanged — no test edits per AC #3)

Test count is stable at 210/210 — the behavior-preservation discipline held.

## Follow-up note (non-blocking)

The `aggregator.py` re-export pattern (`AGENT_PATH_SEPARATOR = _AGENT_PATH_SEPARATOR`) exists to avoid the self-assignment lint warning while preserving the public name. A future pass could migrate `tests/test_aggregator.py` to import directly from `claude_usage.constants` and drop the re-export — leaving as-is for this PR to keep the refactor strictly behavior-preserving.

Fixes #44

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_