### PR TITLE
fix(tests): explicit cwd in two test_session_summary.py subprocess.run sites

### DIFF
--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -21,6 +21,11 @@ from claude_usage.cli.session_summary import (
     render_text,
 )
 
+# Repo root resolved from this file's location so subprocess.run calls that
+# pass a relative --path fixture work correctly regardless of the CWD from
+# which pytest is invoked (main checkout, worktree, /tmp, etc.).
+_REPO_ROOT = _Path(__file__).resolve().parent.parent
+
 
 def _parse_fixture(fixture_path: _Path) -> list[dict]:
     """Read and parse a JSONL fixture into a list of dicts.
@@ -1359,6 +1364,9 @@ class TestExitNoUserTurns:
             ],
             capture_output=True,
             text=True,
+            # Explicit cwd ensures the relative --path fixture resolves
+            # correctly regardless of where pytest was invoked from.
+            cwd=str(_REPO_ROOT),
         )
         assert result.returncode == 2
         assert result.stdout == ""
@@ -1548,6 +1556,9 @@ class TestStdoutStderrDiscipline:
             ],
             capture_output=True,
             text=True,
+            # Explicit cwd ensures the relative --path fixture resolves
+            # correctly regardless of where pytest was invoked from.
+            cwd=str(_REPO_ROOT),
         )
         assert result.returncode == 0
         # Must parse cleanly — no leading/trailing non-JSON text


### PR DESCRIPTION
## Summary

Sibling fix to PR #48: two `subprocess.run` call sites in `tests/test_session_summary.py` shared the same silent-false-pass defect — they passed a relative `--path` fixture argument with no explicit `cwd=`, so the CLI resolved the fixture against the test runner's inherited CWD.

Applies the same fix shape as #48: module-level `_REPO_ROOT = Path(__file__).resolve().parent.parent` anchor, then `cwd=str(_REPO_ROOT)` on each affected call.

## Changes

- `tests/test_session_summary.py` —
  - Added module-level `_REPO_ROOT` constant (resolved from `__file__`).
  - `test_empty_session_exits_2` (L1356) — added `cwd=str(_REPO_ROOT)`.
  - `test_stdout_on_success_is_pure_json` (L1546) — added `cwd=str(_REPO_ROOT)`.
  - Inline comments on both call sites explain why the explicit `cwd=` matters.

## CWD-independence verification

Both affected tests run from two different CWDs:

- From the main checkout (`I:/other/claude-usage`) → `2 passed in 2.55s`
- From parent dir (`I:/other`) with absolute test paths → `2 passed in 0.39s`

Both pass. The defect is structurally impossible at these two sites now.

## Verification (matches CI)

- `uvx --from "ruff~=0.6.0" ruff check claude_usage tests` → All checks passed!
- `uvx --from "ruff~=0.6.0" ruff format --check claude_usage tests` → 26 files already formatted
- `./.venv/Scripts/python.exe -m pytest` → **210 passed** (unchanged — no new tests; per-test behavior fix)

## Other sites confirmed defect-free

Per the audit in #49 itself, no other `subprocess.run` sites in this file need changing:
- L1371, L1393, L1423, L1446, L1474, L1511 all use `tmp_path` (absolute by construction).

Fixes #49

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_