### PR TITLE
Phase 4b: ship dashboard-regen Stop hook + config CLI + version-pin check

### DIFF
--- a/claude_prospector/__init__.py
+++ b/claude_prospector/__init__.py
@@ -1,3 +1,10 @@
 """Claude Prospector — Claude Code usage analytics dashboard."""
 
-__version__ = "0.1.0"
+from __future__ import annotations
+
+try:
+    import importlib.metadata as _meta
+
+    __version__: str = _meta.version("claude-prospector")
+except Exception:
+    __version__ = "0.0.0+local"

--- a/claude_prospector/__main__.py
+++ b/claude_prospector/__main__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import sys
 
-from claude_prospector.cli import dashboard, session_summary
+import claude_prospector
+from claude_prospector.cli import config, dashboard, session_summary
 
 
 def main() -> None:
@@ -18,6 +19,11 @@ def main() -> None:
             "Run 'claude-prospector <subcommand> --help' for details."
         ),
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"claude-prospector {claude_prospector.__version__}",
+    )
     subparsers = parser.add_subparsers(
         dest="subcommand",
         metavar="subcommand",
@@ -25,6 +31,7 @@ def main() -> None:
 
     dashboard.build_parser(subparsers)
     session_summary.build_parser(subparsers)
+    config.build_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -37,6 +44,9 @@ def main() -> None:
 
     if args.subcommand == "session-summary":
         sys.exit(session_summary.run(args))
+
+    if args.subcommand == "config":
+        sys.exit(config.run(args))
 
 
 if __name__ == "__main__":

--- a/claude_prospector/cli/config.py
+++ b/claude_prospector/cli/config.py
@@ -1,0 +1,184 @@
+"""Config subcommand for claude-prospector.
+
+Manages the plugin configuration file at the path returned by
+:func:`claude_prospector.paths.config_path` (default:
+``~/.claude/claude-prospector/config.json``).
+
+The config file is a JSON object. Currently the only supported key is
+``autoregen`` (bool) which controls whether the Stop hook regenerates
+the dashboard at the end of every session.
+
+Subcommand flags (mutually exclusive):
+
+- ``--enable-autoregen``  Sets ``{"autoregen": true}`` (creates file if
+  absent; preserves other keys).
+- ``--disable-autoregen`` Sets ``{"autoregen": false}``.
+- ``--show``              Pretty-prints the current config to stdout.
+  Exits 0 whether or not the file exists.
+
+Running ``python -m claude_prospector config`` with no flags prints
+subcommand help and exits 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from claude_prospector.paths import config_path
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_config(path: Path) -> dict:
+    """Read and parse the config file.
+
+    Returns an empty dict when the file does not exist; propagates
+    :class:`json.JSONDecodeError` on malformed content so the caller can
+    surface a useful error.
+
+    Args:
+        path: Path to the config JSON file.
+
+    Returns:
+        Parsed config dict, or ``{}`` if the file is absent.
+
+    Raises:
+        json.JSONDecodeError: If the file exists but is not valid JSON.
+    """
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_config(path: Path, cfg: dict) -> None:
+    """Write a config dict to *path* as pretty-printed JSON.
+
+    Creates parent directories as needed.
+
+    Args:
+        path: Destination path.
+        cfg: Config mapping to serialise.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Subparser registration
+# ---------------------------------------------------------------------------
+
+
+def build_parser(
+    parent: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Register the 'config' subparser and return it.
+
+    Args:
+        parent: The subparsers action from the top-level parser.
+
+    Returns:
+        The configured config ArgumentParser.
+    """
+    p = parent.add_parser(
+        "config",
+        help=("Read or update the claude-prospector configuration file."),
+    )
+    group = p.add_mutually_exclusive_group()
+    group.add_argument(
+        "--enable-autoregen",
+        action="store_true",
+        default=False,
+        dest="enable_autoregen",
+        help=(
+            "Enable automatic dashboard regeneration on session end "
+            "(sets autoregen=true in config.json)."
+        ),
+    )
+    group.add_argument(
+        "--disable-autoregen",
+        action="store_true",
+        default=False,
+        dest="disable_autoregen",
+        help=(
+            "Disable automatic dashboard regeneration "
+            "(sets autoregen=false in config.json)."
+        ),
+    )
+    group.add_argument(
+        "--show",
+        action="store_true",
+        default=False,
+        dest="show",
+        help="Print the current config as pretty-printed JSON and exit.",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the config subcommand.
+
+    Args:
+        args: Parsed argument namespace. Expected attributes:
+            ``args.enable_autoregen`` (bool),
+            ``args.disable_autoregen`` (bool),
+            ``args.show`` (bool).
+
+    Returns:
+        Integer exit code (0 on success).
+    """
+    path = config_path()
+
+    # ── --show ───────────────────────────────────────────────────────────
+    if args.show:
+        if not path.exists():
+            print("(no config file yet)", file=sys.stderr)
+            print("{}")
+            return 0
+        try:
+            cfg = _read_config(path)
+        except json.JSONDecodeError as exc:
+            print(
+                f"config: malformed JSON in '{path}': {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        print(json.dumps(cfg, indent=2))
+        return 0
+
+    # ── --enable-autoregen / --disable-autoregen ─────────────────────────
+    if args.enable_autoregen or args.disable_autoregen:
+        try:
+            cfg = _read_config(path)
+        except json.JSONDecodeError as exc:
+            print(
+                f"config: malformed JSON in '{path}': {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        cfg["autoregen"] = args.enable_autoregen
+        _write_config(path, cfg)
+        state = "enabled" if args.enable_autoregen else "disabled"
+        print(f"autoregen {state} (config: {path})")
+        return 0
+
+    # ── No flags — print help ─────────────────────────────────────────────
+    # Re-parse with --help to get consistent help output via argparse.
+    # We can't easily reach the subparser from here without plumbing, so
+    # print a minimal usage note instead.
+    print(
+        "Usage: claude-prospector config "
+        "[--enable-autoregen | --disable-autoregen | --show]"
+    )
+    print("Run 'claude-prospector config --help' for full help.")
+    return 0

--- a/claude_prospector/paths.py
+++ b/claude_prospector/paths.py
@@ -1,0 +1,107 @@
+"""Central path resolution for all claude-prospector persistent state.
+
+All paths under ``~/.claude/claude-prospector/`` are resolved through
+this module so hook scripts, the CLI, and reader code all agree on
+locations without duplicating defaults.
+
+Each function checks its own environment variable first; if set, returns
+that path verbatim. Otherwise it builds from :func:`base_dir`.
+
+Environment variable overrides (useful for testing):
+
+- ``CLAUDE_PROSPECTOR_BASE_DIR`` — overrides the base directory.
+- ``CLAUDE_PROSPECTOR_CONFIG`` — overrides :func:`config_path`.
+- ``CLAUDE_PROSPECTOR_DASHBOARD`` — overrides :func:`dashboard_path`.
+- ``CLAUDE_PROSPECTOR_HOOK_LOG`` — overrides :func:`hook_log_path`.
+- ``CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR`` — overrides
+  :func:`skill_tracking_dir`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BASE = Path.home() / ".claude" / "claude-prospector"
+
+
+def base_dir() -> Path:
+    """Return the base directory for all claude-prospector persistent state.
+
+    Defaults to ``~/.claude/claude-prospector/``. Override via the
+    ``CLAUDE_PROSPECTOR_BASE_DIR`` environment variable.
+
+    Returns:
+        Path to the base directory (not guaranteed to exist).
+    """
+    env_val = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
+    if env_val:
+        return Path(env_val)
+    return _DEFAULT_BASE
+
+
+def config_path() -> Path:
+    """Return the path to the settings JSON file.
+
+    Defaults to ``base_dir() / "config.json"``. Override via the
+    ``CLAUDE_PROSPECTOR_CONFIG`` environment variable.
+
+    Returns:
+        Path to the config file (not guaranteed to exist).
+    """
+    env_val = os.environ.get("CLAUDE_PROSPECTOR_CONFIG")
+    if env_val:
+        return Path(env_val)
+    return base_dir() / "config.json"
+
+
+def dashboard_path() -> Path:
+    """Return the path to the generated dashboard HTML file.
+
+    Defaults to ``base_dir() / "dashboard.html"``. Override via the
+    ``CLAUDE_PROSPECTOR_DASHBOARD`` environment variable.
+
+    Returns:
+        Path to the dashboard file (not guaranteed to exist).
+    """
+    env_val = os.environ.get("CLAUDE_PROSPECTOR_DASHBOARD")
+    if env_val:
+        return Path(env_val)
+    return base_dir() / "dashboard.html"
+
+
+def hook_log_path() -> Path:
+    """Return the path to the hook diagnostic log file.
+
+    Defaults to ``base_dir() / "hook.log"``. Override via the
+    ``CLAUDE_PROSPECTOR_HOOK_LOG`` environment variable.
+
+    The log is truncated on each hook run (last-run-wins), so it never
+    grows unbounded.
+
+    Returns:
+        Path to the hook log file (not guaranteed to exist).
+    """
+    env_val = os.environ.get("CLAUDE_PROSPECTOR_HOOK_LOG")
+    if env_val:
+        return Path(env_val)
+    return base_dir() / "hook.log"
+
+
+def skill_tracking_dir() -> Path:
+    """Return the directory used for per-day skill-tracking JSONL files.
+
+    Defaults to ``base_dir() / "skill-tracking"``. Override via the
+    ``CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR`` environment variable.
+
+    Returns:
+        Path to the skill-tracking directory (not guaranteed to exist).
+    """
+    env_val = os.environ.get("CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR")
+    if env_val:
+        return Path(env_val)
+    return base_dir() / "skill-tracking"

--- a/hooks/dashboard-regen.py
+++ b/hooks/dashboard-regen.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Stop hook: regenerate the claude-prospector dashboard on session end.
+
+This script is registered as a Claude Code Stop hook in hooks/hooks.json.
+It fires at the end of every session. Whether it actually does work is
+controlled by the ``autoregen`` key in the plugin config file — when
+``autoregen`` is false (or the config file is absent) the hook exits
+immediately as a no-op so users who haven't opted in are unaffected.
+
+The Stop hook is registered unconditionally in hooks.json rather than
+conditionally based on config because:
+- If registration were conditional on config, users would have to
+  reinstall the plugin to toggle autoregen.
+- A fast no-op on every session end is cheaper than re-install friction.
+
+Path resolution:
+    All paths are resolved via env-var overrides first, then default to
+    ``~/.claude/claude-prospector/``. The env vars are:
+
+    - ``CLAUDE_PROSPECTOR_CONFIG``      — config file path.
+    - ``CLAUDE_PROSPECTOR_DASHBOARD``   — output dashboard file path.
+    - ``CLAUDE_PROSPECTOR_HOOK_LOG``    — hook diagnostic log path.
+    - ``CLAUDE_PLUGIN_ROOT``            — plugin install directory
+      (set by the hook runner; used to locate plugin.json).
+
+Test seam:
+    When ``CLAUDE_PROSPECTOR_FAIL_REGEN=1`` is set, the regen subprocess
+    is skipped and a synthetic failure is simulated so the failure-page
+    code path can be tested without a real crash.
+
+Exit codes:
+    Always 0. Hook failures must never propagate to the Claude Code
+    session runner — that would disrupt the user's workflow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path resolution (mirrors claude_prospector.paths without importing it)
+# ---------------------------------------------------------------------------
+# The hook script is invoked as a standalone Python file by the harness.
+# It cannot safely import claude_prospector without knowing the project
+# root is on sys.path. Rather than risk import failures, we replicate
+# the env-var path resolution inline (env var names are identical to
+# paths.py, so defaults are byte-for-byte compatible).
+
+
+def _base_dir() -> Path:
+    """Return the claude-prospector base directory.
+
+    Returns:
+        Path from CLAUDE_PROSPECTOR_BASE_DIR env var, or the default.
+    """
+    env = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".claude" / "claude-prospector"
+
+
+def _config_path() -> Path:
+    """Return the config file path.
+
+    Returns:
+        Path from CLAUDE_PROSPECTOR_CONFIG env var, or the default.
+    """
+    env = os.environ.get("CLAUDE_PROSPECTOR_CONFIG")
+    if env:
+        return Path(env)
+    return _base_dir() / "config.json"
+
+
+def _dashboard_path() -> Path:
+    """Return the dashboard HTML output path.
+
+    Returns:
+        Path from CLAUDE_PROSPECTOR_DASHBOARD env var, or the default.
+    """
+    env = os.environ.get("CLAUDE_PROSPECTOR_DASHBOARD")
+    if env:
+        return Path(env)
+    return _base_dir() / "dashboard.html"
+
+
+def _hook_log_path() -> Path:
+    """Return the hook diagnostic log path.
+
+    Returns:
+        Path from CLAUDE_PROSPECTOR_HOOK_LOG env var, or the default.
+    """
+    env = os.environ.get("CLAUDE_PROSPECTOR_HOOK_LOG")
+    if env:
+        return Path(env)
+    return _base_dir() / "hook.log"
+
+
+# ---------------------------------------------------------------------------
+# Version comparison
+# ---------------------------------------------------------------------------
+
+
+def _version_tuple(version_str: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a tuple of integers.
+
+    Handles simple dotted-numeric versions like "0.4.0". Non-numeric
+    segments are treated as 0 to stay robust against pre-release tags.
+
+    Args:
+        version_str: A version string such as "0.4.0" or "1.2.3+local".
+
+    Returns:
+        Tuple of ints, e.g. ``(0, 4, 0)``.
+    """
+    # Strip any local/build suffix (e.g. "0.0.0+local" → "0.0.0")
+    base = version_str.split("+")[0].split("-")[0]
+    parts = []
+    for seg in base.split("."):
+        try:
+            parts.append(int(seg))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def _compare_versions(pkg_ver: str, manifest_ver: str) -> int:
+    """Compare two version strings.
+
+    Args:
+        pkg_ver: Package version string.
+        manifest_ver: Manifest (plugin.json) version string.
+
+    Returns:
+        Negative if pkg_ver < manifest_ver, 0 if equal, positive if
+        pkg_ver > manifest_ver.
+    """
+    try:
+        from packaging.version import Version
+
+        pv = Version(pkg_ver)
+        mv = Version(manifest_ver)
+        if pv < mv:
+            return -1
+        if pv > mv:
+            return 1
+        return 0
+    except Exception:
+        # Fall back to tuple comparison on dotted ints.
+        pt = _version_tuple(pkg_ver)
+        mt = _version_tuple(manifest_ver)
+        if pt < mt:
+            return -1
+        if pt > mt:
+            return 1
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# HTML page builders
+# ---------------------------------------------------------------------------
+
+
+def _timestamp() -> str:
+    """Return the current UTC time as an ISO 8601 string.
+
+    Returns:
+        ISO 8601 timestamp string with UTC timezone.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _html_page(title: str, heading: str, body_html: str) -> str:
+    """Build a minimal static HTML page.
+
+    Args:
+        title: Browser tab title.
+        heading: H1 heading text.
+        body_html: Raw HTML to insert in the page body after the heading.
+
+    Returns:
+        Complete HTML document as a string.
+    """
+    ts = _timestamp()
+    return f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{title}</title>
+  <style>
+    body {{ font-family: sans-serif; max-width: 800px; margin: 2rem auto;
+            padding: 0 1rem; }}
+    pre {{ background: #f4f4f4; padding: 1rem; overflow: auto;
+           white-space: pre-wrap; word-break: break-all; }}
+    footer {{ margin-top: 2rem; color: #888; font-size: 0.85em; }}
+  </style>
+</head>
+<body>
+  <h1>{heading}</h1>
+  {body_html}
+  <footer>Generated at {ts}</footer>
+</body>
+</html>
+"""
+
+
+def _write_page(path: Path, html: str) -> None:
+    """Write *html* to *path*, creating parent directories as needed.
+
+    Args:
+        path: Destination file path.
+        html: HTML content to write.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(html, encoding="utf-8")
+
+
+def _python_not_found_page() -> str:
+    """Build the 'Python not found' error page HTML.
+
+    Returns:
+        HTML page informing the user that the python executable failed.
+    """
+    body = """\
+<p>The dashboard could not be regenerated because the
+<code>python -m claude_prospector</code> command failed to start.</p>
+<p>Make sure the <code>claude-prospector</code> Python package is
+installed in the Python environment used by this plugin.</p>
+<p>See the plugin README for installation instructions:
+<code>~/.claude/plugins/cache/.../README.md#install-as-a-claude-code-plugin
+</code></p>
+"""
+    return _html_page(
+        "Python not found — claude-prospector",
+        "Python not found",
+        body,
+    )
+
+
+def _version_mismatch_page(pkg_ver: str, manifest_ver: str) -> str:
+    """Build the version-mismatch error page HTML.
+
+    Args:
+        pkg_ver: The installed Python package version.
+        manifest_ver: The plugin manifest version.
+
+    Returns:
+        HTML page explaining the version mismatch and how to upgrade.
+    """
+    body = f"""\
+<dl>
+  <dt>Plugin (manifest) version</dt><dd><code>{manifest_ver}</code></dd>
+  <dt>Python package version</dt><dd><code>{pkg_ver}</code></dd>
+  <dt>Required</dt>
+  <dd>package version &ge; {manifest_ver}</dd>
+</dl>
+<p>To upgrade the Python package, run:</p>
+<pre>uv pip install --upgrade \
+"git+https://github.com/glitchwerks/claude-prospector.git"</pre>
+<p>Then restart Claude Code to pick up the new version.</p>
+"""
+    return _html_page(
+        "claude-prospector version mismatch",
+        "claude-prospector version mismatch",
+        body,
+    )
+
+
+def _regen_failed_page(stderr_output: str) -> str:
+    """Build the 'regen failed' error page HTML.
+
+    Args:
+        stderr_output: Captured stderr from the failed regen subprocess.
+
+    Returns:
+        HTML page with the captured error output.
+    """
+    import html as _html_mod
+
+    escaped = _html_mod.escape(stderr_output)
+    body = f"""\
+<p>The dashboard regeneration command exited with a non-zero status.</p>
+<p>Captured error output:</p>
+<pre>{escaped}</pre>
+<p>To diagnose, run manually:</p>
+<pre>python -m claude_prospector dashboard --window 7d</pre>
+"""
+    return _html_page(
+        "Dashboard regeneration failed — claude-prospector",
+        "Dashboard regeneration failed",
+        body,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hook log
+# ---------------------------------------------------------------------------
+
+
+def _log(message: str) -> None:
+    """Truncate-on-each-run log write. Silently swallows IO errors.
+
+    Args:
+        message: Diagnostic text to record.
+    """
+    try:
+        log_path = _hook_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "w", encoding="utf-8") as f:
+            f.write(f"[{_timestamp()}] {message}\n")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Entry point for the Stop hook. Returns process exit code.
+
+    Steps:
+    1. Consume stdin (Stop hook payload — content not needed).
+    2. Load config. If autoregen != true, exit 0 as a no-op.
+    3. Check manifest version vs. package version; write mismatch page on
+       downgrade.
+    4. Run regen subprocess. Write failure page on non-zero exit.
+    5. Log success and exit 0.
+
+    Returns:
+        Always 0 — hook failures must not propagate to the session runner.
+    """
+    try:
+        # Step 1: consume stdin so the process closes cleanly.
+        _stdin = sys.stdin.read()
+
+        # Step 2: load config.
+        cfg_path = _config_path()
+        if not cfg_path.exists():
+            return 0  # No config → autoregen not enabled.
+
+        try:
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        except Exception:
+            return 0  # Malformed config → no-op.
+
+        if not cfg.get("autoregen"):
+            return 0  # autoregen disabled.
+
+        dashboard = _dashboard_path()
+
+        # Step 3: version-pin check.
+        plugin_root_env = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+        manifest_ver: str | None = None
+        if plugin_root_env:
+            manifest_path = Path(plugin_root_env) / "plugin.json"
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                manifest_ver = manifest.get("version")
+            except Exception:
+                manifest_ver = None
+
+        # Get package version via subprocess.
+        try:
+            ver_result = subprocess.run(
+                [sys.executable, "-m", "claude_prospector", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=str(Path(sys.executable).parent.parent.parent),
+            )
+            if ver_result.returncode != 0:
+                _write_page(dashboard, _python_not_found_page())
+                return 0
+            # Output is like "claude-prospector 0.4.0"
+            raw_ver = ver_result.stdout.strip() + ver_result.stderr.strip()
+            # Extract the version token (last whitespace-separated segment)
+            pkg_ver = raw_ver.split()[-1] if raw_ver.split() else "0.0.0"
+        except FileNotFoundError:
+            _write_page(dashboard, _python_not_found_page())
+            return 0
+        except Exception:
+            _write_page(dashboard, _python_not_found_page())
+            return 0
+
+        if manifest_ver and _compare_versions(pkg_ver, manifest_ver) < 0:
+            _write_page(dashboard, _version_mismatch_page(pkg_ver, manifest_ver))
+            return 0
+
+        # Test seam: CLAUDE_PROSPECTOR_FAIL_REGEN=1 simulates a failure.
+        if os.environ.get("CLAUDE_PROSPECTOR_FAIL_REGEN") == "1":
+            _write_page(
+                dashboard,
+                _regen_failed_page(
+                    "Simulated regen failure (CLAUDE_PROSPECTOR_FAIL_REGEN=1)"
+                ),
+            )
+            return 0
+
+        # Step 4: run the regen.
+        regen_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "dashboard",
+                "--window",
+                "7d",
+                "--output",
+                str(dashboard),
+                "--no-open",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(Path(sys.executable).parent.parent.parent),
+        )
+
+        if regen_result.returncode != 0:
+            _write_page(dashboard, _regen_failed_page(regen_result.stderr))
+            return 0
+
+        # Step 5: log success.
+        _log(f"Dashboard regenerated successfully → {dashboard}")
+
+    except Exception as exc:
+        sys.stderr.write(f"[dashboard-regen] unexpected error: {exc}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/skill-tracker.py\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/dashboard-regen.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,222 @@
+"""Tests for 'python -m claude_prospector config' subcommand.
+
+All subprocess invocations redirect the config file path via the
+``CLAUDE_PROSPECTOR_CONFIG`` environment variable so tests never touch
+the real home directory.
+
+Covers:
+- ``--enable-autoregen`` creates the config file with autoregen=true.
+- ``--disable-autoregen`` sets autoregen=false (and creates file if absent).
+- ``--show`` prints the current config; reports "(no config file yet)" when
+  absent.
+- Mutual exclusion: combining two flags exits non-zero.
+- No flags: prints usage hint, exits 0.
+- ``--show`` preserves extra keys in the config file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Worktree root — keeps subprocess CWD off the main repo so the empty-
+# string sys.path entry resolves to the worktree package.
+_WORKTREE = Path(__file__).parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _run_config(
+    *args: str,
+    config_path: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the config subcommand with config redirected to *config_path*.
+
+    Args:
+        *args: Additional flags to pass after ``config``.
+        config_path: Path to use as the config file (via env var override).
+        extra_env: Extra environment variables to merge in.
+
+    Returns:
+        CompletedProcess with stdout, stderr, and returncode.
+    """
+    env = {**os.environ, "CLAUDE_PROSPECTOR_CONFIG": str(config_path)}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "claude_prospector", "config", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(_WORKTREE),
+    )
+
+
+# ---------------------------------------------------------------------------
+# --enable-autoregen
+# ---------------------------------------------------------------------------
+
+
+class TestEnableAutoregen:
+    """Tests for the --enable-autoregen flag."""
+
+    def test_creates_config_file_when_absent(self, tmp_path: Path) -> None:
+        """--enable-autoregen creates config.json when it doesn't exist."""
+        cfg_path = tmp_path / "config.json"
+        assert not cfg_path.exists()
+        result = _run_config("--enable-autoregen", config_path=cfg_path)
+        assert result.returncode == 0, result.stderr
+        assert cfg_path.exists()
+
+    def test_sets_autoregen_true(self, tmp_path: Path) -> None:
+        """--enable-autoregen writes autoregen=true to the config file."""
+        cfg_path = tmp_path / "config.json"
+        result = _run_config("--enable-autoregen", config_path=cfg_path)
+        assert result.returncode == 0, result.stderr
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert cfg["autoregen"] is True
+
+    def test_preserves_other_keys(self, tmp_path: Path) -> None:
+        """--enable-autoregen preserves existing keys in the config file."""
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"some_other_key": 42}), encoding="utf-8")
+        _run_config("--enable-autoregen", config_path=cfg_path)
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert cfg["some_other_key"] == 42
+        assert cfg["autoregen"] is True
+
+    def test_overwrites_false_to_true(self, tmp_path: Path) -> None:
+        """--enable-autoregen flips autoregen from false to true."""
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"autoregen": False}), encoding="utf-8")
+        _run_config("--enable-autoregen", config_path=cfg_path)
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert cfg["autoregen"] is True
+
+
+# ---------------------------------------------------------------------------
+# --disable-autoregen
+# ---------------------------------------------------------------------------
+
+
+class TestDisableAutoregen:
+    """Tests for the --disable-autoregen flag."""
+
+    def test_creates_config_file_when_absent(self, tmp_path: Path) -> None:
+        """--disable-autoregen creates config.json when it doesn't exist."""
+        cfg_path = tmp_path / "config.json"
+        result = _run_config("--disable-autoregen", config_path=cfg_path)
+        assert result.returncode == 0, result.stderr
+        assert cfg_path.exists()
+
+    def test_sets_autoregen_false(self, tmp_path: Path) -> None:
+        """--disable-autoregen writes autoregen=false."""
+        cfg_path = tmp_path / "config.json"
+        result = _run_config("--disable-autoregen", config_path=cfg_path)
+        assert result.returncode == 0, result.stderr
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert cfg["autoregen"] is False
+
+    def test_flips_true_to_false(self, tmp_path: Path) -> None:
+        """--disable-autoregen flips autoregen from true to false."""
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"autoregen": True}), encoding="utf-8")
+        _run_config("--disable-autoregen", config_path=cfg_path)
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert cfg["autoregen"] is False
+
+
+# ---------------------------------------------------------------------------
+# --show
+# ---------------------------------------------------------------------------
+
+
+class TestShow:
+    """Tests for the --show flag."""
+
+    def test_exits_zero_when_file_present(self, tmp_path: Path) -> None:
+        """--show exits 0 when the config file exists."""
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"autoregen": True}), encoding="utf-8")
+        result = _run_config("--show", config_path=cfg_path)
+        assert result.returncode == 0
+
+    def test_prints_config_as_json(self, tmp_path: Path) -> None:
+        """--show prints the config as valid JSON to stdout."""
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"autoregen": True}), encoding="utf-8")
+        result = _run_config("--show", config_path=cfg_path)
+        parsed = json.loads(result.stdout)
+        assert parsed["autoregen"] is True
+
+    def test_exits_zero_when_file_absent(self, tmp_path: Path) -> None:
+        """--show exits 0 even when the config file does not exist."""
+        cfg_path = tmp_path / "nonexistent-config.json"
+        result = _run_config("--show", config_path=cfg_path)
+        assert result.returncode == 0
+
+    def test_reports_no_config_on_stderr_when_absent(self, tmp_path: Path) -> None:
+        """--show writes a '(no config file yet)' note to stderr when absent."""
+        cfg_path = tmp_path / "nonexistent-config.json"
+        result = _run_config("--show", config_path=cfg_path)
+        assert "(no config file yet)" in result.stderr
+
+    def test_prints_empty_braces_to_stdout_when_absent(self, tmp_path: Path) -> None:
+        """--show prints '{}' to stdout when the config file is absent."""
+        cfg_path = tmp_path / "nonexistent-config.json"
+        result = _run_config("--show", config_path=cfg_path)
+        assert result.stdout.strip() == "{}"
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestMutualExclusion:
+    """Tests for the mutually-exclusive flag group."""
+
+    def test_enable_and_disable_together_exits_nonzero(self, tmp_path: Path) -> None:
+        """--enable-autoregen and --disable-autoregen together must fail."""
+        cfg_path = tmp_path / "config.json"
+        result = _run_config(
+            "--enable-autoregen",
+            "--disable-autoregen",
+            config_path=cfg_path,
+        )
+        assert result.returncode != 0
+
+    def test_enable_and_show_together_exits_nonzero(self, tmp_path: Path) -> None:
+        """--enable-autoregen and --show together must fail."""
+        cfg_path = tmp_path / "config.json"
+        result = _run_config("--enable-autoregen", "--show", config_path=cfg_path)
+        assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# No flags
+# ---------------------------------------------------------------------------
+
+
+class TestNoFlags:
+    """Tests for bare 'config' subcommand with no flags."""
+
+    def test_no_flags_exits_zero(self, tmp_path: Path) -> None:
+        """'config' with no flags must exit 0 and print usage hint."""
+        cfg_path = tmp_path / "config.json"
+        result = _run_config(config_path=cfg_path)
+        assert result.returncode == 0
+
+    def test_no_flags_mentions_flags(self, tmp_path: Path) -> None:
+        """'config' with no flags must mention the available flags."""
+        cfg_path = tmp_path / "config.json"
+        result = _run_config(config_path=cfg_path)
+        combined = result.stdout + result.stderr
+        assert "autoregen" in combined

--- a/tests/test_dashboard_regen_hook.py
+++ b/tests/test_dashboard_regen_hook.py
@@ -1,0 +1,306 @@
+"""Tests for hooks/dashboard-regen.py Stop hook.
+
+The hook is invoked via subprocess with env vars redirecting all paths to
+``tmp_path`` directories so no real home-directory state is touched.
+
+The contract verified for each test:
+- autoregen=false: hook exits 0 and produces no dashboard file.
+- autoregen=true + missing python (patched): writes "Python not found" page.
+- autoregen=true + version mismatch: writes "version mismatch" page.
+- autoregen=true + regen success: dashboard.html exists with non-zero size.
+- autoregen=true + regen failure: writes "regen failed" page with stderr.
+
+Hook input:
+    The Stop hook payload is read from stdin. The hook ignores the payload
+    content — only autoregen config and the python subprocess matter. We
+    pass ``{}`` as the stdin payload.
+
+CWD note:
+    All subprocess invocations use ``cwd=str(_WORKTREE)`` so that the
+    empty-string sys.path entry resolves to the worktree package, not the
+    main repo checkout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_WORKTREE = Path(__file__).parent.parent
+_HOOK_PATH = _WORKTREE / "hooks" / "dashboard-regen.py"
+
+# Fake plugin.json manifest version (must be parseable as a version string)
+_MANIFEST_VERSION = "0.4.0"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_env(
+    tmp_path: Path,
+    *,
+    autoregen: bool,
+    manifest_version: str = _MANIFEST_VERSION,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build the subprocess environment for a hook invocation.
+
+    Creates:
+    - A config file under ``tmp_path/config.json`` with ``autoregen`` set.
+    - A plugin.json manifest under ``tmp_path/plugin-root/`` at the version
+      given by *manifest_version*.
+
+    Returns the env dict with all relevant CLAUDE_PROSPECTOR_* vars
+    pointing into tmp_path.
+
+    Args:
+        tmp_path: pytest temporary directory.
+        autoregen: Value to write for ``{"autoregen": <bool>}``.
+        manifest_version: Version string to embed in the plugin manifest.
+        extra: Extra vars to merge (last wins).
+
+    Returns:
+        Environment dict suitable for ``subprocess.run(..., env=...)``.
+    """
+    # Config file
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"autoregen": autoregen}), encoding="utf-8")
+
+    # Dashboard output dir
+    dashboard_file = tmp_path / "dashboard.html"
+
+    # Hook log
+    hook_log = tmp_path / "hook.log"
+
+    # Plugin manifest
+    plugin_root = tmp_path / "plugin-root"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    (plugin_root / "plugin.json").write_text(
+        json.dumps({"version": manifest_version}), encoding="utf-8"
+    )
+
+    env = {
+        **os.environ,
+        "CLAUDE_PROSPECTOR_CONFIG": str(cfg_path),
+        "CLAUDE_PROSPECTOR_DASHBOARD": str(dashboard_file),
+        "CLAUDE_PROSPECTOR_HOOK_LOG": str(hook_log),
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+    }
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _run_hook(
+    env: dict[str, str],
+    stdin_payload: dict | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke dashboard-regen.py as a subprocess.
+
+    Args:
+        env: Environment dict (from _make_env).
+        stdin_payload: JSON payload to write to stdin. Defaults to ``{}``.
+
+    Returns:
+        CompletedProcess with stdout, stderr, returncode.
+    """
+    payload = json.dumps(stdin_payload or {})
+    return subprocess.run(
+        [sys.executable, str(_HOOK_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(_WORKTREE),
+    )
+
+
+# ---------------------------------------------------------------------------
+# autoregen=false (no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoregenDisabled:
+    """When autoregen is false the hook must be a no-op."""
+
+    def test_exits_zero(self, tmp_path: Path) -> None:
+        """Hook exits 0 when autoregen=false."""
+        env = _make_env(tmp_path, autoregen=False)
+        result = _run_hook(env)
+        assert result.returncode == 0, result.stderr
+
+    def test_no_dashboard_written(self, tmp_path: Path) -> None:
+        """Hook does not create dashboard.html when autoregen=false."""
+        env = _make_env(tmp_path, autoregen=False)
+        dashboard = tmp_path / "dashboard.html"
+        _run_hook(env)
+        assert not dashboard.exists()
+
+    def test_no_config_file(self, tmp_path: Path) -> None:
+        """Hook exits 0 with no dashboard when config file is missing."""
+        env = {
+            **os.environ,
+            "CLAUDE_PROSPECTOR_CONFIG": str(tmp_path / "nonexistent-config.json"),
+            "CLAUDE_PROSPECTOR_DASHBOARD": str(tmp_path / "dashboard.html"),
+            "CLAUDE_PROSPECTOR_HOOK_LOG": str(tmp_path / "hook.log"),
+            "CLAUDE_PLUGIN_ROOT": str(tmp_path / "plugin-root"),
+        }
+        # Create a minimal plugin root so manifest parsing doesn't fail first
+        (tmp_path / "plugin-root").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "plugin-root" / "plugin.json").write_text(
+            json.dumps({"version": _MANIFEST_VERSION}), encoding="utf-8"
+        )
+        result = _run_hook(env)
+        assert result.returncode == 0
+        assert not (tmp_path / "dashboard.html").exists()
+
+
+# ---------------------------------------------------------------------------
+# autoregen=true + version mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestVersionMismatch:
+    """When the manifest version > package version, write the mismatch page."""
+
+    def test_writes_version_mismatch_page(self, tmp_path: Path) -> None:
+        """A higher manifest version causes the mismatch page to be written."""
+        # Set manifest version to something higher than the installed package
+        env = _make_env(tmp_path, autoregen=True, manifest_version="999.0.0")
+        _run_hook(env)
+        dashboard = tmp_path / "dashboard.html"
+        assert dashboard.exists(), "Expected mismatch page to be written"
+        content = dashboard.read_text(encoding="utf-8")
+        assert "mismatch" in content.lower() or "version" in content.lower()
+
+    def test_mismatch_page_shows_both_versions(self, tmp_path: Path) -> None:
+        """Mismatch page includes both manifest and package version info."""
+        env = _make_env(tmp_path, autoregen=True, manifest_version="999.0.0")
+        _run_hook(env)
+        content = (tmp_path / "dashboard.html").read_text(encoding="utf-8")
+        assert "999.0.0" in content
+
+    def test_exits_zero_on_mismatch(self, tmp_path: Path) -> None:
+        """Hook still exits 0 on version mismatch (no propagation to runner)."""
+        env = _make_env(tmp_path, autoregen=True, manifest_version="999.0.0")
+        result = _run_hook(env)
+        assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# autoregen=true + regen success
+# ---------------------------------------------------------------------------
+
+
+class TestRegenSuccess:
+    """When autoregen=true and versions match, the dashboard is regenerated."""
+
+    def test_dashboard_file_created(self, tmp_path: Path) -> None:
+        """Successful regen creates a non-empty dashboard.html."""
+        env = _make_env(tmp_path, autoregen=True)
+        result = _run_hook(env)
+        assert result.returncode == 0, result.stderr
+        dashboard = tmp_path / "dashboard.html"
+        assert (
+            dashboard.exists()
+        ), f"dashboard.html not created. stderr: {result.stderr!r}"
+        assert dashboard.stat().st_size > 0
+
+    def test_dashboard_is_html(self, tmp_path: Path) -> None:
+        """Regenerated dashboard.html contains HTML markup."""
+        env = _make_env(tmp_path, autoregen=True)
+        _run_hook(env)
+        content = (tmp_path / "dashboard.html").read_text(encoding="utf-8")
+        assert "<html" in content.lower() or "<!doctype" in content.lower()
+
+    def test_hook_log_written_on_success(self, tmp_path: Path) -> None:
+        """On success the hook writes a log entry to hook.log."""
+        env = _make_env(tmp_path, autoregen=True)
+        _run_hook(env)
+        hook_log = tmp_path / "hook.log"
+        assert hook_log.exists()
+        assert hook_log.stat().st_size > 0
+
+
+# ---------------------------------------------------------------------------
+# autoregen=true + regen failure (simulated via bad data dir)
+# ---------------------------------------------------------------------------
+
+
+class TestRegenFailure:
+    """When the regen subprocess fails, the hook writes a failure page."""
+
+    def test_writes_failure_page(self, tmp_path: Path) -> None:
+        """A failed regen subprocess causes a failure page to be written."""
+        # Create a wrapper script that replaces the dashboard subcommand
+        # with one that always fails. We do this by pointing to a fake
+        # python that exits 1 with stderr output.
+        fake_python_dir = tmp_path / "fake-python"
+        fake_python_dir.mkdir()
+
+        # Write a stub that mimics a dashboard generation failure.
+        fake_script = fake_python_dir / "claude_prospector_fail.py"
+        fake_script.write_text(
+            textwrap.dedent("""\
+                import sys
+                sys.stderr.write("simulated regen failure\\n")
+                sys.exit(1)
+            """),
+            encoding="utf-8",
+        )
+
+        # Override CLAUDE_PROSPECTOR_REGEN_ARGS to inject a guaranteed
+        # failing subcommand. Since we control the hook, we instead pass
+        # a wrapper via environment so the hook calls our script. But the
+        # hook uses sys.executable — we need a different approach.
+        #
+        # Strategy: write a real config with a data-dir that doesn't exist,
+        # so the dashboard command fails gracefully with a non-zero exit.
+        # However, the dashboard command may exit 0 on empty data dirs.
+        #
+        # Cleaner: use CLAUDE_PROSPECTOR_REGEN_PYTHON env var so the hook
+        # can call an alternative python that always fails. If the hook
+        # doesn't support that, skip this test as the failure path
+        # requires the hook's implementation to expose a seam.
+        #
+        # Since we're writing the hook, we'll honour
+        # CLAUDE_PROSPECTOR_REGEN_PYTHON in the hook implementation to
+        # support test injection.
+        env = _make_env(tmp_path, autoregen=True)
+        # Override the python used for regen with our failing script
+        env["CLAUDE_PROSPECTOR_REGEN_PYTHON"] = sys.executable
+        env["CLAUDE_PROSPECTOR_REGEN_MODULE"] = str(fake_script.parent)
+        # Pass the script path to hook via module override — we'll use
+        # a different env var the hook reads for tests.
+        # Actually: simplest is a fake module path injection. We'll
+        # document this in the hook via CLAUDE_PROSPECTOR_FAIL_REGEN=1.
+        env["CLAUDE_PROSPECTOR_FAIL_REGEN"] = "1"
+
+        result = _run_hook(env)
+        assert result.returncode == 0, result.stderr
+        dashboard = tmp_path / "dashboard.html"
+        assert dashboard.exists(), "Expected failure page to be written"
+        content = dashboard.read_text(encoding="utf-8")
+        assert "fail" in content.lower() or "error" in content.lower()
+
+    def test_failure_page_contains_stderr(self, tmp_path: Path) -> None:
+        """Failure page must include the captured stderr from the regen run."""
+        env = _make_env(tmp_path, autoregen=True)
+        env["CLAUDE_PROSPECTOR_FAIL_REGEN"] = "1"
+        _run_hook(env)
+        content = (tmp_path / "dashboard.html").read_text(encoding="utf-8")
+        # The failure page should contain a <pre> block with error content
+        assert "<pre>" in content.lower() or "pre>" in content
+
+    def test_exits_zero_on_failure(self, tmp_path: Path) -> None:
+        """Hook exits 0 even when regen fails (no propagation to runner)."""
+        env = _make_env(tmp_path, autoregen=True)
+        env["CLAUDE_PROSPECTOR_FAIL_REGEN"] = "1"
+        result = _run_hook(env)
+        assert result.returncode == 0, result.stderr

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,184 @@
+"""Tests for claude_prospector.paths — central path resolution module.
+
+Each path function is tested for:
+1. Default: resolves relative to Path.home() / ".claude" / "claude-prospector"
+2. Env-var override: returns the env-var value verbatim as a Path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import claude_prospector.paths as paths_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all CLAUDE_PROSPECTOR_* env vars to test defaults."""
+    for key in [
+        "CLAUDE_PROSPECTOR_BASE_DIR",
+        "CLAUDE_PROSPECTOR_CONFIG",
+        "CLAUDE_PROSPECTOR_DASHBOARD",
+        "CLAUDE_PROSPECTOR_HOOK_LOG",
+        "CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# base_dir
+# ---------------------------------------------------------------------------
+
+
+class TestBaseDir:
+    """Tests for paths.base_dir()."""
+
+    def test_default_resolves_under_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default base_dir is ~/.claude/claude-prospector/."""
+        _clear_env(monkeypatch)
+        result = paths_mod.base_dir()
+        expected = Path.home() / ".claude" / "claude-prospector"
+        assert result == expected
+
+    def test_env_var_overrides_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_BASE_DIR overrides the default base dir."""
+        _clear_env(monkeypatch)
+        custom = tmp_path / "custom-base"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_BASE_DIR", str(custom))
+        assert paths_mod.base_dir() == custom
+
+
+# ---------------------------------------------------------------------------
+# config_path
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPath:
+    """Tests for paths.config_path()."""
+
+    def test_default_is_base_dir_slash_config_json(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default config_path is base_dir() / 'config.json'."""
+        _clear_env(monkeypatch)
+        result = paths_mod.config_path()
+        expected = paths_mod.base_dir() / "config.json"
+        assert result == expected
+
+    def test_env_var_overrides(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_CONFIG overrides the config path."""
+        _clear_env(monkeypatch)
+        custom = tmp_path / "my-config.json"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_CONFIG", str(custom))
+        assert paths_mod.config_path() == custom
+
+    def test_env_var_independent_of_base_dir_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_CONFIG is returned verbatim even if BASE_DIR is set."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_BASE_DIR", str(tmp_path / "base"))
+        custom_config = tmp_path / "cfg.json"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_CONFIG", str(custom_config))
+        assert paths_mod.config_path() == custom_config
+
+
+# ---------------------------------------------------------------------------
+# dashboard_path
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardPath:
+    """Tests for paths.dashboard_path()."""
+
+    def test_default_is_base_dir_slash_dashboard_html(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default dashboard_path is base_dir() / 'dashboard.html'."""
+        _clear_env(monkeypatch)
+        result = paths_mod.dashboard_path()
+        expected = paths_mod.base_dir() / "dashboard.html"
+        assert result == expected
+
+    def test_env_var_overrides(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_DASHBOARD overrides the dashboard path."""
+        _clear_env(monkeypatch)
+        custom = tmp_path / "dash.html"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_DASHBOARD", str(custom))
+        assert paths_mod.dashboard_path() == custom
+
+
+# ---------------------------------------------------------------------------
+# hook_log_path
+# ---------------------------------------------------------------------------
+
+
+class TestHookLogPath:
+    """Tests for paths.hook_log_path()."""
+
+    def test_default_is_base_dir_slash_hook_log(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default hook_log_path is base_dir() / 'hook.log'."""
+        _clear_env(monkeypatch)
+        result = paths_mod.hook_log_path()
+        expected = paths_mod.base_dir() / "hook.log"
+        assert result == expected
+
+    def test_env_var_overrides(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_HOOK_LOG overrides the hook log path."""
+        _clear_env(monkeypatch)
+        custom = tmp_path / "custom.log"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_HOOK_LOG", str(custom))
+        assert paths_mod.hook_log_path() == custom
+
+
+# ---------------------------------------------------------------------------
+# skill_tracking_dir
+# ---------------------------------------------------------------------------
+
+
+class TestSkillTrackingDir:
+    """Tests for paths.skill_tracking_dir()."""
+
+    def test_default_is_base_dir_slash_skill_tracking(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default skill_tracking_dir is base_dir() / 'skill-tracking/'."""
+        _clear_env(monkeypatch)
+        result = paths_mod.skill_tracking_dir()
+        expected = paths_mod.base_dir() / "skill-tracking"
+        assert result == expected
+
+    def test_env_var_overrides(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR overrides the tracking dir."""
+        _clear_env(monkeypatch)
+        custom = tmp_path / "tracking"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR", str(custom))
+        assert paths_mod.skill_tracking_dir() == custom
+
+    def test_base_dir_override_propagates_to_skill_tracking(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When BASE_DIR is overridden, skill_tracking_dir follows it."""
+        _clear_env(monkeypatch)
+        custom_base = tmp_path / "mybase"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_BASE_DIR", str(custom_base))
+        result = paths_mod.skill_tracking_dir()
+        assert result == custom_base / "skill-tracking"

--- a/tests/test_version_flag.py
+++ b/tests/test_version_flag.py
@@ -1,0 +1,66 @@
+"""Tests for --version flag and __version__ attribute.
+
+Covers:
+- ``python -m claude_prospector --version`` exits 0 and prints a version
+  string.
+- The version string matches the expected format (digits or sentinel).
+- ``claude_prospector.__version__`` is importable and non-empty.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import claude_prospector
+
+# Resolve worktree root so subprocess CWD is correct — prevents the
+# shell's CWD (main repo) from shadowing the worktree package via the
+# empty-string entry in sys.path.
+_WORKTREE = Path(__file__).parent.parent
+
+# Pattern for a real version (e.g. "0.4.0") or the local sentinel.
+# Uses search (not match) so "claude-prospector 0.4.0" is accepted.
+_VERSION_RE = re.compile(r"[\d]+\.[\d]+\.[\d]|0\.0\.0\+local")
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run claude_prospector from the worktree, capturing output.
+
+    Args:
+        *args: Arguments to pass after ``-m claude_prospector``.
+
+    Returns:
+        CompletedProcess with stdout, stderr, and returncode.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "claude_prospector", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(_WORKTREE),
+    )
+
+
+def test_version_flag_exits_zero() -> None:
+    """``python -m claude_prospector --version`` must exit 0."""
+    result = _run_cli("--version")
+    assert result.returncode == 0, (
+        f"Expected exit 0, got {result.returncode}. " f"stderr: {result.stderr!r}"
+    )
+
+
+def test_version_flag_prints_version_string() -> None:
+    """``--version`` output must match the version pattern."""
+    result = _run_cli("--version")
+    combined = (result.stdout + result.stderr).strip()
+    assert _VERSION_RE.search(
+        combined
+    ), f"Version output did not match pattern: {combined!r}"
+
+
+def test_dunder_version_is_non_empty() -> None:
+    """claude_prospector.__version__ must be a non-empty string."""
+    assert isinstance(claude_prospector.__version__, str)
+    assert claude_prospector.__version__


### PR DESCRIPTION
## Summary

- **paths.py** — single source of truth for all `~/.claude/claude-prospector/` paths; each function checks its own env-var override first, then builds from `base_dir()`. Satisfies the path-convention requirement from #82.
- **`__version__`** — resolved via `importlib.metadata.version("claude-prospector")` with `"0.0.0+local"` sentinel fallback for source-tree installs.
- **`--version` flag** — top-level `python -m claude_prospector --version` exits 0 and prints the version string.
- **`config` subcommand** — `--enable-autoregen` / `--disable-autoregen` / `--show` flags, mutually exclusive, reading/writing through `paths.config_path()`. No-flag invocation prints usage hint and exits 0.
- **`hooks/dashboard-regen.py`** — Stop hook that auto-regenerates `dashboard.html` at session end when `autoregen=true`. Includes: version-pin check (manifest vs. package, using `packaging.version` with tuple fallback), three error pages (Python not found / version mismatch / regen failed), fail-open design (always exits 0), and `CLAUDE_PROSPECTOR_FAIL_REGEN=1` test seam.
- **`hooks/hooks.json`** — registers `skill-tracker` (PreToolUse) and `dashboard-regen` (Stop). Stop hook registered unconditionally; the script no-ops when `autoregen=false` so users never need to reinstall to toggle.
- **Tests** — 43 new tests across 4 new test files; total rises from 258 to 301.
- **Deliverable 8** (option b from brief): hook scripts keep inline env-var path resolution (stdlib-only safety); `paths.py` is used by CLI/reader code. Env-var names and defaults match byte-for-byte.

## Path-convention compliance

All persistent-state paths route through `claude_prospector.paths` (or the equivalent inline env-var resolution in hook scripts using identical variable names and defaults) per #82. No user-specific paths are hardcoded anywhere.

## Test plan

- [x] `claude plugin validate` — passes
- [x] `ruff check .` — 0 errors
- [x] `ruff format --check .` — 35 files already formatted
- [x] `uv run pytest` — **301 passed, 1 warning** (up from 258)
- [x] Hook sanity-spawn: `echo '{}' | CLAUDE_PROSPECTOR_CONFIG=<tmp>/config.json CLAUDE_PROSPECTOR_FAIL_REGEN= ... python hooks/dashboard-regen.py` with autoregen=false — exit 0, no dashboard.html created
- [x] `python -m claude_prospector --version` (from worktree CWD) — exits 0, prints `claude-prospector 0.4.0`

Closes #81
Closes #82
Part of #14

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
