### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-usage"
-version = "0.2.0"
+version = "0.3.0"
 description = "Parse Claude Code session data and generate an interactive HTML usage dashboard"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

One-line `pyproject.toml` bump from `0.2.0` → `0.3.0` ahead of cutting the repo's first git tag and GitHub release.

## Why now

- `0.2.0` was set by PR #33 (Issue #19, session-summary) but never tagged.
- Since then, Issue #41 (nested sub-agent attribution, PR #42) shipped — a substantial new feature in `parser.py`, `aggregator.py`, and the dashboard — plus the Issue #45 polish umbrella (PRs #51, #52, #53, #54) and follow-up fixes #43, #44, #40, #49.
- Under pre-1.0 semver conventions the new feature warrants a minor bump. Tagging the post-#41 state as 0.3.0 is the right baseline before the project is converted into a Claude Code plugin.

## Follow-up (post-merge)

Issue #55 tracks the remaining work — creating the annotated `v0.3.0` tag and the GitHub release.

Refs #55

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_