### PR TITLE
README: lead with plugin usage, demote Python-module CLI to dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # claude-prospector
 
-Parse Claude Code session data and generate an interactive HTML dashboard showing token consumption by model, agent, skill, project, and time period.
+Token usage analyzer for Claude Code that surfaces where your budget is going across all three billing windows, with per-model and per-agent attribution and concrete optimization recommendations.
 
 ## Why
 
 Claude Code tracks three billing buckets (5h rolling, 7d rolling, Sonnet-only 7d) but provides no per-agent or per-skill visibility. This tool reads Claude Code's local JSONL session files and generates a dashboard that breaks down where your tokens are going.
 
-## Install as a Claude Code Plugin
+## Install as a Claude Code plugin
 
 The easiest way to use `claude-prospector` is as a Claude Code plugin — no manual
 cloning or path configuration required.
@@ -16,32 +16,40 @@ claude plugin marketplace add glitchwerks/plugins
 claude plugin install claude-prospector@glitchwerks
 ```
 
-### Python prerequisite
+### Prerequisite: Python package
 
 The plugin invokes `python -m claude_prospector` under the hood, so the Python
-package must be installed in the environment Claude Code runs in. Two options:
+package must be importable in the environment Claude Code uses. Install with either:
 
-**From a local clone** (recommended for development):
+- **From a local clone**: `uv pip install -e .`
+- **Directly from GitHub**: `uv pip install "git+https://github.com/glitchwerks/claude-prospector.git"`
+
+> A future enhancement (#67) tracks eliminating this two-step install so `claude plugin update` is sufficient on its own.
+
+## What the plugin provides
+
+The v0.4.0 plugin scaffold is in place; the following capabilities ship in the planned plugin phases:
+
+- **Interactive dashboard** — HTML report with three-bucket budget gauges (5h / 7d / Sonnet-7d), per-model donut and bar charts, per-agent token attribution with nested sub-agent tracing, skill-invocation counts, and per-project breakdowns.
+- **Conversational analysis skill** (`usage-analysis`) — answers questions like "am I close to my Sonnet limit?", "where are my tokens going?", and "which agent uses the most?" with concrete recommendations. Coming in a later plugin phase.
+- **Slash command** (`/usage-dashboard`) — explicit invocation for power users. Coming in a later plugin phase.
+- **Stop hook (opt-in)** — auto-regenerate the dashboard after every session. Coming in a later plugin phase.
+
+## Development / Standalone CLI
+
+For working on the package directly, or running it without the Claude Code plugin.
+
+### Install for development
 
 ```bash
-uv pip install -e .
-```
-
-**Directly from GitHub** (no clone needed):
-
-```bash
-uv pip install "git+https://github.com/glitchwerks/claude-prospector.git"
-```
-
-## Install
-
-```bash
-pip install -e .
+git clone https://github.com/cbeaulieu-gt/claude-prospector.git
+cd claude-prospector
+uv pip install -e ".[dev]"   # installs runtime + ruff + pytest
 ```
 
 Requires Python 3.10+.
 
-## Usage
+### Run the CLI directly
 
 ```bash
 # Default: last 7 days, opens in browser
@@ -64,12 +72,11 @@ python -m claude_prospector --data-dir "D:\other\.claude"
 python -m claude_prospector --limit-5h 600000 --limit-7d 4000000 --limit-sonnet-7d 2000000
 ```
 
-## Subcommands
+### Subcommands
 
-After the subparser refactor, all functionality is accessed through named
-subcommands. Bare `claude-prospector` prints help and exits 0.
+All functionality is accessed through named subcommands. Bare `claude-prospector` prints help and exits 0.
 
-### `dashboard` — interactive HTML dashboard
+#### `dashboard` — interactive HTML dashboard
 
 ```bash
 # Default: last 7 days, opens in browser
@@ -99,7 +106,7 @@ claude-prospector dashboard --format json
 All flags are unchanged from the pre-refactor form — only their location
 moved (now under the `dashboard` subparser).
 
-### `session-summary` — deterministic session recap (new in v0.2.0)
+#### `session-summary` — deterministic session recap (new in v0.2.0)
 
 Reads a single Claude Code transcript JSONL file and emits a structured
 JSON summary suitable for consumption by the `/whats-next` skill or any
@@ -144,7 +151,7 @@ claude-prospector session-summary --path ~/.claude/projects/<hash>/<session>.jso
 
 On any non-zero exit, stdout is empty and stderr contains exactly one line.
 
-### Migration note
+#### Migration note
 
 The old flag-only form **no longer works** after v0.2.0:
 
@@ -158,6 +165,29 @@ claude-prospector dashboard --format json
 
 Any script, skill, or CI step that invokes `claude-prospector` with bare flags
 (no subcommand) must be updated to use `claude-prospector dashboard [flags]`.
+
+### Testing
+
+```bash
+pytest                # ~151 tests, typically finishes in under 5 seconds
+```
+
+### Linting & formatting
+
+```bash
+ruff check .          # lint
+ruff format .         # autoformat in-place
+ruff format --check . # format gate (used in CI — exits non-zero on drift)
+```
+
+### CI
+
+GitHub Actions runs on every PR and push to `main`:
+
+- **lint** (Ubuntu): `ruff check .` + `ruff format --check .`
+- **test** (Ubuntu + Windows, Python 3.10): `pytest`
+
+Both jobs must be green before a PR can merge.
 
 ## Nested agent attribution
 
@@ -221,36 +251,3 @@ The generated HTML dashboard includes:
 ## How It Works
 
 Reads JSONL session files from `~/.claude/projects/`. Each session file contains timestamped assistant messages with model name and token usage. Subagent metadata (`.meta.json`) maps child agent tokens to their agent type. Skill invocations are extracted from `Skill` tool-use entries.
-
-## Development
-
-### Setup
-
-```bash
-git clone https://github.com/cbeaulieu-gt/claude-prospector.git
-cd claude-prospector
-uv pip install -e ".[dev]"   # installs runtime + ruff + pytest
-```
-
-### Testing
-
-```bash
-pytest                # ~151 tests, typically finishes in under 5 seconds
-```
-
-### Linting & formatting
-
-```bash
-ruff check .          # lint
-ruff format .         # autoformat in-place
-ruff format --check . # format gate (used in CI — exits non-zero on drift)
-```
-
-### CI
-
-GitHub Actions runs on every PR and push to `main`:
-
-- **lint** (Ubuntu): `ruff check .` + `ruff format --check .`
-- **test** (Ubuntu + Windows, Python 3.10): `pytest`
-
-Both jobs must be green before a PR can merge.


### PR DESCRIPTION
This PR restructures README.md so a plugin user can find what they need in under 5 seconds, while preserving every CLI flag and example for developers.

**Before/after section changes:**

- "Install as a Claude Code Plugin" was the third section after a generic install block; it is now the primary install section at the top, immediately after Why
- Old `## Install` (bare `pip install -e .`) — removed; superseded by the plugin prerequisite and the dev install under Development
- Old `## Usage` (`python -m claude_prospector` examples) — removed as a top-level section; moved intact under `## Development / Standalone CLI > ### Run the CLI directly`
- Old `## Subcommands` (dashboard, session-summary, migration note) — removed as a top-level section; moved intact under `## Development / Standalone CLI > ### Subcommands` with `####` subheadings
- New `## What the plugin provides` section added — honest about v0.4.0 scaffold state, marks future capabilities as "Coming in a later plugin phase"
- Intro sentence reframed from "Parse Claude Code session data and generate an interactive HTML dashboard..." to the analyzer+recommendations framing from #68 / PR #69
- `## Development` setup content consolidated under `## Development / Standalone CLI`; no content dropped

**Test plan:**

- [ ] Scan README: plugin install steps (`claude plugin marketplace add` / `claude plugin install`) reachable in under 5 seconds
- [ ] Scan README: developer install (`uv pip install -e ".[dev]"`) reachable under `## Development / Standalone CLI` in under 15 seconds
- [ ] Confirm no duplicate `## Install` or `## Usage` H2 headings
- [ ] Confirm all 8 `python -m claude_prospector` examples still present

Closes #71

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
