### PR TITLE
docs: deepen MessageRecord, clarify README depth-limit, log baseline-flat methodology gap (#45 part 2/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,12 @@ complete root-to-leaf chain rather than just the immediate leaf.
   of the other. This rule preserves the dashboard JS's per-agent token
   apportionment, which divides session totals by `s.agents.length`.
 
-- **Depth limit.** The parser enforces `_MAX_AGENT_PATH_LENGTH = 10` segments. If
-  a chain exceeds this limit the parser emits a `UserWarning` and stops
-  descending; deeper messages are bucketed under the last walked ancestor.
+- **Depth limit.** Path tuples may contain up to **10 segments** total —
+  the root agent plus up to 9 levels of nested sub-agents
+  (`_MAX_AGENT_PATH_LENGTH = 10`). Beyond that, the parser emits a single
+  `UserWarning` and stops descending; deeper messages are bucketed under the
+  last walked ancestor. The warning fires at most once per session parse (not
+  once per overflowing message), as do the cycle and OSError warnings below.
   On Windows, junction-based cycles are caught by this same cap rather than
   by the POSIX visited-set short-circuit.
 

--- a/docs/decisions/2026-05-14-baseline-flat-methodology-gap.md
+++ b/docs/decisions/2026-05-14-baseline-flat-methodology-gap.md
@@ -1,0 +1,57 @@
+# Baseline-flat test methodology gap (PR #42)
+
+**Date:** 2026-05-14
+**Issue:** #45 (item 10)
+**Status:** Documented; not fixed.
+
+## What was supposed to happen
+
+The implementation plan for Issue #41 (nested sub-agent attribution) —
+[`docs/superpowers/plans/2026-05-13-issue-41-nested-agent-attribution-plan.md`](../superpowers/plans/2026-05-13-issue-41-nested-agent-attribution-plan.md)
+— called for a Phase 0 baseline test at `tests/test_aggregator_baseline_flat.py`.
+That test was meant to assert the *old* flat-agent-key shape on a depth-2 fixture,
+then fail loudly under the new code path once Phase 4 landed — proving the migration
+moved the needle rather than no-op'ing.
+
+Plan reference: Task 0.2 — "Capture flat-agent baseline (with explicit limit)" —
+checkbox unchecked.
+
+## What actually happened
+
+The baseline test was never written. Phase 4 implemented the new path-keyed shape
+directly without first capturing the old contract. The Phase 4.1 "delete the
+baseline-flat test" step was a no-op because the file never existed.
+
+## Why we are not retroactively fixing it
+
+Retroactively writing the baseline-flat test now would mean asserting behavior the
+codebase no longer implements — the flat-key `by_agent` contract is gone. Such a
+test would either:
+
+1. Fail immediately (asserting deleted behavior) — adds noise, ships nothing.
+2. Require synthetic fixtures of the *old* shape just to have something to assert
+   against — circular and unmaintainable.
+
+The migration shipped (PR #42). The new shape is exercised by
+`TestAggregateByAgentPath` and related path-keyed tests in
+`tests/test_aggregator.py`. The regression risk the baseline test was meant to
+address has passed.
+
+## What we will do differently next time
+
+Any "we will write X as a baseline" plan task should be the **first commit on the
+implementing branch**, before any code change that would obsolete the baseline. If it
+is not the first commit, it gets skipped under deadline pressure and the methodology
+guarantee is lost.
+
+Concretely:
+
+- Phase 0 tasks should be self-contained commits that pass on a clean `main`.
+- Subsequent phases should not delete or modify Phase 0 tests in the same PR — if
+  they must, the Phase 0 commit should ship on its own PR first so it enters
+  `main`'s history independently.
+- This applies to any "regression baseline" or "would-have-failed-but-for-the-fix"
+  test pattern.
+
+This is recorded here per `CLAUDE.md § Verify Artifact Persistence` (recovery
+clause): methodology gaps should be honestly disclosed, not silently regenerated.

--- a/docs/design.md
+++ b/docs/design.md
@@ -79,10 +79,93 @@ claude-usage/
 
 ### Module Responsibilities
 
-**`models.py`** — Data classes representing parsed data:
-- `MessageRecord`: timestamp, model, `agent_path: tuple[str, ...]` (root-to-leaf chain, e.g. `("general-purpose", "project-planner", "Explore")`), `agent_type: str` (stored field, parallel to `agent_path`; parser-enforced invariant: `agent_type == agent_path[-1]` when `agent_path` is non-empty — the dataclass does not derive this automatically), skill (optional), input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens.
-- `SessionRecord`: session_id, project, start_time, root_agent, messages (list of MessageRecord), subagents (list of agent types)
-- Total tokens computed as sum of all four token fields
+**`models.py`** — Data classes representing parsed data.
+
+#### MessageRecord
+
+A single assistant message attributed to a specific agent in the invocation tree.
+Each record carries the full root-to-leaf path of the agent that produced it, plus
+independent token-count fields for the four billing buckets Claude Code tracks.
+
+**Fields:**
+
+- `timestamp: datetime` — when the assistant message was produced.
+- `model: str` — full model ID string (e.g. `"claude-opus-4-6"`).
+- `agent_type: str` — leaf agent name (e.g. `"general-purpose"`). Stored as a plain
+  field; not derived from `agent_path`. See the invariant below.
+- `agent_path: tuple[str, ...]` — full ancestry tuple from root to leaf (e.g.
+  `("general-purpose", "project-planner", "Explore")`). Defaults to the empty
+  tuple for records that pre-date nested attribution.
+- `skill: str | None` — skill name invoked in this message, or `None`.
+- `input_tokens: int` — prompt token count.
+- `output_tokens: int` — completion token count.
+- `cache_read_tokens: int` — tokens served from the prompt cache.
+- `cache_creation_tokens: int` — tokens written to the prompt cache.
+- `total_tokens` (property) — sum of all four token fields.
+
+**Invariants:**
+
+- `agent_type == agent_path[-1]` when `agent_path` is non-empty. The dataclass does
+  not enforce this automatically; it is the parser's responsibility at construction
+  time (`claude_usage/parser.py`, `_parse_jsonl_messages` and
+  `_parse_subagents_recursive`).
+- `agent_path` segments are sanitized: no segment may contain the path separator
+  U+2192 `→`. See Sanitization below.
+
+**Aggregation contract:**
+
+The aggregator (`claude_usage/aggregator.py`) keys `by_agent` on the full path string
+`AGENT_PATH_SEPARATOR.join(agent_path)`, e.g. `"general-purpose→project-planner→Explore"`.
+Keys are created only for paths with direct messages — there are no implicit
+intermediate keys. A path `"general-purpose→project-planner"` does not appear in
+`by_agent` unless the `project-planner` agent itself produced messages (not just its
+descendants). The per-session `agents` list (used by the dashboard JS for token
+apportionment) contains only the deepest-leaf path per chain: a path key `k` is
+included only when no other key in the same session starts with
+`k + AGENT_PATH_SEPARATOR`. Sibling chains that share a leaf name but differ in
+their ancestors are both kept, as neither is a prefix of the other.
+
+**Sanitization:**
+
+The path separator `→` (U+2192 RIGHTWARDS ARROW, defined as `AGENT_PATH_SEPARATOR`
+in `claude_usage/constants.py`) must not appear inside any `agent_path` segment.
+If an agent name read from a `.meta.json` file contains this character,
+`_sanitize_agent_name` in `claude_usage/parser.py` replaces it with `﹖`
+(U+FE56 SMALL QUESTION MARK, defined as `SANITIZED_SEPARATOR_REPLACEMENT`) and
+emits a `UserWarning`. The sanitized name is used throughout parse, aggregation,
+and the dashboard key.
+
+**Defenses:**
+
+- **Depth cap** — `_MAX_AGENT_PATH_LENGTH = 10` in `claude_usage/parser.py`. When
+  `len(parent_path) >= 10`, the recursive walk stops and a `UserWarning` is emitted.
+  Maximum path length is 10 segments (root agent + up to 9 nested sub-agent levels).
+- **Cycle detection** — a `visited: set[Path]` accumulator short-circuits
+  symlink/junction cycles by comparing resolved real paths. On Windows, junctions
+  may not resolve correctly; the depth cap provides a second-line defense.
+- **OSError on resolve()** — broken symlinks and revoked permissions raise `OSError`
+  on `Path.resolve()`; the parser catches this, emits a warning, and skips the
+  affected branch.
+
+All three warnings are de-duplicated per `_parse_session` call: each fires at most
+once regardless of how many times the condition is hit within a single session.
+
+**Examples:**
+
+```python
+# Depth-1 (root only — equivalent to the pre-PR42 flat model)
+MessageRecord(agent_type="general-purpose", agent_path=("general-purpose",), ...)
+
+# Depth-2 (one sub-agent)
+MessageRecord(agent_type="project-planner", agent_path=("general-purpose", "project-planner"), ...)
+
+# Depth-3 (two levels of sub-agent)
+MessageRecord(agent_type="Explore", agent_path=("general-purpose", "project-planner", "Explore"), ...)
+```
+
+**`SessionRecord`** — session_id, project, start_time, root_agent, messages (list of
+MessageRecord), subagents (list of agent types). Total tokens computed as sum of all
+four token fields across all messages.
 
 **`parser.py`** — Reads the filesystem and produces `SessionRecord` objects:
 - Walks `~/.claude/projects/` to find session JSONL files


### PR DESCRIPTION
## Summary

**PR 2 of 4** for Issue #45 (nested-attribution polish umbrella). Addresses items 6, 9, and 10 — all documentation, no code changes.

1. **README depth-limit clarification (item 6)** — rewrote the depth-limit bullet to be unambiguous about "10 segments total = root + up to 9 nested sub-agents", and folded in the post-PR #51 dedup note (cycle / depth-cap / OSError warnings each fire at most once per parse).
2. **`docs/design.md` MessageRecord expansion (item 9)** — replaced the one-liner with a full subsection covering fields, the `agent_type == agent_path[-1]` invariant, the path-keyed `by_agent` aggregation contract, the prefix-membership rule for `agents_in_session`, the sanitization rule (`→` U+2192 → `﹖` U+FE56), the defenses (depth/cycle/OSError + dedup flags), and depth-1/2/3 examples. The depth-2/depth-3 examples were aligned with the actual `nested_session_dir` fixture (`project-planner` at depth 2, `Explore` at depth 3) rather than the plan sketch.
3. **Methodology decision record (item 10)** — new `docs/decisions/2026-05-14-baseline-flat-methodology-gap.md` documenting the Phase 0 baseline-flat test that was specified in the Issue #41 plan but never written, why we are NOT retroactively writing it, and the process change for next time ("baseline tests must be the first commit on the implementing branch"). Per `CLAUDE.md § Verify Artifact Persistence`'s recovery clause — methodology gaps get honestly disclosed, not silently regenerated.

The `docs/decisions/` directory did not exist before this PR; it was created here. No existing ADR-style precedent was found in `docs/`, so a minimal frontmatter-free style was used.

## Changes

| File | Delta | Description |
|---|---|---|
| `README.md` | +5 lines | Depth-limit bullet rewrite (item 6) |
| `docs/design.md` | +55 lines | MessageRecord subsection expansion (item 9) |
| `docs/decisions/2026-05-14-baseline-flat-methodology-gap.md` | +57 lines (new) | Methodology decision record (item 10) |

## Verification

- `uvx --from "ruff~=0.6.0" ruff check claude_usage tests` → All checks passed!
- `uvx --from "ruff~=0.6.0" ruff format --check claude_usage tests` → 26 files already formatted
- `./.venv/Scripts/python.exe -m pytest` → **212 passed** (unchanged — docs-only PR)

Refs #45

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_