### PR TITLE
fix(tests): explicit cwd in test_existing_dashboard_unchanged subprocess.run

### DIFF
--- a/tests/test_dashboard_snapshot.py
+++ b/tests/test_dashboard_snapshot.py
@@ -21,6 +21,13 @@ SNAPSHOT_FILE = (
     Path(__file__).parent / "fixtures" / "dashboard_snapshot_pre_refactor.json"
 )
 
+# Repo root resolved from this file's location, so pytest invoked from any
+# directory (main checkout, worktree, /tmp) uses the correct tree.  Without an
+# explicit cwd=, the subprocess inherits the test-runner's CWD and can silently
+# pass when invoked from a sibling checkout that happens to have the same
+# module importable but different fixture data.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 def test_existing_dashboard_unchanged() -> None:
     """dashboard --format json output must be byte-identical to pre-refactor.
@@ -51,6 +58,9 @@ def test_existing_dashboard_unchanged() -> None:
         ],
         capture_output=True,
         text=True,
+        # Explicit cwd ensures the subprocess resolves sys.path against the
+        # correct repo root regardless of where pytest was invoked from.
+        cwd=str(_REPO_ROOT),
     )
     assert (
         result.returncode == 0


### PR DESCRIPTION
## Summary

`test_existing_dashboard_unchanged` invoked `subprocess.run(...)` without an explicit `cwd=`, so the subprocess inherited the test runner's CWD. When pytest was invoked from a sibling checkout (or any non-worktree directory), the snapshot check ran against the wrong tree and silently false-passed.

Fix: pass `cwd=str(_REPO_ROOT)` where `_REPO_ROOT = Path(__file__).resolve().parent.parent` — anchors the subprocess to the test file's repo root regardless of pytest's launch directory.

## Changes

- `tests/test_dashboard_snapshot.py` — added module-level `_REPO_ROOT` constant; passed `cwd=str(_REPO_ROOT)` to `subprocess.run` in `test_existing_dashboard_unchanged` with an inline comment explaining why the explicit `cwd=` matters (prevents the next maintainer from "cleaning it up" as redundant).

## CWD-independence verification

Ran pytest from two different CWDs after the fix:

- From the worktree root → `210 passed`
- From the main checkout, with absolute test path → `1 passed` (targeted run)

Both pass. The defect (silent false-pass when run from a sibling tree) is now structurally impossible for this test.

## Verification (matches CI)

- `uvx --from "ruff~=0.6.0" ruff check claude_usage tests` → All checks passed!
- `uvx --from "ruff~=0.6.0" ruff format --check claude_usage tests` → 26 files already formatted
- `./.venv/Scripts/python.exe -m pytest` → **210 passed** (unchanged — this is a behavior-fix on an existing test, not a new test)

## Follow-up (out of scope for #40)

During the audit, two other call sites in `tests/test_session_summary.py` were found to have the same defect — they pass a relative-path `--path` argument (`tests/fixtures/session_summaries/...`) to a `subprocess.run` without an explicit `cwd=`, so the CLI resolves the fixture relative to the runner's CWD:

- `test_empty_session_exits_2` (around L1351)
- `test_stdout_on_success_is_pure_json` (around L1538)

These are tracked separately so each PR stays focused; see the follow-up issue filed alongside this PR.

Fixes #40

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_