### PR TITLE
refactor(parser): dedup warnings, rename _MAX_AGENT_DEPTH, defend empty agentType (#45 part 1/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ complete root-to-leaf chain rather than just the immediate leaf.
   of the other. This rule preserves the dashboard JS's per-agent token
   apportionment, which divides session totals by `s.agents.length`.
 
-- **Depth limit.** The parser enforces `_MAX_AGENT_DEPTH = 10` segments. If
+- **Depth limit.** The parser enforces `_MAX_AGENT_PATH_LENGTH = 10` segments. If
   a chain exceeds this limit the parser emits a `UserWarning` and stops
   descending; deeper messages are bucketed under the last walked ancestor.
   On Windows, junction-based cycles are caught by this same cap rather than

--- a/claude_usage/parser.py
+++ b/claude_usage/parser.py
@@ -13,7 +13,7 @@ from claude_usage.constants import (
 )
 from claude_usage.models import MessageRecord, SessionRecord
 
-_MAX_AGENT_DEPTH = 10
+_MAX_AGENT_PATH_LENGTH = 10
 
 
 def decode_project_hash(hash_name: str) -> str:
@@ -129,6 +129,8 @@ def _parse_subagents_recursive(
     visited: set[Path],
     depth: int,
     overflow_emitted: list[bool],
+    cycle_emitted: list[bool],
+    oserror_emitted: list[bool],
 ) -> list[MessageRecord]:
     """Walk <parent_session_dir>/subagents/ and recurse into each sub-agent.
 
@@ -138,13 +140,18 @@ def _parse_subagents_recursive(
     directory.
 
     Contract:
-        - ``depth > _MAX_AGENT_DEPTH``: return ``[]``. Emit one
-          ``UserWarning`` per session (de-duped via ``overflow_emitted[0]``).
+        - ``len(parent_path) >= _MAX_AGENT_PATH_LENGTH``: return ``[]``.
+          Emit one ``UserWarning`` per session (de-duped via
+          ``overflow_emitted[0]``).
         - ``parent_session_dir.resolve()`` already in ``visited``: emit a
-          cycle ``UserWarning`` and return ``[]``.
-        - For each ``*.meta.json``: read ``agentType``, sanitize it, append
-          to accumulator, build child path, parse matching JSONL, and
-          recurse into ``<parent_session_dir>/subagents/<agent_id>/``.
+          cycle ``UserWarning`` (de-duped via ``cycle_emitted[0]``) and
+          return ``[]``.
+        - ``OSError`` from ``resolve()``: emit a warning (de-duped via
+          ``oserror_emitted[0]``) and return ``[]``.
+        - For each ``*.meta.json``: read ``agentType`` (empty string and
+          ``None`` both default to ``"unknown"``), sanitize it, append to
+          accumulator, build child path, parse matching JSONL, and recurse
+          into ``<parent_session_dir>/subagents/<agent_id>/``.
         - Missing JSONL: silently skipped.
         - Empty or non-existent ``subagents/``: returns ``[]``.
 
@@ -159,19 +166,25 @@ def _parse_subagents_recursive(
             infinite recursion through symlink or junction cycles.
         depth: Current recursion depth (1 = first sub-agent level under
             the root session).
-        overflow_emitted: Single-element list used as a mutable flag; set to
-            ``True`` once the depth-cap warning has been emitted so it fires
+        overflow_emitted: Single-element list used as a mutable flag; set
+            to ``True`` once the path-length-cap warning has been emitted so
+            it fires at most once per ``_parse_session`` call.
+        cycle_emitted: Single-element list used as a mutable flag; set to
+            ``True`` once the cycle warning has been emitted so it fires at
+            most once per ``_parse_session`` call.
+        oserror_emitted: Single-element list used as a mutable flag; set to
+            ``True`` once the OSError warning has been emitted so it fires
             at most once per ``_parse_session`` call.
 
     Returns:
         Flat list of ``MessageRecord`` objects produced at this level and
         all reachable descendant levels.
     """
-    if depth > _MAX_AGENT_DEPTH - 1:
+    if len(parent_path) >= _MAX_AGENT_PATH_LENGTH:
         if not overflow_emitted[0]:
             warnings.warn(
-                f"Subagent recursion depth cap ({_MAX_AGENT_DEPTH}) exceeded"
-                f" at {parent_session_dir}",
+                f"Subagent path length cap ({_MAX_AGENT_PATH_LENGTH})"
+                f" exceeded at {parent_session_dir}",
                 UserWarning,
                 stacklevel=2,
             )
@@ -186,22 +199,26 @@ def _parse_subagents_recursive(
     # path.  On POSIX, symlinks are fully resolved; on Windows, junctions
     # may not be normalized (fallback to depth cap).
     # OSError can occur on broken symlinks, revoked permissions, or
-    # other filesystem faults — warn and skip rather than crash.
+    # other filesystem faults — warn once and skip rather than crash.
     try:
         real_dir = subagent_dir.resolve()
     except OSError as exc:
-        warnings.warn(
-            f"Skipping unreadable subagent directory {subagent_dir}: {exc}",
-            UserWarning,
-            stacklevel=2,
-        )
+        if not oserror_emitted[0]:
+            warnings.warn(
+                f"Skipping unreadable subagent directory {subagent_dir}: {exc}",
+                UserWarning,
+                stacklevel=2,
+            )
+            oserror_emitted[0] = True
         return []
     if real_dir in visited:
-        warnings.warn(
-            f"Subagent directory cycle detected: {real_dir}",
-            UserWarning,
-            stacklevel=2,
-        )
+        if not cycle_emitted[0]:
+            warnings.warn(
+                f"Subagent directory cycle detected: {real_dir}",
+                UserWarning,
+                stacklevel=2,
+            )
+            cycle_emitted[0] = True
         return []
     visited.add(real_dir)
 
@@ -209,7 +226,7 @@ def _parse_subagents_recursive(
     for meta_path in subagent_dir.glob("*.meta.json"):
         try:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
-            raw_agent_type = meta.get("agentType", "unknown")
+            raw_agent_type = meta.get("agentType") or "unknown"
         except (json.JSONDecodeError, OSError):
             raw_agent_type = "unknown"
 
@@ -240,6 +257,8 @@ def _parse_subagents_recursive(
                 visited=visited,
                 depth=depth + 1,
                 overflow_emitted=overflow_emitted,
+                cycle_emitted=cycle_emitted,
+                oserror_emitted=oserror_emitted,
             )
         )
 
@@ -319,6 +338,8 @@ def _parse_session(jsonl_path: Path, project_name: str) -> SessionRecord | None:
     subagent_types: list[str] = []
     visited: set[Path] = set()
     overflow_emitted: list[bool] = [False]
+    cycle_emitted: list[bool] = [False]
+    oserror_emitted: list[bool] = [False]
     messages.extend(
         _parse_subagents_recursive(
             parent_session_dir=jsonl_path.parent / session_id,
@@ -327,6 +348,8 @@ def _parse_session(jsonl_path: Path, project_name: str) -> SessionRecord | None:
             visited=visited,
             depth=1,
             overflow_emitted=overflow_emitted,
+            cycle_emitted=cycle_emitted,
+            oserror_emitted=oserror_emitted,
         )
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,7 +306,7 @@ def nested_session_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def pathological_depth_session_dir(tmp_path: Path) -> Path:
-    """Create a 12-level-deep subagent chain to exercise _MAX_AGENT_DEPTH = 10.
+    """Create a 12-level-deep subagent chain to exercise _MAX_AGENT_PATH_LENGTH = 10.
 
     Layout::
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -425,8 +425,8 @@ class TestNestedSubagents:
         assert len(session.messages) == 1
 
     def test_pathological_depth_cap(self, pathological_depth_session_dir: Path):
-        """12-deep chain triggers depth-cap warning; no path exceeds depth 10."""
-        with pytest.warns(UserWarning, match=r"depth cap"):
+        """12-deep chain triggers path-length-cap warning; no path exceeds 10."""
+        with pytest.warns(UserWarning, match=r"path length cap"):
             sessions = parse_sessions(pathological_depth_session_dir)
         assert len(sessions) == 1
         for msg in sessions[0].messages:
@@ -462,7 +462,7 @@ class TestNestedSubagents:
         Two assertions:
         (a) Cycle-specific warning fires (distinct from depth-cap warning).
         (b) Cycled segment appears at most once, and max path depth is <= 3
-            (well below _MAX_AGENT_DEPTH = 10, proving the cap didn't fire).
+            (well below _MAX_AGENT_PATH_LENGTH = 10, proving the cap didn't fire).
         """
         with pytest.warns(UserWarning, match=r"Subagent directory cycle detected"):
             sessions = parse_sessions(symlink_cycle_session_dir)
@@ -478,12 +478,12 @@ class TestNestedSubagents:
     def test_depth_cap_fires_when_visited_set_misses(
         self, pathological_depth_session_dir: Path
     ):
-        """Non-cyclic 12-deep chain triggers depth-cap (not cycle) warning.
+        """Non-cyclic 12-deep chain triggers path-length-cap (not cycle) warning.
 
         Distinct message text from the cycle warning proves the two defenses
         are independently observable.
         """
-        with pytest.warns(UserWarning, match=r"depth cap"):
+        with pytest.warns(UserWarning, match=r"path length cap"):
             sessions = parse_sessions(pathological_depth_session_dir)
         assert len(sessions) == 1
         # No path should exceed the cap
@@ -617,7 +617,7 @@ class TestOSErrorDefense:
         msg = caught_messages[0]
         # Must not match the other two warning types
         assert "cycle detected" not in msg
-        assert "depth cap" not in msg
+        assert "path length cap" not in msg
         # Must contain the OSError-specific text
         assert "unreadable subagent directory" in msg
 
@@ -826,3 +826,137 @@ class TestOSErrorDefense:
         ok_session = next(s for s in sessions if s.session_id == ok_session_id)
         assert len(ok_session.messages) == 1
         assert ok_session.messages[0].input_tokens == 77
+
+
+class TestEmptyAgentTypeDefense:
+    """Tests for empty/null agentType defense in _parse_subagents_recursive.
+
+    Covers issue #45 Item 3: ``meta.get("agentType") or "unknown"`` must
+    handle missing-key, ``None``, and empty-string ``""`` uniformly,
+    producing ``agent_type == "unknown"`` in all three cases.
+    """
+
+    def _make_session_with_subagent_meta(
+        self, tmp_path: Path, agent_type_value: object
+    ) -> Path:
+        """Build a minimal session fixture with one subagent whose meta has
+        the given agentType value (or omits the key when value is a sentinel).
+
+        Args:
+            tmp_path: Pytest-provided temporary directory.
+            agent_type_value: The value to write for ``agentType`` in the
+                subagent's ``*.meta.json``.  Pass the string ``"__omit__"``
+                to omit the key entirely.
+
+        Returns:
+            Path to the data directory suitable for ``parse_sessions()``.
+        """
+        session_id = "sess-empty-agent-type"
+        project_dir = tmp_path / "projects" / "proj"
+        project_dir.mkdir(parents=True)
+        jsonl = project_dir / f"{session_id}.jsonl"
+
+        root_lines = [
+            {
+                "type": "agent-setting",
+                "agentSetting": "general-purpose",
+                "sessionId": session_id,
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-14T10:00:00.000Z",
+                "sessionId": session_id,
+                "message": {
+                    "model": "claude-opus-4-6",
+                    "role": "assistant",
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    },
+                },
+            },
+        ]
+        jsonl.write_text(
+            "\n".join(json.dumps(line) for line in root_lines),
+            encoding="utf-8",
+        )
+
+        subagent_dir = project_dir / session_id / "subagents"
+        subagent_dir.mkdir(parents=True)
+
+        if agent_type_value == "__omit__":
+            meta: dict = {}
+        else:
+            meta = {"agentType": agent_type_value}
+        (subagent_dir / "agent-ea.meta.json").write_text(
+            json.dumps(meta), encoding="utf-8"
+        )
+
+        subagent_lines = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-14T10:01:00.000Z",
+                "sessionId": session_id,
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "role": "assistant",
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 10,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    },
+                },
+            },
+        ]
+        (subagent_dir / "agent-ea.jsonl").write_text(
+            "\n".join(json.dumps(line) for line in subagent_lines),
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_empty_string_agent_type_defaults_to_unknown(self, tmp_path: Path) -> None:
+        """agentType ``""`` in metadata.json must parse as ``"unknown"``.
+
+        An empty string passes through ``meta.get("agentType", "unknown")``
+        unchanged, producing an empty-string leaf in ``agent_path``.  The
+        ``or "unknown"`` fix must short-circuit the empty string.
+        """
+        data_dir = self._make_session_with_subagent_meta(tmp_path, "")
+        sessions = parse_sessions(data_dir)
+        assert len(sessions) == 1
+        subagent_msgs = [m for m in sessions[0].messages if len(m.agent_path) == 2]
+        assert len(subagent_msgs) >= 1
+        for msg in subagent_msgs:
+            assert msg.agent_type == "unknown", (
+                f"Expected agent_type='unknown' for empty agentType, "
+                f"got {msg.agent_type!r}"
+            )
+            assert (
+                msg.agent_path[-1] == "unknown"
+            ), f"Expected agent_path leaf='unknown', got {msg.agent_path!r}"
+
+    def test_null_agent_type_defaults_to_unknown(self, tmp_path: Path) -> None:
+        """agentType ``null`` in metadata.json must parse as ``"unknown"``.
+
+        JSON ``null`` deserialises to Python ``None``.
+        ``meta.get("agentType", "unknown")`` returns ``None`` (key present),
+        which must be caught by the ``or "unknown"`` guard.
+        """
+        data_dir = self._make_session_with_subagent_meta(tmp_path, None)
+        sessions = parse_sessions(data_dir)
+        assert len(sessions) == 1
+        subagent_msgs = [m for m in sessions[0].messages if len(m.agent_path) == 2]
+        assert len(subagent_msgs) >= 1
+        for msg in subagent_msgs:
+            assert msg.agent_type == "unknown", (
+                f"Expected agent_type='unknown' for null agentType, "
+                f"got {msg.agent_type!r}"
+            )
+            assert (
+                msg.agent_path[-1] == "unknown"
+            ), f"Expected agent_path leaf='unknown', got {msg.agent_path!r}"


### PR DESCRIPTION
## Summary

**PR 1 of 4** for Issue #45 (nested-attribution polish umbrella). Addresses items 1, 2, and 3:

1. **De-duplicate cycle and OSError warnings** — both used to emit once per hit; now emit once per parse via threaded `cycle_emitted`/`oserror_emitted` flags, mirroring the existing `overflow_emitted` pattern.
2. **Rename `_MAX_AGENT_DEPTH` → `_MAX_AGENT_PATH_LENGTH`** + rewrite the cap check as `if len(parent_path) >= _MAX_AGENT_PATH_LENGTH:` (explicit, no off-by-one). The cap is on **path length** (root + 9 subagent levels = 10 segments), and now both the name and the check make that obvious.
3. **Defend empty `agentType`** — `meta.get("agentType", "unknown")` only defaulted on missing key; `{"agentType": ""}` slipped through producing an empty-string leaf in `agent_path`. Changed to `meta.get("agentType") or "unknown"`, which handles missing, `None`, and `""` uniformly.

PR1 also includes the surface-level constant-name updates in `README.md` and `tests/conftest.py` to avoid a stale-name window before PR2 (which expands the README prose and design.md content).

## Changes

- `claude_usage/parser.py` — threaded `cycle_emitted`/`oserror_emitted` recursion flags; renamed constant; rewrote depth check; `or "unknown"` defense.
- `tests/test_parser.py` — new `TestEmptyAgentTypeDefense` class (+2 tests: empty-string and `None` defenses); updated 3 existing tests' warning-text matchers from `"depth cap"` → `"path length cap"` to match Item 2's new wording.
- `tests/conftest.py` — fixture docstring constant-name update.
- `README.md` — constant-name swap only (prose rewrite is Item 6, deferred to PR2).

## Warning text (after PR1)

- **Depth cap (renamed):** `"Subagent path length cap (10) exceeded at <dir>"`
- **Cycle (unchanged text, now deduped):** `"Subagent directory cycle detected: <dir>"`
- **OSError (unchanged text, now deduped):** `"Skipping unreadable subagent directory <dir>: <exc>"`

## Verification (matches CI)

- `uvx --from "ruff~=0.6.0" ruff check claude_usage tests` → All checks passed!
- `uvx --from "ruff~=0.6.0" ruff format --check claude_usage tests` → 26 files already formatted
- `./.venv/Scripts/python.exe -m pytest` → **212 passed** (was 210; +2 new tests for Item 3)

## Behavior-change disclosure

The dedup in Item 1 is the only **observable** behavior change in this PR — a session with N cycle hits now emits 1 cycle warning instead of N. No existing test was counting warnings (verified during execution), so no test breakage.

Item 2 is purely an internal rename + check-equivalent rewrite. Item 3 is a defensive widening (more inputs accepted as `"unknown"`).

Refs #45

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_