### PR TITLE
ci: add PyPI trusted-publisher release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+
+  # ---------------------------------------------------------------------------
+  # Build sdist + wheel
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      # verified 2026-05-17 via gh api repos/astral-sh/setup-uv/git/refs/tags/v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: "3.10"
+          activate-environment: "true"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Upload built distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dist
+          path: dist/
+
+  # ---------------------------------------------------------------------------
+  # Publish to PyPI (stable tags only — no -rc / -alpha / -beta)
+  # ---------------------------------------------------------------------------
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref, '-rc') && !contains(github.ref, '-alpha') && !contains(github.ref, '-beta') }}
+    environment:
+      name: pypi
+      url: https://pypi.org/p/claude-prospector
+    permissions:
+      id-token: write  # Required for trusted publisher OIDC
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        # verified 2026-05-17 via gh api repos/pypa/gh-action-pypi-publish/git/refs/tags/v1.14.0 (annotated tag) → git/tags/<tag-sha>.object.sha
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+
+  # ---------------------------------------------------------------------------
+  # Publish to TestPyPI (pre-release tags: -rc / -alpha / -beta)
+  # ---------------------------------------------------------------------------
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: contains(github.ref, '-rc') || contains(github.ref, '-alpha') || contains(github.ref, '-beta')
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/claude-prospector
+    permissions:
+      id-token: write  # Required for trusted publisher OIDC
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        # verified 2026-05-17 via gh api repos/pypa/gh-action-pypi-publish/git/refs/tags/v1.14.0 (annotated tag) → git/tags/<tag-sha>.object.sha
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

Adds a PyPI trusted-publisher release workflow mirroring the OIDC pattern used by `glitchwerks/claude-wayfinder`. On every `v*` tag push, the workflow builds an sdist and wheel via `uv build`, then publishes to PyPI using OIDC federation — no long-lived API tokens required.

- **Stable tags** (`v1.2.3`, `v0.6.1`) → PyPI (`pypi` environment)
- **Pre-release tags** (`v1.0.0-rc1`, `v1.0.0-alpha`) → TestPyPI (`testpypi` environment)
- All `uses:` lines are SHA-pinned with tag comments, verified against the GitHub refs API at write time

Refs #107 (AC1 — PyPI publish prerequisite for Pattern W adoption)

## Manual steps required before first release

The workflow uses PyPI's **trusted publisher** (OIDC) mechanism — no API token is stored as a GitHub secret. Before pushing the first `v*` tag, you must configure the trusted publisher on the PyPI side:

1. Go to https://pypi.org/manage/account/publishing/ (or the project page once created)
2. Add a new pending trusted publisher:
   - **PyPI project name**: `claude-prospector`
   - **Owner**: `glitchwerks`
   - **Repository name**: `claude-prospector`
   - **Workflow filename**: `release.yml`
   - **Environment name**: `pypi`
3. Repeat for TestPyPI at https://test.pypi.org/manage/account/publishing/ using environment name `testpypi`
4. Create the **GitHub Environments** (`pypi` and `testpypi`) in repo Settings → Environments if they don't exist yet — the OIDC token's audience scope is bound to the environment name

## Trigger contract

```bash
# Stable release → publishes to PyPI
git tag v0.6.1
git push origin v0.6.1

# Pre-release → publishes to TestPyPI
git tag v0.7.0-rc1
git push origin v0.7.0-rc1
```

## Differences from this brief vs. wayfinder (wayfinder is authoritative)

The task brief suggested `release: { types: [published] }` as the trigger. Wayfinder uses `push: tags: v*` instead. I followed wayfinder's pattern — tag push is more automatable (no UI step required), separates stable vs pre-release cleanly via the tag name, and is the pattern the user already runs via `gh release create`.

---

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*
