### PR TITLE
test: extract no-warning assertion, strengthen flat-key absence assertion (#45 part 3/4)

### DIFF
--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -268,6 +268,13 @@ class TestAggregateByAgentPath:
         (which the old code emitted via ``m.agent_type``) must NOT appear;
         the full path-key ``"general-purpose→project-planner→Explore"`` is
         the only correct form for those depth-3 messages.
+
+        Similarly, the bare key ``"project-planner"`` must not appear.  In
+        the ``nested_session_dir`` fixture ``project-planner`` has its own
+        direct messages, so it DOES produce the path-keyed entry
+        ``"general-purpose→project-planner"`` — but it must NOT appear under
+        the old flat ``"project-planner"`` key.  This asserts that the
+        path-keyed shape applies to every depth, not only the deepest leaf.
         """
         sessions = parse_sessions(nested_session_dir)
         result = aggregate(sessions)
@@ -276,6 +283,14 @@ class TestAggregateByAgentPath:
         assert "Explore" not in result.by_agent, (
             "Bare leaf key 'Explore' must NOT appear in by_agent after Phase 4; "
             "only the full path key 'general-purpose→project-planner→Explore' "
+            "is valid"
+        )
+        # "project-planner" (bare depth-2 name) must also not appear as a
+        # flat key — the path-keyed form is the only valid shape.
+        assert "project-planner" not in result.by_agent, (
+            "Bare depth-2 key 'project-planner' must NOT appear in by_agent; "
+            f"only the full path key "
+            f"'general-purpose{AGENT_PATH_SEPARATOR}project-planner' "
             "is valid"
         )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -440,7 +440,14 @@ class TestNestedSubagents:
         ]
         assert len(explore_msgs) >= 1
         assert explore_msgs[0].agent_path[-1] == "Explore"
-        # No sanitization warning should fire for a plain PascalCase name
+
+    def test_well_formed_tree_emits_no_warnings(self, nested_session_dir: Path):
+        """A well-formed nested session tree must not emit any UserWarnings.
+
+        Specifically, no cycle, depth-cap, OSError, or sanitization warning
+        should fire when parsing a tree whose agent names are valid and whose
+        depth is within the path-length cap.
+        """
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
             _ = parse_sessions(nested_session_dir)


### PR DESCRIPTION
## Summary

**PR 3 of 4** for Issue #45 (nested-attribution polish umbrella). Addresses items 4 and 5 — test-only PR, no production code changes.

1. **Item 4 — Split no-warning side-clause out of `test_pascalcase_agent_name_roundtrips`** — that test was silently asserting "no warnings fire on a well-formed parse" inside a `warnings.simplefilter("error")` block tacked onto its end, with no test name documenting it. The side-clause has been removed from the PascalCase test and extracted into a dedicated `test_well_formed_tree_emits_no_warnings` with a docstring naming every warning class it guards against (cycle, depth-cap, OSError, sanitization).
2. **Item 5 — Strengthen `test_intermediate_path_not_implicitly_created`** — see "Item 5 deviation" below.

## Item 5 deviation from the plan

Plan-time assumption: an intermediate path like `"general-purpose→project-planner"` exists in the `nested_session_dir` fixture with **no direct messages** (only rolled-up descendants), and the test should assert that such an intermediate key is absent from `by_agent`.

Reality discovered during execution: every node in the `nested_session_dir` fixture — `general-purpose` (depth 1), `project-planner` (depth 2), `Explore` (depth 3) — has at least one direct message. So `"general-purpose→project-planner"` IS a legitimate `by_agent` key, and there is no truly "intermediate with no direct messages" path in the current fixture.

Two options were considered:

1. **Extend `tests/conftest.py`** to add a depth-2 agent with no direct messages purely to enable the original assertion. This would touch shared test infrastructure for a polish PR, and the new fixture variant would only ever be used by this one assertion.
2. **Pivot to a logically equivalent invariant**: assert that the bare flat key `"project-planner"` (the old pre-Phase-4 shape) does NOT appear in `by_agent`, even though the full path-keyed form `"general-purpose→project-planner"` does. This is the same class of invariant as the existing `"Explore"` flat-key assertion, extended to cover depth-2 agents.

Picked option 2. The test now catches the regression class "aggregator started emitting bare flat keys alongside path-keyed ones" at all observed depths (depth 1: no direct top-level rollup; depth 2: `"project-planner"`; depth 3: `"Explore"`). The test's docstring was updated to explain why `"project-planner"` has a path-keyed entry but must not appear as a bare flat name.

A truly "intermediate with no direct messages" assertion is a fixture-extension change worth tracking separately if it becomes useful — not bundled into this polish PR.

## Changes

- `tests/test_parser.py` — trimmed `test_pascalcase_agent_name_roundtrips` body; added `test_well_formed_tree_emits_no_warnings`.
- `tests/test_aggregator.py` — added flat-key absence assertion for `"project-planner"` to `test_intermediate_path_not_implicitly_created`; updated docstring.

## Verification (matches CI)

- `uvx --from "ruff~=0.6.0" ruff check claude_usage tests` → All checks passed!
- `uvx --from "ruff~=0.6.0" ruff format --check claude_usage tests` → 26 files already formatted
- `./.venv/Scripts/python.exe -m pytest` → **213 passed** (was 212; +1 from extracted test)

Refs #45

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_