### PR TITLE
Phase 3: add /usage-dashboard slash command

### DIFF
--- a/commands/usage-dashboard.md
+++ b/commands/usage-dashboard.md
@@ -1,0 +1,71 @@
+---
+allowed-tools: Bash(python:*)
+description: Generate the Claude Code token usage dashboard (5h / 7d / Sonnet-7d windows)
+---
+
+# `/usage-dashboard` — generate the Claude Code token usage dashboard
+
+You are running the user's `claude-prospector` plugin to regenerate the interactive
+HTML token-usage dashboard. The user invoked this command explicitly, so produce the
+dashboard and report the output path. Do not interpret the data — the conversational
+analysis path lives in the `usage-analysis` skill; this command is the bare
+"regenerate the file" surface.
+
+## Default behavior
+
+If the user passes no arguments, run the **7-day rolling** window (matches the most
+useful billing bucket) and write the dashboard to the platform-appropriate path:
+
+- POSIX: `$HOME/.claude/usage-dashboard.html`
+- Windows: `%USERPROFILE%\.claude\usage-dashboard.html`
+
+Pass `--no-open` so the file lands at the known path without spawning a browser tab —
+that side effect is usually unwanted from inside a Claude Code session.
+
+```bash
+# POSIX
+python -m claude_prospector dashboard --window 7d --output "$HOME/.claude/usage-dashboard.html" --no-open
+
+# Windows
+python -m claude_prospector dashboard --window 7d --output "%USERPROFILE%\.claude\usage-dashboard.html" --no-open
+```
+
+The CLI prints `Dashboard written to <path>` to stdout on success. Echo that line
+back to the user so they have the absolute path to open or read.
+
+## Arguments
+
+The user may pass any of these. Forward them through to the underlying CLI; do not
+re-interpret.
+
+| Argument | Behavior |
+| --- | --- |
+| `--window 5h` | 5-hour rolling window — useful for "how am I doing right now in this session". |
+| `--window 7d` | 7-day rolling window (default). |
+| `--window 30d` | 30-day rolling window — useful for monthly trend context. Larger windows are slower; flag that if `--window` exceeds 30d. |
+| `--from YYYY-MM-DD --to YYYY-MM-DD` | Explicit date range. Mutually exclusive with `--window`. If both are supplied, surface the conflict and ask which one to use. |
+| Any other CLI flag (`--limit-5h`, `--limit-7d`, `--limit-sonnet-7d`, `--format json`, `--data-dir`, etc.) | Forward verbatim. See `python -m claude_prospector dashboard --help` for the full surface. |
+
+Always include `--output <path>` and `--no-open` in the final command line, even
+when the user passed neither — they are quality-of-life defaults for the slash
+command's invocation context.
+
+## When the dashboard already exists
+
+The CLI overwrites `--output` unconditionally. Do not pre-check or back-up the
+existing file — that's the user's job if they want one. Just regenerate.
+
+## Errors
+
+If the CLI exits non-zero, capture stderr and surface it to the user verbatim
+under a `**Dashboard generation failed:**` heading. Common causes:
+
+- `python` not on PATH — the user has not installed the Python package; point them
+  at the README's `## Install as a Claude Code plugin` § `### Prerequisite: Python
+  package` section.
+- `ModuleNotFoundError: claude_prospector` — same cause as above; the plugin is
+  installed but the package isn't.
+- Permission errors on the output path — surface verbatim and suggest passing a
+  different `--output`.
+
+Do not retry; surface the error and stop.


### PR DESCRIPTION
## Summary

Adds `commands/usage-dashboard.md` — explicit-invocation slash command for the `claude-prospector` plugin. Forwards to `python -m claude_prospector dashboard` with quality-of-life defaults (`--no-open`, output to `~/.claude/usage-dashboard.html`).

The skill (`usage-analysis`) is the conversational analysis surface; the command is the bare regenerate-the-file surface for power users.

## Deliverable

`commands/usage-dashboard.md` with frontmatter:

```yaml
---
allowed-tools: Bash(python:*)
description: Generate the Claude Code token usage dashboard (5h / 7d / Sonnet-7d windows)
---
```

Body documents:
- Default 7d rolling window
- Output path with POSIX + Windows pairs
- `--no-open` baked into the invocation (headless context)
- Examples for `--window 5h/7d/30d`, `--from/--to` date range, and arbitrary flag passthrough
- Error-surface guidance (missing python, ModuleNotFoundError, permission failures)

## Test plan

- [x] `claude plugin validate <repo>` passes
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes (26 files formatted)
- [x] `uv run pytest` → 215 passed (matches main)
- [x] Leak audit: no hard-coded user paths, no claude-usage references, no harness-specific examples

## Out of scope

- Hooks (Phase 4)
- Removing the user's local skill copy + local Stop hook glue (Phase 5)

Closes #79
Part of #14

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_