### PR TITLE
feat: migrate autoregen to userConfig block

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,12 @@
   "license": "MIT",
   "homepage": "https://github.com/glitchwerks/claude-prospector",
   "repository": "https://github.com/glitchwerks/claude-prospector",
-  "keywords": ["claude-code", "usage", "tokens", "billing", "dashboard", "observability"]
+  "keywords": ["claude-code", "usage", "tokens", "billing", "dashboard", "observability"],
+  "userConfig": {
+    "autoregen": {
+      "type": "boolean",
+      "title": "Auto-regenerate dashboard on session end",
+      "description": "When enabled, automatically regenerates the HTML usage dashboard at the end of every Claude Code session. Toggle via the plugin manager (/plugin reconfigure claude-prospector) or at install time."
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -34,11 +34,39 @@ v0.4.0 ships the full plugin surface:
 - **`usage-analysis` skill** — conversational analysis with recommendations. Answers questions like "am I close to my Sonnet limit?", "where are my tokens going?", and "which agent uses the most?". Triggered by natural-language phrases.
 - **`usage-dashboard` skill** — bare regeneration surface. Triggered by phrases like "regenerate the dashboard" or "rebuild my usage dashboard"; writes the HTML file and reports the path, without interpreting the data.
 - **`skill-tracker` hook** (PreToolUse, always-on) — logs `Skill` tool-use events to the state directory for the `by_skill` and skill-passed-vs-invoked analyses.
-- **`dashboard-regen` hook** (Stop, opt-in) — auto-regenerates the dashboard after every session when enabled via `python -m claude_prospector config --enable-autoregen`.
+- **`dashboard-regen` hook** (Stop, opt-in) — auto-regenerates the dashboard after every session when the `autoregen` user-config is enabled via the plugin manager (`/plugin reconfigure claude-prospector` or at install time).
+
+### Configuration (autoregen)
+
+The `dashboard-regen` Stop hook is opt-in. Toggle it through the Claude Code
+plugin manager — no manual file edits required:
+
+```
+/plugin reconfigure claude-prospector
+```
+
+You will be prompted to enable or disable `autoregen`. You can also set it at
+install time when the plugin manager shows the initial configuration prompt.
+
+To inspect the current plugin state, use the read-only CLI:
+
+```bash
+python -m claude_prospector config --show
+```
+
+This prints the legacy `config.json` contents if present. The authoritative
+value is the `autoregen` setting shown in the plugin manager.
+
+> **Upgrading from v0.4.x?** If you previously ran
+> `python -m claude_prospector config --enable-autoregen`, your old
+> `config.json` is still readable via `--show`. The hook will log a one-time
+> advisory message to `hook.log` the first time it runs with the new
+> user-config path. Re-toggle via `/plugin reconfigure claude-prospector` to
+> move to the managed setting. The old `config.json` file is not deleted.
 
 ### State storage
 
-When running as a plugin, state (config, dashboard HTML, hook log, skill-tracking JSONL files) is stored under the `${CLAUDE_PLUGIN_DATA}` directory — the Anthropic-documented persistent state location that survives plugin updates.
+When running as a plugin, state (dashboard HTML, hook log, skill-tracking JSONL files) is stored under the `${CLAUDE_PLUGIN_DATA}` directory — the Anthropic-documented persistent state location that survives plugin updates.
 
 Users upgrading from v0.4.0 get a **one-time automatic migration**: on the first session after upgrade, any existing files from `~/.claude/claude-prospector/` are moved into `${CLAUDE_PLUGIN_DATA}` and the legacy directory is removed.
 

--- a/claude_prospector/cli/config.py
+++ b/claude_prospector/cli/config.py
@@ -1,23 +1,24 @@
-"""Config subcommand for claude-prospector.
+"""Config subcommand for claude-prospector (read-only after issue #99).
 
-Manages the plugin configuration file at the path returned by
-:func:`claude_prospector.paths.config_path` (default:
-``~/.claude/claude-prospector/config.json``).
+Provides inspection of the plugin configuration. As of v0.5.x, autoregen
+is managed via Anthropic's ``userConfig`` plugin-manager UX rather than
+by writing to ``config.json`` directly. This subcommand is therefore
+read-only: it shows the current state but does not mutate anything.
 
-The config file is a JSON object. Currently the only supported key is
-``autoregen`` (bool) which controls whether the Stop hook regenerates
-the dashboard at the end of every session.
+Subcommand flags:
 
-Subcommand flags (mutually exclusive):
-
-- ``--enable-autoregen``  Sets ``{"autoregen": true}`` (creates file if
-  absent; preserves other keys).
-- ``--disable-autoregen`` Sets ``{"autoregen": false}``.
-- ``--show``              Pretty-prints the current config to stdout.
-  Exits 0 whether or not the file exists.
+- ``--show``  Pretty-prints the current ``config.json`` to stdout.
+  When no config file exists, prints ``{}`` to stdout and a note to
+  stderr directing the user to the plugin manager. Exits 0 in all cases.
 
 Running ``python -m claude_prospector config`` with no flags prints
 subcommand help and exits 0.
+
+To toggle autoregen, use the plugin manager:
+
+    /plugin reconfigure claude-prospector
+
+or enable it at install time when prompted.
 """
 
 from __future__ import annotations
@@ -56,19 +57,6 @@ def _read_config(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _write_config(path: Path, cfg: dict) -> None:
-    """Write a config dict to *path* as pretty-printed JSON.
-
-    Creates parent directories as needed.
-
-    Args:
-        path: Destination path.
-        cfg: Config mapping to serialise.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
-
-
 # ---------------------------------------------------------------------------
 # Subparser registration
 # ---------------------------------------------------------------------------
@@ -87,30 +75,14 @@ def build_parser(
     """
     p = parent.add_parser(
         "config",
-        help=("Read or update the claude-prospector configuration file."),
-    )
-    group = p.add_mutually_exclusive_group()
-    group.add_argument(
-        "--enable-autoregen",
-        action="store_true",
-        default=False,
-        dest="enable_autoregen",
         help=(
-            "Enable automatic dashboard regeneration on session end "
-            "(sets autoregen=true in config.json)."
+            "Inspect the claude-prospector configuration. "
+            "Use --show to print current settings. "
+            "Toggle autoregen via the plugin manager "
+            "(/plugin reconfigure claude-prospector)."
         ),
     )
-    group.add_argument(
-        "--disable-autoregen",
-        action="store_true",
-        default=False,
-        dest="disable_autoregen",
-        help=(
-            "Disable automatic dashboard regeneration "
-            "(sets autoregen=false in config.json)."
-        ),
-    )
-    group.add_argument(
+    p.add_argument(
         "--show",
         action="store_true",
         default=False,
@@ -129,9 +101,7 @@ def run(args: argparse.Namespace) -> int:
     """Execute the config subcommand.
 
     Args:
-        args: Parsed argument namespace. Expected attributes:
-            ``args.enable_autoregen`` (bool),
-            ``args.disable_autoregen`` (bool),
+        args: Parsed argument namespace. Expected attribute:
             ``args.show`` (bool).
 
     Returns:
@@ -143,6 +113,11 @@ def run(args: argparse.Namespace) -> int:
     if args.show:
         if not path.exists():
             print("(no config file yet)", file=sys.stderr)
+            print(
+                "autoregen is managed via plugin user-config;"
+                " toggle with /plugin reconfigure claude-prospector",
+                file=sys.stderr,
+            )
             print("{}")
             return 0
         try:
@@ -156,29 +131,13 @@ def run(args: argparse.Namespace) -> int:
         print(json.dumps(cfg, indent=2))
         return 0
 
-    # ── --enable-autoregen / --disable-autoregen ─────────────────────────
-    if args.enable_autoregen or args.disable_autoregen:
-        try:
-            cfg = _read_config(path)
-        except json.JSONDecodeError as exc:
-            print(
-                f"config: malformed JSON in '{path}': {exc}",
-                file=sys.stderr,
-            )
-            return 1
-        cfg["autoregen"] = args.enable_autoregen
-        _write_config(path, cfg)
-        state = "enabled" if args.enable_autoregen else "disabled"
-        print(f"autoregen {state} (config: {path})")
-        return 0
-
     # ── No flags — print help ─────────────────────────────────────────────
-    # Re-parse with --help to get consistent help output via argparse.
-    # We can't easily reach the subparser from here without plumbing, so
-    # print a minimal usage note instead.
     print(
-        "Usage: claude-prospector config "
-        "[--enable-autoregen | --disable-autoregen | --show]"
+        "Usage: claude-prospector config [--show]\n"
+        "\n"
+        "To toggle autoregen, use the plugin manager:\n"
+        "    /plugin reconfigure claude-prospector\n"
+        "\n"
+        "Run 'claude-prospector config --help' for full help."
     )
-    print("Run 'claude-prospector config --help' for full help.")
     return 0

--- a/hooks/dashboard-regen.py
+++ b/hooks/dashboard-regen.py
@@ -3,9 +3,27 @@
 
 This script is registered as a Claude Code Stop hook in hooks/hooks.json.
 It fires at the end of every session. Whether it actually does work is
-controlled by the ``autoregen`` key in the plugin config file — when
-``autoregen`` is false (or the config file is absent) the hook exits
-immediately as a no-op so users who haven't opted in are unaffected.
+controlled by the ``autoregen`` setting — when false (or not set) the hook
+exits immediately as a no-op so users who haven't opted in are unaffected.
+
+Autoregen gate (priority order):
+    1. ``--autoregen <value>`` CLI argument — set by hooks.json via the
+       ``${user_config.autoregen}`` substitution. The value is parsed by
+       :func:`_parse_autoregen_arg`; truthy strings are ``"true"``,
+       ``"1"``, ``"yes"`` (case-insensitive). Anything else (including
+       empty string — the value when the user has never configured
+       userConfig) is falsy. This is the primary gate for plugin users.
+    2. Legacy ``${CLAUDE_PLUGIN_DATA}/config.json`` — used when the
+       ``--autoregen`` argument is absent (manual invocation, pre-#99
+       users). Reads the ``autoregen`` boolean from the JSON file.
+
+Migration notice:
+    When the ``--autoregen`` arg IS provided (new hook path) and a legacy
+    ``config.json`` is present at the config path, the hook writes a
+    one-time ``[migration]`` notice to ``hook.log`` advising the user to
+    toggle via the plugin manager. A sibling sentinel file
+    ``config.json.migrated-notice`` suppresses the notice after the first
+    run. The legacy ``config.json`` is never deleted.
 
 The Stop hook is registered unconditionally in hooks.json rather than
 conditionally based on config because:
@@ -35,6 +53,7 @@ Exit codes:
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import subprocess
@@ -110,6 +129,74 @@ def _hook_log_path() -> Path:
     if env:
         return Path(env)
     return _base_dir() / "hook.log"
+
+
+# ---------------------------------------------------------------------------
+# Autoregen arg parsing
+# ---------------------------------------------------------------------------
+
+
+_TRUTHY_VALUES: frozenset[str] = frozenset({"true", "1", "yes"})
+
+
+def _parse_autoregen_arg(value: str) -> bool:
+    """Parse the --autoregen CLI argument value as a boolean.
+
+    Treats ``"true"``, ``"1"``, and ``"yes"`` (case-insensitive) as truthy.
+    Everything else — including the empty string (the substitution result
+    when the user has never configured ``userConfig.autoregen``) — is
+    falsy.
+
+    Args:
+        value: The raw string passed via ``--autoregen``.
+
+    Returns:
+        True when the value is a recognised truthy token; False otherwise.
+    """
+    return value.strip().lower() in _TRUTHY_VALUES
+
+
+# ---------------------------------------------------------------------------
+# Migration notice
+# ---------------------------------------------------------------------------
+
+
+def _maybe_log_migration_notice(cfg_path: Path) -> None:
+    """Write a one-time migration notice to hook.log if legacy config exists.
+
+    When a legacy ``config.json`` is detected alongside the new
+    ``--autoregen`` CLI-arg path, log a single ``[migration]`` advisory
+    to ``hook.log`` so the user knows to switch to the plugin-manager UX.
+    A sentinel file ``config.json.migrated-notice`` is created after the
+    first notice to prevent log spam on subsequent sessions.
+
+    The legacy ``config.json`` is never deleted.
+
+    Args:
+        cfg_path: Path to the (possibly-absent) legacy config file.
+    """
+    if not cfg_path.exists():
+        return
+
+    sentinel = cfg_path.parent / (cfg_path.name + ".migrated-notice")
+    if sentinel.exists():
+        return  # Already notified; skip to avoid log spam.
+
+    try:
+        log_path = _hook_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Append so the migration line is not lost if _log() writes later.
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(
+                f"[{_timestamp()}] [migration] legacy config.json detected"
+                f" at {cfg_path}; autoregen is now managed via plugin"
+                " user-config — toggle via"
+                " /plugin reconfigure claude-prospector\n"
+            )
+        # Touch sentinel to suppress future notices.
+        sentinel.touch()
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -334,16 +421,45 @@ def _log(message: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the Stop hook.
+
+    Returns:
+        Parsed namespace with ``autoregen`` attribute (str or None).
+    """
+    parser = argparse.ArgumentParser(
+        description="claude-prospector Stop hook",
+        add_help=False,  # Hook must never error on unknown args from harness.
+    )
+    parser.add_argument(
+        "--autoregen",
+        default=None,
+        metavar="VALUE",
+        help=(
+            "Autoregen gate from userConfig substitution. "
+            "Truthy: 'true', '1', 'yes' (case-insensitive). "
+            "Omit to fall back to legacy config.json."
+        ),
+    )
+    # Use parse_known_args so unexpected harness-injected flags don't crash.
+    ns, _ = parser.parse_known_args()
+    return ns
+
+
 def main() -> int:
     """Entry point for the Stop hook. Returns process exit code.
 
     Steps:
     1. Consume stdin (Stop hook payload — content not needed).
-    2. Load config. If autoregen != true, exit 0 as a no-op.
-    3. Check manifest version vs. package version; write mismatch page on
+    2. Determine autoregen state:
+       a. If ``--autoregen`` arg was given: parse it as truthy/falsy.
+          Also check for legacy config.json and log one-time notice.
+       b. Otherwise: fall back to reading config.json (legacy path).
+    3. If autoregen is not enabled, exit 0 as a no-op.
+    4. Check manifest version vs. package version; write mismatch page on
        downgrade.
-    4. Run regen subprocess. Write failure page on non-zero exit.
-    5. Log success and exit 0.
+    5. Run regen subprocess. Write failure page on non-zero exit.
+    6. Log success and exit 0.
 
     Returns:
         Always 0 — hook failures must not propagate to the session runner.
@@ -352,22 +468,31 @@ def main() -> int:
         # Step 1: consume stdin so the process closes cleanly.
         _stdin = sys.stdin.read()
 
-        # Step 2: load config.
+        # Step 2: determine autoregen state.
+        ns = _parse_args()
         cfg_path = _config_path()
-        if not cfg_path.exists():
-            return 0  # No config → autoregen not enabled.
 
-        try:
-            cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
-        except Exception:
-            return 0  # Malformed config → no-op.
+        if ns.autoregen is not None:
+            # New path: --autoregen arg was supplied by hooks.json via
+            # ${user_config.autoregen} substitution.
+            autoregen_enabled = _parse_autoregen_arg(ns.autoregen)
+        else:
+            # Legacy path: --autoregen was not supplied (manual invocation).
+            if not cfg_path.exists():
+                return 0  # No config → autoregen not enabled.
+            try:
+                cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+            except Exception:
+                return 0  # Malformed config → no-op.
+            autoregen_enabled = bool(cfg.get("autoregen"))
 
-        if not cfg.get("autoregen"):
-            return 0  # autoregen disabled.
+        # Step 3: gate on autoregen.
+        if not autoregen_enabled:
+            return 0
 
         dashboard = _dashboard_path()
 
-        # Step 3: version-pin check.
+        # Step 4: version-pin check.
         plugin_root_env = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
         manifest_ver: str | None = None
         if plugin_root_env:
@@ -438,8 +563,12 @@ def main() -> int:
             _write_page(dashboard, _regen_failed_page(regen_result.stderr))
             return 0
 
-        # Step 5: log success.
+        # Step 6: log success, then append one-time migration notice if needed.
+        # _log() uses write mode (truncates), so migration notice must be
+        # appended afterwards via _maybe_log_migration_notice()'s append mode.
         _log(f"Dashboard regenerated successfully → {dashboard}")
+        if ns.autoregen is not None:
+            _maybe_log_migration_notice(cfg_path)
 
     except Exception as exc:
         sys.stderr.write(f"[dashboard-regen] unexpected error: {exc}\n")

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/dashboard-regen.py\""
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/dashboard-regen.py\" --autoregen \"${user_config.autoregen}\""
           }
         ]
       }

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -4,14 +4,16 @@ All subprocess invocations redirect the config file path via the
 ``CLAUDE_PROSPECTOR_CONFIG`` environment variable so tests never touch
 the real home directory.
 
+After issue #99, the config subcommand is read-only (--show only).
+The --enable-autoregen and --disable-autoregen flags are removed; autoregen
+is now managed via the plugin manager user-config (userConfig.autoregen).
+
 Covers:
-- ``--enable-autoregen`` creates the config file with autoregen=true.
-- ``--disable-autoregen`` sets autoregen=false (and creates file if absent).
 - ``--show`` prints the current config; reports "(no config file yet)" when
   absent.
-- Mutual exclusion: combining two flags exits non-zero.
+- ``--show`` prints user-config guidance when no config file exists.
+- ``--enable-autoregen`` and ``--disable-autoregen`` are rejected (unknown).
 - No flags: prints usage hint, exits 0.
-- ``--show`` preserves extra keys in the config file.
 """
 
 from __future__ import annotations
@@ -60,77 +62,34 @@ def _run_config(
 
 
 # ---------------------------------------------------------------------------
-# --enable-autoregen
+# Removed flags (issue #99 — now rejected as unknown)
 # ---------------------------------------------------------------------------
 
 
-class TestEnableAutoregen:
-    """Tests for the --enable-autoregen flag."""
+class TestRemovedFlags:
+    """--enable-autoregen and --disable-autoregen are removed in v0.5.x."""
 
-    def test_creates_config_file_when_absent(self, tmp_path: Path) -> None:
-        """--enable-autoregen creates config.json when it doesn't exist."""
-        cfg_path = tmp_path / "config.json"
-        assert not cfg_path.exists()
-        result = _run_config("--enable-autoregen", config_path=cfg_path)
-        assert result.returncode == 0, result.stderr
-        assert cfg_path.exists()
-
-    def test_sets_autoregen_true(self, tmp_path: Path) -> None:
-        """--enable-autoregen writes autoregen=true to the config file."""
+    def test_enable_autoregen_exits_nonzero(self, tmp_path: Path) -> None:
+        """--enable-autoregen is no longer a valid flag; must exit non-zero."""
         cfg_path = tmp_path / "config.json"
         result = _run_config("--enable-autoregen", config_path=cfg_path)
-        assert result.returncode == 0, result.stderr
-        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
-        assert cfg["autoregen"] is True
+        assert (
+            result.returncode != 0
+        ), "--enable-autoregen should be rejected after demotion to read-only"
 
-    def test_preserves_other_keys(self, tmp_path: Path) -> None:
-        """--enable-autoregen preserves existing keys in the config file."""
-        cfg_path = tmp_path / "config.json"
-        cfg_path.write_text(json.dumps({"some_other_key": 42}), encoding="utf-8")
-        _run_config("--enable-autoregen", config_path=cfg_path)
-        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
-        assert cfg["some_other_key"] == 42
-        assert cfg["autoregen"] is True
-
-    def test_overwrites_false_to_true(self, tmp_path: Path) -> None:
-        """--enable-autoregen flips autoregen from false to true."""
-        cfg_path = tmp_path / "config.json"
-        cfg_path.write_text(json.dumps({"autoregen": False}), encoding="utf-8")
-        _run_config("--enable-autoregen", config_path=cfg_path)
-        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
-        assert cfg["autoregen"] is True
-
-
-# ---------------------------------------------------------------------------
-# --disable-autoregen
-# ---------------------------------------------------------------------------
-
-
-class TestDisableAutoregen:
-    """Tests for the --disable-autoregen flag."""
-
-    def test_creates_config_file_when_absent(self, tmp_path: Path) -> None:
-        """--disable-autoregen creates config.json when it doesn't exist."""
+    def test_disable_autoregen_exits_nonzero(self, tmp_path: Path) -> None:
+        """--disable-autoregen is no longer a valid flag; must exit non-zero."""
         cfg_path = tmp_path / "config.json"
         result = _run_config("--disable-autoregen", config_path=cfg_path)
-        assert result.returncode == 0, result.stderr
-        assert cfg_path.exists()
+        assert (
+            result.returncode != 0
+        ), "--disable-autoregen should be rejected after demotion to read-only"
 
-    def test_sets_autoregen_false(self, tmp_path: Path) -> None:
-        """--disable-autoregen writes autoregen=false."""
+    def test_enable_autoregen_does_not_write_config(self, tmp_path: Path) -> None:
+        """--enable-autoregen must not create or modify config.json."""
         cfg_path = tmp_path / "config.json"
-        result = _run_config("--disable-autoregen", config_path=cfg_path)
-        assert result.returncode == 0, result.stderr
-        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
-        assert cfg["autoregen"] is False
-
-    def test_flips_true_to_false(self, tmp_path: Path) -> None:
-        """--disable-autoregen flips autoregen from true to false."""
-        cfg_path = tmp_path / "config.json"
-        cfg_path.write_text(json.dumps({"autoregen": True}), encoding="utf-8")
-        _run_config("--disable-autoregen", config_path=cfg_path)
-        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
-        assert cfg["autoregen"] is False
+        _run_config("--enable-autoregen", config_path=cfg_path)
+        assert not cfg_path.exists(), "Removed flag must not side-effect config.json"
 
 
 # ---------------------------------------------------------------------------
@@ -174,30 +133,14 @@ class TestShow:
         result = _run_config("--show", config_path=cfg_path)
         assert result.stdout.strip() == "{}"
 
-
-# ---------------------------------------------------------------------------
-# Mutual exclusion
-# ---------------------------------------------------------------------------
-
-
-class TestMutualExclusion:
-    """Tests for the mutually-exclusive flag group."""
-
-    def test_enable_and_disable_together_exits_nonzero(self, tmp_path: Path) -> None:
-        """--enable-autoregen and --disable-autoregen together must fail."""
-        cfg_path = tmp_path / "config.json"
-        result = _run_config(
-            "--enable-autoregen",
-            "--disable-autoregen",
-            config_path=cfg_path,
-        )
-        assert result.returncode != 0
-
-    def test_enable_and_show_together_exits_nonzero(self, tmp_path: Path) -> None:
-        """--enable-autoregen and --show together must fail."""
-        cfg_path = tmp_path / "config.json"
-        result = _run_config("--enable-autoregen", "--show", config_path=cfg_path)
-        assert result.returncode != 0
+    def test_show_mentions_plugin_manager_when_config_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """--show with no config mentions plugin manager for configuration."""
+        cfg_path = tmp_path / "nonexistent-config.json"
+        result = _run_config("--show", config_path=cfg_path)
+        combined = result.stdout + result.stderr
+        assert "plugin" in combined.lower() or "reconfigure" in combined.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -214,9 +157,9 @@ class TestNoFlags:
         result = _run_config(config_path=cfg_path)
         assert result.returncode == 0
 
-    def test_no_flags_mentions_flags(self, tmp_path: Path) -> None:
-        """'config' with no flags must mention the available flags."""
+    def test_no_flags_mentions_show(self, tmp_path: Path) -> None:
+        """'config' with no flags must mention --show."""
         cfg_path = tmp_path / "config.json"
         result = _run_config(config_path=cfg_path)
         combined = result.stdout + result.stderr
-        assert "autoregen" in combined
+        assert "--show" in combined

--- a/tests/test_dashboard_regen_hook.py
+++ b/tests/test_dashboard_regen_hook.py
@@ -10,6 +10,12 @@ The contract verified for each test:
 - autoregen=true + regen success: dashboard.html exists with non-zero size.
 - autoregen=true + regen failure: writes "regen failed" page with stderr.
 
+New (issue #99) contracts:
+- --autoregen true/false/1/yes/no: hook parses the CLI arg as the gate.
+- --autoregen absent: hook falls back to legacy config.json.
+- Migration notice: one-time log entry when legacy config.json is present.
+- Sentinel file prevents duplicate migration notices.
+
 Hook input:
     The Stop hook payload is read from stdin. The hook ignores the payload
     content — only autoregen config and the python subprocess matter. We
@@ -100,25 +106,73 @@ def _make_env(
 def _run_hook(
     env: dict[str, str],
     stdin_payload: dict | None = None,
+    autoregen_arg: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Invoke dashboard-regen.py as a subprocess.
 
     Args:
         env: Environment dict (from _make_env).
         stdin_payload: JSON payload to write to stdin. Defaults to ``{}``.
+        autoregen_arg: If given, passes ``--autoregen <value>`` to the hook.
+            When None, the hook is invoked without the flag (legacy path).
 
     Returns:
         CompletedProcess with stdout, stderr, returncode.
     """
     payload = json.dumps(stdin_payload or {})
+    cmd = [sys.executable, str(_HOOK_PATH)]
+    if autoregen_arg is not None:
+        cmd += ["--autoregen", autoregen_arg]
     return subprocess.run(
-        [sys.executable, str(_HOOK_PATH)],
+        cmd,
         input=payload,
         capture_output=True,
         text=True,
         env=env,
         cwd=str(_WORKTREE),
     )
+
+
+def _make_env_no_config(
+    tmp_path: Path,
+    *,
+    manifest_version: str = _MANIFEST_VERSION,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build env pointing at non-existent config (no config.json created).
+
+    Useful for testing the --autoregen CLI-arg path where config.json
+    should not exist.
+
+    Args:
+        tmp_path: pytest temporary directory.
+        manifest_version: Version string to embed in the plugin manifest.
+        extra: Extra vars to merge (last wins).
+
+    Returns:
+        Environment dict suitable for ``subprocess.run(..., env=...)``.
+    """
+    cfg_path = tmp_path / "config.json"  # intentionally not created
+
+    dashboard_file = tmp_path / "dashboard.html"
+    hook_log = tmp_path / "hook.log"
+
+    plugin_root = tmp_path / "plugin-root"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    (plugin_root / "plugin.json").write_text(
+        json.dumps({"version": manifest_version}), encoding="utf-8"
+    )
+
+    env = {
+        **os.environ,
+        "CLAUDE_PROSPECTOR_CONFIG": str(cfg_path),
+        "CLAUDE_PROSPECTOR_DASHBOARD": str(dashboard_file),
+        "CLAUDE_PROSPECTOR_HOOK_LOG": str(hook_log),
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+    }
+    if extra:
+        env.update(extra)
+    return env
 
 
 # ---------------------------------------------------------------------------
@@ -304,3 +358,170 @@ class TestRegenFailure:
         env["CLAUDE_PROSPECTOR_FAIL_REGEN"] = "1"
         result = _run_hook(env)
         assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# --autoregen CLI argument parsing (issue #99)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoregenArgParsing:
+    """--autoregen CLI arg gates the hook; truthy/falsy values are parsed."""
+
+    def test_autoregen_true_enables_regen(self, tmp_path: Path) -> None:
+        """--autoregen true triggers dashboard generation (success path)."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env, autoregen_arg="true")
+        assert result.returncode == 0, result.stderr
+        dashboard = tmp_path / "dashboard.html"
+        assert dashboard.exists(), (
+            f"Dashboard not created with --autoregen true. "
+            f"stderr: {result.stderr!r}"
+        )
+
+    def test_autoregen_false_is_noop(self, tmp_path: Path) -> None:
+        """--autoregen false skips dashboard generation."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env, autoregen_arg="false")
+        assert result.returncode == 0, result.stderr
+        assert not (tmp_path / "dashboard.html").exists()
+
+    def test_autoregen_1_enables_regen(self, tmp_path: Path) -> None:
+        """--autoregen 1 is treated as truthy."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env, autoregen_arg="1")
+        assert result.returncode == 0, result.stderr
+        assert (tmp_path / "dashboard.html").exists()
+
+    def test_autoregen_yes_enables_regen(self, tmp_path: Path) -> None:
+        """--autoregen yes is treated as truthy."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env, autoregen_arg="yes")
+        assert result.returncode == 0, result.stderr
+        assert (tmp_path / "dashboard.html").exists()
+
+    def test_autoregen_true_case_insensitive(self, tmp_path: Path) -> None:
+        """--autoregen TRUE (uppercase) is treated as truthy."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env, autoregen_arg="TRUE")
+        assert result.returncode == 0, result.stderr
+        assert (tmp_path / "dashboard.html").exists()
+
+    def test_autoregen_empty_string_is_noop(self, tmp_path: Path) -> None:
+        """--autoregen '' (empty string) is treated as falsy."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env, autoregen_arg="")
+        assert result.returncode == 0, result.stderr
+        assert not (tmp_path / "dashboard.html").exists()
+
+    def test_autoregen_0_is_noop(self, tmp_path: Path) -> None:
+        """--autoregen 0 is treated as falsy."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env, autoregen_arg="0")
+        assert result.returncode == 0, result.stderr
+        assert not (tmp_path / "dashboard.html").exists()
+
+
+# ---------------------------------------------------------------------------
+# Legacy config.json fallback (issue #99)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyConfigFallback:
+    """When --autoregen is absent, the hook falls back to config.json."""
+
+    def test_no_arg_with_autoregen_true_in_config_enables_regen(
+        self, tmp_path: Path
+    ) -> None:
+        """No --autoregen arg + config.json autoregen=true triggers regen."""
+        env = _make_env(tmp_path, autoregen=True)
+        result = _run_hook(env)  # no autoregen_arg
+        assert result.returncode == 0, result.stderr
+        assert (tmp_path / "dashboard.html").exists()
+
+    def test_no_arg_with_autoregen_false_in_config_is_noop(
+        self, tmp_path: Path
+    ) -> None:
+        """No --autoregen arg + config.json autoregen=false is a no-op."""
+        env = _make_env(tmp_path, autoregen=False)
+        result = _run_hook(env)
+        assert result.returncode == 0, result.stderr
+        assert not (tmp_path / "dashboard.html").exists()
+
+    def test_no_arg_no_config_is_noop(self, tmp_path: Path) -> None:
+        """No --autoregen arg + no config.json at all is a no-op."""
+        env = _make_env_no_config(tmp_path)
+        result = _run_hook(env)
+        assert result.returncode == 0, result.stderr
+        assert not (tmp_path / "dashboard.html").exists()
+
+
+# ---------------------------------------------------------------------------
+# Migration notice (issue #99)
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationNotice:
+    """Legacy config.json triggers a one-time migration notice in hook.log."""
+
+    def test_migration_notice_logged_when_legacy_config_present(
+        self, tmp_path: Path
+    ) -> None:
+        """First run with legacy config.json writes [migration] to hook.log."""
+        # Pass --autoregen true so the hook proceeds past the autoregen gate,
+        # then checks for the legacy file.
+        env = _make_env(tmp_path, autoregen=True)
+        _run_hook(env, autoregen_arg="true")
+        hook_log = tmp_path / "hook.log"
+        assert hook_log.exists(), "hook.log should exist after successful regen"
+        content = hook_log.read_text(encoding="utf-8")
+        assert (
+            "[migration]" in content
+        ), f"Expected [migration] prefix in hook.log. Got: {content!r}"
+
+    def test_migration_notice_not_logged_when_no_legacy_config(
+        self, tmp_path: Path
+    ) -> None:
+        """No legacy config.json means no [migration] line in hook.log."""
+        env = _make_env_no_config(tmp_path)
+        _run_hook(env, autoregen_arg="true")
+        hook_log = tmp_path / "hook.log"
+        if hook_log.exists():
+            content = hook_log.read_text(encoding="utf-8")
+            assert (
+                "[migration]" not in content
+            ), "Should not log [migration] when no legacy config present"
+
+    def test_migration_notice_written_only_once(self, tmp_path: Path) -> None:
+        """Second run does not repeat the [migration] notice (sentinel guards)."""
+        env = _make_env(tmp_path, autoregen=True)
+
+        # First run — should write notice.
+        _run_hook(env, autoregen_arg="true")
+        hook_log_after_first = (tmp_path / "hook.log").read_text(encoding="utf-8")
+        assert "[migration]" in hook_log_after_first
+
+        # Second run — hook.log is truncated each run; if sentinel works, the
+        # migration line must NOT appear this time.
+        _run_hook(env, autoregen_arg="true")
+        hook_log_after_second = (tmp_path / "hook.log").read_text(encoding="utf-8")
+        assert (
+            "[migration]" not in hook_log_after_second
+        ), "Migration notice should not appear on second run (sentinel check)"
+
+    def test_sentinel_file_created_after_first_run(self, tmp_path: Path) -> None:
+        """Sentinel file config.json.migrated-notice is created after notice."""
+        env = _make_env(tmp_path, autoregen=True)
+        _run_hook(env, autoregen_arg="true")
+        sentinel = tmp_path / "config.json.migrated-notice"
+        assert (
+            sentinel.exists()
+        ), "Expected sentinel file 'config.json.migrated-notice' to be created"
+
+    def test_legacy_config_not_deleted(self, tmp_path: Path) -> None:
+        """Migration must NOT delete the legacy config.json file."""
+        env = _make_env(tmp_path, autoregen=True)
+        cfg_path = tmp_path / "config.json"
+        assert cfg_path.exists(), "Precondition: config.json must exist"
+        _run_hook(env, autoregen_arg="true")
+        assert cfg_path.exists(), "config.json must not be deleted during migration"


### PR DESCRIPTION
## Summary

Implements the user-config half of the #95 plugin-convention audit. The `autoregen` setting moves from a CLI-mutated `${CLAUDE_PLUGIN_DATA}/config.json` to Anthropic's documented `userConfig` manifest block — the convention prescribed by [Plugins reference § User configuration](https://code.claude.com/docs/en/plugins-reference#user-configuration) (fetched 2026-05-16).

## Design

- **Manifest** — `.claude-plugin/plugin.json` declares `userConfig.autoregen` (boolean) with title and description. Claude Code prompts the user at plugin enable time and on `/plugin reconfigure claude-prospector`.
- **Hook command** — `hooks/hooks.json` Stop hook passes the substituted value as a CLI argument: `--autoregen "${user_config.autoregen}"`. **Doing the truthy check in Python** sidesteps two ambiguities at once: how Claude Code substitutes booleans into command strings (undocumented), and which shell syntax is portable across POSIX and Windows. The Python parse is the canonical gate.
- **Truthy parser** — `"true"`, `"1"`, `"yes"` (case-insensitive) are truthy; anything else, including the empty string (which is what an unset `userConfig` value substitutes to), is falsy. Default-off semantics on first install.
- **Legacy fallback** — when `--autoregen` is **not** passed (manual hook invocation outside Claude Code), the script falls back to reading `${CLAUDE_PLUGIN_DATA}/config.json` as before. Preserves the manual-invocation escape hatch.
- **Migration notice** — if the legacy `config.json` is present at hook time, a one-time `[migration] legacy config.json detected at <path>; autoregen is now managed via plugin user-config — toggle via /plugin reconfigure claude-prospector` line is written to `hook.log`. A sentinel file `config.json.migrated-notice` suppresses repeats. **The legacy file is never deleted** — users can still consult it to see what their previous toggle state was.
- **CLI demoted** — `python -m claude_prospector config` keeps only `--show`. The mutation flags (`--enable-autoregen` / `--disable-autoregen`) are removed; their job now belongs to the plugin manager. `--show` with no config present advises the user to use `/plugin reconfigure claude-prospector`.

## Files changed

| File | Change |
|---|---|
| `.claude-plugin/plugin.json` | + `userConfig.autoregen` block |
| `hooks/hooks.json` | Stop command passes `--autoregen "${user_config.autoregen}"` |
| `hooks/dashboard-regen.py` | `argparse` for `--autoregen`, truthy parser, migration-notice with sentinel, fallback to `config.json` when arg absent |
| `claude_prospector/cli/config.py` | Trim to read-only `--show`; remove mutation flags; updated empty-state messaging |
| `tests/test_cli_config.py` | Drop `TestEnableAutoregen` / `TestDisableAutoregen` / `TestMutualExclusion`; add `TestRemovedFlags`; update `TestShow` / `TestNoFlags` |
| `tests/test_dashboard_regen_hook.py` | + `TestAutoregenArgParsing` (8), `TestLegacyConfigFallback` (3), `TestMigrationNotice` (5) |
| `README.md` | Configuration section rewrite — plugin-manager UX first, `--show` as inspection escape hatch |

## Verification (all CI gates green locally)

| Gate | Result |
|---|---|
| `python -m pytest` | **322 passed** (was 312 in v0.5.0; net +10 after removing CLI-mutation tests and adding hook tests) |
| `python -m ruff check` | All checks passed |
| `python -m ruff format --check` | 35 files already formatted |

## Notes for review

- The default-falsy behavior of the empty-string substitution is the **documented** correct behavior for an opt-in feature — users must affirmatively enable autoregen via the plugin manager (or accept the prompt at install time). Existing users with `autoregen: true` in their legacy `config.json` will see autoregen **stop firing** until they re-toggle through the plugin manager; the migration notice surfaces this. This is intentional — silently honoring legacy state would defeat the point of the convention move.
- This change does NOT bump the plugin/package version. Version bump batched with the release PR that ships this.

Closes #99.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_