### PR TITLE
release: v0.6.0 (userConfig refactor)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-17
+
+### Changed
+
+- **Breaking — user-config mechanism:** the `autoregen` setting is now declared in `plugin.json` under the `userConfig` block and toggled through the plugin manager (`/plugin reconfigure claude-prospector` or the install-time prompt), per [Anthropic's documented convention](https://code.claude.com/docs/en/plugins-reference#user-configuration). The `Stop` hook receives the value via `--autoregen "${user_config.autoregen}"` and parses truthiness in Python (`true` / `1` / `yes` case-insensitive). (#99, #100)
+- **Breaking — CLI surface:** `python -m claude_prospector config` is now read-only (`--show`). The mutation flags `--enable-autoregen` and `--disable-autoregen` are removed — their job belongs to the plugin manager now.
+- **Behavioral break for existing users:** if you had `autoregen: true` in the legacy `${CLAUDE_PLUGIN_DATA}/config.json`, autoregen will stop firing after upgrading until you re-toggle it through the plugin manager. The legacy file is preserved (not deleted) so you can consult your previous state.
+
+### Added
+
+- One-time `[migration]` notice written to `hook.log` when the legacy `config.json` is detected, advising users to re-toggle through the plugin manager. A sentinel file (`config.json.migrated-notice`) suppresses duplicate notices. (#100)
+
+[0.6.0]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.6.0
+
 ## [0.5.0] - 2026-05-17
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.5.0"
+version = "0.6.0"
 description = "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill."
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Single feature change since v0.5.0 — PR #100 (userConfig refactor, closes #99 and completes the #95 plugin-convention audit). Minor bump with intentional breaking changes per `0.x.x` semver.

- Bump `pyproject.toml` → `0.6.0`
- Bump `.claude-plugin/plugin.json` → `0.6.0`
- Add `CHANGELOG.md` v0.6.0 section citing #99 / #100 with breaking-change notice

## Breaking changes (call out for users)

- **CLI surface:** `python -m claude_prospector config --enable-autoregen` / `--disable-autoregen` flags removed. Use the plugin manager (`/plugin reconfigure claude-prospector`).
- **Behavioral:** existing users with `autoregen: true` in legacy `${CLAUDE_PLUGIN_DATA}/config.json` will see autoregen stop firing until they re-toggle through the plugin manager. The migration notice surfaces this in `hook.log`. The legacy file is preserved.

## Verification

- `pytest`: 322 passed
- `ruff check`: All checks passed
- `ruff format --check`: 35 files already formatted

## Post-merge follow-up

- [ ] Tag `v0.6.0` on the squashed merge commit and push
- [ ] Bump `glitchwerks/plugins/.claude-plugin/marketplace.json` — `claude-prospector.source.sha` → v0.6.0 tag commit
- [ ] Reinstall editable into `~/.claude/.venv` so `importlib.metadata.version("claude-prospector")` reports `0.6.0`

Closes #103.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_