### PR TITLE
release: v0.5.0 (state-storage refactor)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-17
+
+### Changed
+
+- State-storage path resolution now uses a three-tier `base_dir()` lookup: `CLAUDE_PROSPECTOR_BASE_DIR` (explicit override) → `CLAUDE_PLUGIN_DATA` (Anthropic plugin state dir, populated by Claude Code at plugin load) → legacy `~/.claude/claude-prospector/` (fallback). Both hook scripts replicate the resolver inline to remain stdlib-only. (#96)
+
+### Added
+
+- One-time auto-migration: when `CLAUDE_PLUGIN_DATA` is set and the legacy `~/.claude/claude-prospector/` directory has content while the new location is empty, `paths.base_dir()` moves the contents via `shutil.move` and removes the legacy dir. Idempotent (skipped if new dir is non-empty); failures are logged to `hook.log` with a `[migration]` prefix and never crash the run. (#96)
+
+[0.5.0]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.5.0
+
 ## [0.4.0] - 2026-05-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.4.0"
+version = "0.5.0"
 description = "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill."
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Single feature change since v0.4.0 — PR #96 (state-storage three-tier resolution + auto-migration). New behavioral capability with back-compat preserved → minor bump.

- Bump `pyproject.toml` → `0.5.0`
- Bump `.claude-plugin/plugin.json` → `0.5.0`
- Add `CHANGELOG.md` v0.5.0 section citing #96

## Verification

- `pytest`: 312 passed
- `ruff check`: All checks passed
- `ruff format --check`: 35 files already formatted

## Post-merge follow-up

- [ ] Tag `v0.5.0` on the squashed merge commit and push
- [ ] Bump `glitchwerks/plugins/.claude-plugin/marketplace.json` — `claude-prospector.source.sha` → v0.5.0 tag commit
- [ ] Reinstall editable into `~/.claude/.venv` so `importlib.metadata.version("claude-prospector")` reports `0.5.0`

Closes #97.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_