### PR TITLE
Resolve state path via ${CLAUDE_PLUGIN_DATA} with one-time legacy migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,16 @@ v0.4.0 ships the full plugin surface:
 - **Interactive dashboard** — HTML report with three-bucket budget gauges (5h / 7d / Sonnet-7d), per-model donut and bar charts, per-agent token attribution with nested sub-agent tracing, skill-invocation counts, and per-project breakdowns.
 - **`usage-analysis` skill** — conversational analysis with recommendations. Answers questions like "am I close to my Sonnet limit?", "where are my tokens going?", and "which agent uses the most?". Triggered by natural-language phrases.
 - **`usage-dashboard` skill** — bare regeneration surface. Triggered by phrases like "regenerate the dashboard" or "rebuild my usage dashboard"; writes the HTML file and reports the path, without interpreting the data.
-- **`skill-tracker` hook** (PreToolUse, always-on) — logs `Skill` tool-use events to `~/.claude/claude-prospector/skill-tracking/<YYYY-MM-DD>.jsonl` for the `by_skill` and skill-passed-vs-invoked analyses.
+- **`skill-tracker` hook** (PreToolUse, always-on) — logs `Skill` tool-use events to the state directory for the `by_skill` and skill-passed-vs-invoked analyses.
 - **`dashboard-regen` hook** (Stop, opt-in) — auto-regenerates the dashboard after every session when enabled via `python -m claude_prospector config --enable-autoregen`.
+
+### State storage
+
+When running as a plugin, state (config, dashboard HTML, hook log, skill-tracking JSONL files) is stored under the `${CLAUDE_PLUGIN_DATA}` directory — the Anthropic-documented persistent state location that survives plugin updates.
+
+Users upgrading from v0.4.0 get a **one-time automatic migration**: on the first session after upgrade, any existing files from `~/.claude/claude-prospector/` are moved into `${CLAUDE_PLUGIN_DATA}` and the legacy directory is removed.
+
+For testing or non-plugin use, set `CLAUDE_PROSPECTOR_BASE_DIR` to override the location entirely (takes priority over `${CLAUDE_PLUGIN_DATA}`).
 
 ## Development / Standalone CLI
 

--- a/claude_prospector/paths.py
+++ b/claude_prospector/paths.py
@@ -1,15 +1,28 @@
 """Central path resolution for all claude-prospector persistent state.
 
-All paths under ``~/.claude/claude-prospector/`` are resolved through
-this module so hook scripts, the CLI, and reader code all agree on
-locations without duplicating defaults.
+All paths under the base directory are resolved through this module so
+hook scripts, the CLI, and reader code all agree on locations without
+duplicating defaults.
 
 Each function checks its own environment variable first; if set, returns
 that path verbatim. Otherwise it builds from :func:`base_dir`.
 
+``base_dir()`` uses a three-tier resolution (highest priority first):
+
+1. ``CLAUDE_PROSPECTOR_BASE_DIR`` — explicit override for tests and
+   non-plugin invocations.
+2. ``CLAUDE_PLUGIN_DATA`` — the Anthropic-documented plugin state
+   directory, populated by Claude Code when the plugin is loaded.
+   Used as-is (no subdirectory appended). When this tier fires and the
+   legacy directory exists with content, a one-time migration runs to
+   move the legacy files into the new location.
+3. Legacy ``~/.claude/claude-prospector/`` — fallback for non-plugin
+   invocations and users who have not yet migrated.
+
 Environment variable overrides (useful for testing):
 
-- ``CLAUDE_PROSPECTOR_BASE_DIR`` — overrides the base directory.
+- ``CLAUDE_PROSPECTOR_BASE_DIR`` — overrides the base directory (tier 1).
+- ``CLAUDE_PLUGIN_DATA`` — plugin-managed state dir used as base (tier 2).
 - ``CLAUDE_PROSPECTOR_CONFIG`` — overrides :func:`config_path`.
 - ``CLAUDE_PROSPECTOR_DASHBOARD`` — overrides :func:`dashboard_path`.
 - ``CLAUDE_PROSPECTOR_HOOK_LOG`` — overrides :func:`hook_log_path`.
@@ -20,6 +33,7 @@ Environment variable overrides (useful for testing):
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -32,16 +46,38 @@ _DEFAULT_BASE = Path.home() / ".claude" / "claude-prospector"
 def base_dir() -> Path:
     """Return the base directory for all claude-prospector persistent state.
 
-    Defaults to ``~/.claude/claude-prospector/``. Override via the
-    ``CLAUDE_PROSPECTOR_BASE_DIR`` environment variable.
+    Resolves using a three-tier priority (highest first):
+
+    1. ``CLAUDE_PROSPECTOR_BASE_DIR`` env var — explicit test/override
+       path; returned verbatim with no migration side-effects.
+    2. ``CLAUDE_PLUGIN_DATA`` env var — the Anthropic plugin state
+       directory. Used as-is (no subdirectory appended). Triggers a
+       one-time migration from the legacy directory if applicable.
+    3. Legacy ``~/.claude/claude-prospector/`` — fallback for non-plugin
+       invocations and pre-migration users.
 
     Returns:
         Path to the base directory (not guaranteed to exist).
     """
-    env_val = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
-    if env_val:
-        return Path(env_val)
+    # Tier 1: explicit override — no migration.
+    env_override = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
+    if env_override:
+        return Path(env_override)
+
+    # Tier 2: Anthropic plugin data dir.
+    plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA")
+    if plugin_data:
+        new_base = Path(plugin_data)
+        _migrate_legacy_if_needed(new_base)
+        return new_base
+
+    # Tier 3: legacy fallback.
     return _DEFAULT_BASE
+
+
+# ---------------------------------------------------------------------------
+# Derived path helpers
+# ---------------------------------------------------------------------------
 
 
 def config_path() -> Path:
@@ -105,3 +141,83 @@ def skill_tracking_dir() -> Path:
     if env_val:
         return Path(env_val)
     return base_dir() / "skill-tracking"
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _migrate_legacy_if_needed(new_base: Path) -> None:
+    """Perform a one-time migration from the legacy dir to *new_base*.
+
+    Migration runs only when all three conditions hold:
+
+    - The legacy directory (``_DEFAULT_BASE``) exists and is non-empty.
+    - *new_base* does not exist or is empty (so we never clobber data).
+
+    On success the legacy directory is removed. If the migration raises
+    for any reason the error is swallowed and logged — hook execution
+    continues using *new_base* regardless.
+
+    Idempotency: once the legacy dir is gone (or the new dir is
+    non-empty), subsequent calls are no-ops.
+
+    Args:
+        new_base: The ``CLAUDE_PLUGIN_DATA`` path that will receive the
+            migrated files.
+    """
+    legacy = _DEFAULT_BASE
+
+    # Guard: legacy must exist and have content.
+    if not legacy.is_dir():
+        return
+    legacy_contents = list(legacy.iterdir())
+    if not legacy_contents:
+        return
+
+    # Guard: new dir must be absent or empty (and actually a directory).
+    if new_base.is_dir() and any(True for _ in new_base.iterdir()):
+        return
+
+    try:
+        new_base.mkdir(parents=True, exist_ok=True)
+        for item in legacy_contents:
+            dest = new_base / item.name
+            shutil.move(str(item), str(dest))
+        # Remove the now-empty legacy dir.
+        legacy.rmdir()
+        _log_migration(f"migrated from {legacy} to {new_base}")
+    except Exception as exc:  # noqa: BLE001
+        _log_migration(f"migration failed ({exc}); continuing with {new_base}")
+
+
+def _log_migration(message: str) -> None:
+    """Append a ``[migration]`` line to the hook log.
+
+    Uses the ``CLAUDE_PROSPECTOR_HOOK_LOG`` env var for the log path
+    (same resolution as :func:`hook_log_path` but inlined to avoid a
+    circular call through :func:`base_dir`).
+
+    Errors are silently swallowed so a log failure never crashes a hook.
+
+    Args:
+        message: Diagnostic text to record after the ``[migration]``
+            prefix.
+    """
+    try:
+        env_val = os.environ.get("CLAUDE_PROSPECTOR_HOOK_LOG")
+        if env_val:
+            log = Path(env_val)
+        else:
+            # Resolve log path without calling base_dir() again.
+            plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA")
+            if plugin_data:
+                log = Path(plugin_data) / "hook.log"
+            else:
+                log = _DEFAULT_BASE / "hook.log"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with open(log, "a", encoding="utf-8") as fh:
+            fh.write(f"[migration] {message}\n")
+    except Exception:  # noqa: BLE001
+        pass

--- a/hooks/dashboard-regen.py
+++ b/hooks/dashboard-regen.py
@@ -55,12 +55,24 @@ from pathlib import Path
 def _base_dir() -> Path:
     """Return the claude-prospector base directory.
 
+    Three-tier resolution (highest priority first):
+
+    1. ``CLAUDE_PROSPECTOR_BASE_DIR`` — explicit test/override path.
+    2. ``CLAUDE_PLUGIN_DATA`` — Anthropic plugin state dir (used as-is).
+    3. Legacy ``~/.claude/claude-prospector/`` — pre-migration fallback.
+
+    Migration logic is intentionally omitted here; it runs only from
+    ``claude_prospector.paths.base_dir()`` so it happens exactly once.
+
     Returns:
-        Path from CLAUDE_PROSPECTOR_BASE_DIR env var, or the default.
+        Resolved base directory path.
     """
-    env = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
-    if env:
-        return Path(env)
+    env_override = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
+    if env_override:
+        return Path(env_override)
+    plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA")
+    if plugin_data:
+        return Path(plugin_data)
     return Path.home() / ".claude" / "claude-prospector"
 
 

--- a/hooks/skill-tracker.py
+++ b/hooks/skill-tracker.py
@@ -32,11 +32,35 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 
+def _base_dir() -> Path:
+    """Return the claude-prospector base directory.
+
+    Three-tier resolution (highest priority first):
+
+    1. ``CLAUDE_PROSPECTOR_BASE_DIR`` — explicit test/override path.
+    2. ``CLAUDE_PLUGIN_DATA`` — Anthropic plugin state dir (used as-is).
+    3. Legacy ``~/.claude/claude-prospector/`` — pre-migration fallback.
+
+    Migration logic is intentionally omitted here; it runs only from
+    ``claude_prospector.paths.base_dir()`` so it happens exactly once.
+
+    Returns:
+        Resolved base directory path.
+    """
+    env_override = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
+    if env_override:
+        return Path(env_override)
+    plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA")
+    if plugin_data:
+        return Path(plugin_data)
+    return Path.home() / ".claude" / "claude-prospector"
+
+
 def _tracking_dir() -> Path:
     """Return the directory used for per-day tracking JSONL files.
 
     Reads ``CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR`` from the environment;
-    falls back to ``~/.claude/claude-prospector/skill-tracking/``.
+    falls back to ``<base_dir>/skill-tracking/``.
 
     Returns:
         Path to the tracking directory (not guaranteed to exist yet).
@@ -44,14 +68,14 @@ def _tracking_dir() -> Path:
     env_val = os.environ.get("CLAUDE_PROSPECTOR_SKILL_TRACKING_DIR")
     if env_val:
         return Path(env_val)
-    return Path.home() / ".claude" / "claude-prospector" / "skill-tracking"
+    return _base_dir() / "skill-tracking"
 
 
 def _log_path() -> Path:
     """Return the path to the hook diagnostic log file.
 
     Reads ``CLAUDE_PROSPECTOR_HOOK_LOG`` from the environment; falls back
-    to ``~/.claude/claude-prospector/hook.log``.
+    to ``<base_dir>/hook.log``.
 
     Returns:
         Path to the hook log file (not guaranteed to exist yet).
@@ -59,7 +83,7 @@ def _log_path() -> Path:
     env_val = os.environ.get("CLAUDE_PROSPECTOR_HOOK_LOG")
     if env_val:
         return Path(env_val)
-    return Path.home() / ".claude" / "claude-prospector" / "hook.log"
+    return _base_dir() / "hook.log"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -3,6 +3,9 @@
 Each path function is tested for:
 1. Default: resolves relative to Path.home() / ".claude" / "claude-prospector"
 2. Env-var override: returns the env-var value verbatim as a Path.
+3. Three-tier resolution: CLAUDE_PROSPECTOR_BASE_DIR > CLAUDE_PLUGIN_DATA >
+   legacy ~/.claude/claude-prospector/.
+4. One-time migration from legacy dir to CLAUDE_PLUGIN_DATA.
 """
 
 from __future__ import annotations
@@ -20,9 +23,10 @@ import claude_prospector.paths as paths_mod
 
 
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Remove all CLAUDE_PROSPECTOR_* env vars to test defaults."""
+    """Remove all path-controlling env vars to test defaults."""
     for key in [
         "CLAUDE_PROSPECTOR_BASE_DIR",
+        "CLAUDE_PLUGIN_DATA",
         "CLAUDE_PROSPECTOR_CONFIG",
         "CLAUDE_PROSPECTOR_DASHBOARD",
         "CLAUDE_PROSPECTOR_HOOK_LOG",
@@ -182,3 +186,221 @@ class TestSkillTrackingDir:
         monkeypatch.setenv("CLAUDE_PROSPECTOR_BASE_DIR", str(custom_base))
         result = paths_mod.skill_tracking_dir()
         assert result == custom_base / "skill-tracking"
+
+
+# ---------------------------------------------------------------------------
+# Three-tier resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBaseDirThreeTier:
+    """Tests for the three-tier base_dir() resolution order."""
+
+    def test_plugin_data_used_when_no_base_dir_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PLUGIN_DATA is used when CLAUDE_PROSPECTOR_BASE_DIR is unset."""
+        _clear_env(monkeypatch)
+        plugin_data = tmp_path / "plugin-data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_data))
+        result = paths_mod.base_dir()
+        assert result == plugin_data
+
+    def test_base_dir_wins_over_plugin_data(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_BASE_DIR takes priority over CLAUDE_PLUGIN_DATA."""
+        _clear_env(monkeypatch)
+        override = tmp_path / "override"
+        plugin_data = tmp_path / "plugin-data"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_BASE_DIR", str(override))
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_data))
+        result = paths_mod.base_dir()
+        assert result == override
+
+    def test_legacy_fallback_when_neither_env_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Legacy ~/.claude/claude-prospector/ used when no env vars set."""
+        _clear_env(monkeypatch)
+        result = paths_mod.base_dir()
+        expected = Path.home() / ".claude" / "claude-prospector"
+        assert result == expected
+
+    def test_plugin_data_does_not_append_subdir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PLUGIN_DATA is used as-is; no subdirectory is appended."""
+        _clear_env(monkeypatch)
+        plugin_data = tmp_path / "my-plugin-state"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_data))
+        result = paths_mod.base_dir()
+        assert result == plugin_data
+        # Confirm no extra path segment was appended
+        assert result.name == "my-plugin-state"
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyMigration:
+    """Tests for one-time migration from legacy dir to CLAUDE_PLUGIN_DATA."""
+
+    def _make_legacy(self, legacy_dir: Path) -> None:
+        """Create a legacy dir with some content."""
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        (legacy_dir / "config.json").write_text('{"autoregen": false}')
+        (legacy_dir / "hook.log").write_text("old log")
+        tracking = legacy_dir / "skill-tracking"
+        tracking.mkdir()
+        (tracking / "2026-01-01.jsonl").write_text('{"event":"test"}')
+
+    def test_migration_moves_files_and_removes_legacy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Files are copied to new dir and legacy dir is deleted."""
+        _clear_env(monkeypatch)
+        legacy = tmp_path / ".claude" / "claude-prospector"
+        self._make_legacy(legacy)
+        new_base = tmp_path / "plugin-data"
+        # new_base does not exist yet (empty target)
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(new_base))
+        # Redirect legacy path resolution to our tmp_path version
+        monkeypatch.setattr(paths_mod, "_DEFAULT_BASE", legacy)
+
+        result = paths_mod.base_dir()
+
+        assert result == new_base
+        # Content should have moved
+        assert (new_base / "config.json").exists()
+        assert (new_base / "hook.log").exists()
+        assert (new_base / "skill-tracking" / "2026-01-01.jsonl").exists()
+        # Legacy dir should be gone
+        assert not legacy.exists()
+
+    def test_migration_skipped_when_legacy_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """No error when legacy dir doesn't exist."""
+        _clear_env(monkeypatch)
+        legacy = tmp_path / ".claude" / "claude-prospector"
+        # legacy dir intentionally NOT created
+        new_base = tmp_path / "plugin-data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(new_base))
+        monkeypatch.setattr(paths_mod, "_DEFAULT_BASE", legacy)
+
+        result = paths_mod.base_dir()
+
+        assert result == new_base
+        assert not new_base.exists()  # No files to move, no creation
+
+    def test_migration_skipped_when_new_dir_nonempty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Migration is skipped when the new dir already has content."""
+        _clear_env(monkeypatch)
+        legacy = tmp_path / ".claude" / "claude-prospector"
+        self._make_legacy(legacy)
+        new_base = tmp_path / "plugin-data"
+        new_base.mkdir(parents=True)
+        existing_file = new_base / "existing.txt"
+        existing_file.write_text("already here")
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(new_base))
+        monkeypatch.setattr(paths_mod, "_DEFAULT_BASE", legacy)
+
+        paths_mod.base_dir()
+
+        # Legacy dir should still exist (migration was skipped)
+        assert legacy.exists()
+        # Existing content in new dir should be untouched
+        assert existing_file.exists()
+
+    def test_migration_skipped_when_legacy_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Migration is skipped when legacy dir exists but has no content."""
+        _clear_env(monkeypatch)
+        legacy = tmp_path / ".claude" / "claude-prospector"
+        legacy.mkdir(parents=True)  # exists but empty
+        new_base = tmp_path / "plugin-data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(new_base))
+        monkeypatch.setattr(paths_mod, "_DEFAULT_BASE", legacy)
+
+        paths_mod.base_dir()
+
+        # Legacy dir still there (empty, no migration needed)
+        assert legacy.exists()
+
+    def test_migration_idempotent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A second call after successful migration is a no-op."""
+        _clear_env(monkeypatch)
+        legacy = tmp_path / ".claude" / "claude-prospector"
+        self._make_legacy(legacy)
+        new_base = tmp_path / "plugin-data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(new_base))
+        monkeypatch.setattr(paths_mod, "_DEFAULT_BASE", legacy)
+
+        # First call — performs migration
+        paths_mod.base_dir()
+        assert not legacy.exists()
+        assert (new_base / "config.json").exists()
+
+        # Second call — legacy gone, new dir non-empty → no error
+        result = paths_mod.base_dir()
+        assert result == new_base
+        assert (new_base / "config.json").exists()
+
+    def test_migration_failure_does_not_raise(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A failed migration logs the error but does not propagate."""
+        _clear_env(monkeypatch)
+        legacy = tmp_path / ".claude" / "claude-prospector"
+        self._make_legacy(legacy)
+        new_base = tmp_path / "plugin-data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(new_base))
+        monkeypatch.setattr(paths_mod, "_DEFAULT_BASE", legacy)
+
+        # Make new_base a file so mkdir/move fails
+        new_base.write_text("I am a file, not a dir")
+
+        # Should not raise — returns the plugin_data path anyway
+        result = paths_mod.base_dir()
+        assert result == new_base
+
+    def test_migration_logs_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Successful migration writes a [migration] line to the hook log."""
+        _clear_env(monkeypatch)
+        legacy = tmp_path / ".claude" / "claude-prospector"
+        self._make_legacy(legacy)
+        new_base = tmp_path / "plugin-data"
+        log_path = tmp_path / "hook.log"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(new_base))
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_HOOK_LOG", str(log_path))
+        monkeypatch.setattr(paths_mod, "_DEFAULT_BASE", legacy)
+
+        paths_mod.base_dir()
+
+        assert log_path.exists()
+        content = log_path.read_text()
+        assert "[migration]" in content


### PR DESCRIPTION
## Summary

Closes the **state-storage** half of #95 (the user-config refactor will land in a follow-up PR before the v0.5.0 tag).

`base_dir()` now resolves in three tiers (highest priority first):

1. `CLAUDE_PROSPECTOR_BASE_DIR` env — explicit test/override.
2. `CLAUDE_PLUGIN_DATA` env — [Anthropic plugin state dir](https://code.claude.com/docs/en/plugins-reference#environment-variables), populated by Claude Code when the plugin is loaded.
3. Legacy `~/.claude/claude-prospector/` — fallback for non-plugin invocations and pre-migration users.

When tier 2 fires and the legacy dir has content but the new dir is empty, `paths.base_dir()` migrates contents via `shutil.move` and removes the legacy dir. Idempotent (skipped if new dir non-empty). Migration failures are swallowed, logged to `hook.log` with a `[migration]` prefix, and the run continues using the new path.

Hooks (`hooks/skill-tracker.py`, `hooks/dashboard-regen.py`) replicate the three-tier resolution inline (stdlib-only, no `claude_prospector` import) but **omit** the migration logic — migration runs exactly once from `paths.base_dir()`.

## Files changed

| File | Change |
| --- | --- |
| `claude_prospector/paths.py` | Three-tier `base_dir()`, `_migrate_legacy_if_needed`, `_log_migration` |
| `hooks/skill-tracker.py` | New `_base_dir()` with three-tier resolution; `_tracking_dir` / `_log_path` delegate |
| `hooks/dashboard-regen.py` | `_base_dir()` updated to match `skill-tracker.py` byte-for-byte |
| `tests/test_paths.py` | +11 cases: `TestBaseDirThreeTier`, `TestLegacyMigration` |
| `README.md` | New "State storage" subsection |

## Verification

- `pytest`: **312 passed** (was 301; +11 new cases)
- `ruff check`: All checks passed
- `ruff format --check`: 35 files already formatted

## Judgment calls

- **Migration idempotency check** uses "new dir non-empty" rather than a `.migrated-from-legacy` sentinel file — simpler, also covers the case where the user manually populates the new dir.
- **Migration log uses append mode** (not the hook's last-run-wins truncate) because this is a one-time diagnostic event; overwriting would destroy evidence of the migration itself.
- **Hook resolution inlined verbatim** in both hooks rather than shared via import — matches the existing "replicate inline" design contract documented in the hook source.
- **Tier-1 (`CLAUDE_PROSPECTOR_BASE_DIR`) bypasses migration.** Intentional: tests must not trigger filesystem migration as a side-effect.

## Test plan

- [x] 312 pytest pass locally
- [x] ruff lint + format clean
- [x] Migration triggers on legacy-populated + new-empty
- [x] Migration skipped on new-non-empty, legacy-absent, both-absent
- [x] Migration is idempotent (second call no-op)
- [x] Migration failure (unwritable target) logged but does not raise
- [ ] CI green

Part of #95. v0.5.0 milestone.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_