### PR TITLE
Reframe plugin description: analyzer with recommendations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-prospector",
   "version": "0.4.0",
-  "description": "Claude Code token usage dashboard with three-bucket billing windows (5h / 7d / Sonnet-7d), per-model and per-agent attribution including nested sub-agent paths, and skill adoption tracking.",
+  "description": "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill.",
   "author": {
     "name": "Christopher Beaulieu",
     "email": "cmb_dev@outlook.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "claude-prospector"
 version = "0.4.0"
-description = "Parse Claude Code session data and generate an interactive HTML usage dashboard"
+description = "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill."
 requires-python = ">=3.10"
 dependencies = [
     "jinja2>=3.1",


### PR DESCRIPTION
## Summary

Updates `.claude-plugin/plugin.json` and `pyproject.toml` `[project] description` to lead with the **analyzer + recommendations** framing instead of "dashboard". The bundled `usage-analysis` skill is a conversational analysis surface that produces concrete optimization advice based on captured session data — the previous "dashboard" framing undersold it.

## Diff

Both files now use this string:

> Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill.

## Companion PR

The marketplace registration in `glitchwerks/plugins` (PR #4 there) is being amended to match this description before merge so users see the same framing in `claude plugin list`.

## Test plan

- [x] `plugin.json` parses as valid JSON
- [x] `uv run pytest` still green (no behavior change)

Closes #68
Part of #14

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_