### PR TITLE
test: add e2e sanitization test, real-data renderer regression (#45 part 4/4)

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -266,6 +266,69 @@ class TestSubagentModelAttribution:
         )
 
 
+class TestSeparatorSanitizationE2E:
+    """End-to-end guard: separator in agent name is sanitized through aggregation.
+
+    Item 7 of issue #45 — parser-level sanitization is unit-tested in
+    ``tests/test_parser.py``; this integration test proves the sanitized
+    character survives all the way through ``parse_sessions → aggregate``
+    so the ``by_agent`` keys are safe for downstream consumers.
+    """
+
+    def test_separator_in_agent_name_sanitized_through_aggregation(
+        self, separator_in_name_session_dir: Path
+    ) -> None:
+        """Separator U+2192 in agentType is replaced by U+FE56 in by_agent keys.
+
+        The fixture contains a subagent with ``agentType: "weird→name"`` where
+        ``→`` (U+2192) is the path-separator character.  After the full
+        ``parse_sessions → aggregate`` pipeline the resulting ``by_agent``
+        dict must:
+
+        1.  Contain the sanitized key
+            ``"general-purpose→weird﹖name"`` (U+2192 as separator,
+            U+FE56 replacing the original ``→`` inside the segment name).
+        2.  NOT contain any key with a bare stray ``→`` inside a segment
+            name (i.e. no ``"weird→name"`` substring in any key).
+
+        This is the integration counterpart of the unit test in
+        ``test_parser.py::TestSanitizeAgentName`` which only exercises
+        ``_sanitize_agent_name`` in isolation.
+        """
+        sessions = parse_sessions(separator_in_name_session_dir)
+        result = aggregate(sessions)
+
+        # U+2192 RIGHTWARDS ARROW (path separator)
+        sep = "→"
+        # U+FE56 SMALL QUESTION MARK (sanitized replacement)
+        replacement = "﹖"
+
+        sanitized_key = f"general-purpose{sep}weird{replacement}name"
+
+        assert sanitized_key in result.by_agent, (
+            f"Sanitized key {sanitized_key!r} must appear in by_agent. "
+            f"Keys present: {sorted(result.by_agent)}"
+        )
+
+        # No key should contain a raw U+2192 *inside* a segment name.
+        # The separator between segments is expected (U+2192), but the
+        # sanitizer must have replaced any U+2192 within segment text.
+        for key in result.by_agent:
+            segments = key.split(sep)
+            for segment in segments:
+                assert replacement not in segment or sep not in segment, (
+                    f"Segment {segment!r} in key {key!r} contains both the "
+                    f"separator and the replacement — sanitization may be "
+                    f"double-replacing."
+                )
+            # The segment that was originally "weird→name" must not still
+            # contain the raw separator character.
+            assert "weird→name" not in key, (
+                f"Key {key!r} contains the unsanitized segment 'weird→name' — "
+                f"sanitization did not propagate through aggregation."
+            )
+
+
 class TestChartLabelSkip:
     """Regression test for issue #7: category-axis labels skipped on Tokens by Agent
     and Skill Invocations charts.

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from claude_usage.aggregator import AggregateResult
+from claude_usage.aggregator import AggregateResult, aggregate
+from claude_usage.parser import parse_sessions
 from claude_usage.renderer import render
 
 # U+2192 RIGHTWARDS ARROW — the candidate separator for nested agent path keys.
@@ -216,3 +217,65 @@ def test_path_keys_render_through(tmp_path: Path) -> None:
     assert (
         data_obj["by_agent"][path_key]["total_tokens"] == 100
     ), "Round-tripped by_agent entry must preserve the total_tokens value."
+
+
+def test_real_data_depth3_renders_correct_by_agent_values(
+    nested_session_dir: Path, tmp_path: Path
+) -> None:
+    """Real depth-3 aggregator output renders correct by_agent values for leaf.
+
+    Plan Task 4.3 regression — ``test_path_keys_render_through`` uses a
+    synthetic ``AggregateResult`` built directly.  This test runs the full
+    ``parse_sessions(nested_session_dir) → aggregate → render`` pipeline and
+    verifies the embedded ``DATA.by_agent`` entry for the depth-3 leaf key
+    ``"general-purpose→project-planner→Explore"`` matches the values the
+    aggregator actually computed.
+
+    Expected values (derived from the ``nested_session_dir`` fixture in
+    ``conftest.py`` and confirmed by
+    ``TestAggregateByAgentPath.test_depth_three_uses_full_path_key``):
+
+    - ``total_tokens``:  600  (400 input + 200 output for the Explore agent)
+    - ``primary_model``: ``"haiku"``  (``claude-haiku-4-5`` → short name)
+    - ``session_count``: 1
+
+    This is a permanent regression gate: if a future change causes real
+    aggregator output to be embedded incorrectly in the HTML (e.g. the
+    renderer serialises a stale or partial result), this test will fail
+    independently of the synthetic-data guard in
+    ``test_path_keys_render_through``.
+    """
+    sessions = parse_sessions(nested_session_dir)
+    result = aggregate(sessions)
+
+    output = tmp_path / "dashboard-depth3.html"
+    render(result, output_path=output, open_browser=False)
+    html = output.read_text(encoding="utf-8")
+
+    # Extract the embedded DATA JSON payload the same way test_path_keys_render_through
+    # does — raw_decode handles the → JSON-escape transparently.
+    data_line_marker = "const DATA = "
+    data_start = html.index(data_line_marker) + len(data_line_marker)
+    decoder = json.JSONDecoder()
+    data_obj, _ = decoder.raw_decode(html, data_start)
+
+    leaf_key = "general-purpose→project-planner→Explore"
+
+    assert leaf_key in data_obj["by_agent"], (
+        f"DATA.by_agent must contain the depth-3 leaf key {leaf_key!r}. "
+        f"Keys present: {sorted(data_obj['by_agent'])}"
+    )
+
+    entry = data_obj["by_agent"][leaf_key]
+
+    assert entry["total_tokens"] == 600, (
+        f"Depth-3 leaf total_tokens must be 600 (400 input + 200 output). "
+        f"Got: {entry['total_tokens']!r}"
+    )
+    assert entry["primary_model"] == "haiku", (
+        f"Depth-3 leaf primary_model must be 'haiku' (claude-haiku-4-5). "
+        f"Got: {entry['primary_model']!r}"
+    )
+    assert entry["session_count"] == 1, (
+        f"Depth-3 leaf session_count must be 1. " f"Got: {entry['session_count']!r}"
+    )


### PR DESCRIPTION
## Summary

- Adds the two remaining items from issue #45 (part 4 of 4 of the nested-attribution polish umbrella)
- Item 7: end-to-end integration test proving `→` in an agent name is sanitized through the full `parse_sessions → aggregate` pipeline — the sanitized key appears in `by_agent`, the unsanitized segment does not
- Item 8: real-data renderer regression running `parse_sessions(nested_session_dir) → aggregate → render` and asserting `DATA.by_agent["general-purpose→project-planner→Explore"]` embeds the correct `total_tokens`, `primary_model`, and `session_count` values

## Changes

- `tests/test_e2e.py` — `TestSeparatorSanitizationE2E.test_separator_in_agent_name_sanitized_through_aggregation`: reuses the `separator_in_name_session_dir` conftest fixture; runs the full pipeline; asserts sanitized key present and unsanitized segment absent
- `tests/test_renderer.py` — `test_real_data_depth3_renders_correct_by_agent_values`: runs the full `parse_sessions → aggregate → render` pipeline against `nested_session_dir`; extracts `const DATA = ...` via `json.JSONDecoder.raw_decode`; asserts `total_tokens=600`, `primary_model="haiku"`, `session_count=1` for the depth-3 leaf key. Preserves existing `test_path_keys_render_through` (synthetic guard) — both tests coexist.

## Verification (matches CI)

```
uvx --from "ruff~=0.6.0" ruff check claude_usage tests
All checks passed!

uvx --from "ruff~=0.6.0" ruff format --check claude_usage tests
26 files already formatted

./.venv/Scripts/python.exe -m pytest
215 passed, 1 warning in 9.13s
```

Refs #45
Closes #45

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_