### PR TITLE
release: bump to 0.7.0rc1 for TestPyPI rehearsal

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.6.0",
+  "version": "0.7.0rc1",
   "description": "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0rc1] - 2026-05-18
+
+### Added
+
+- TestPyPI rehearsal of the PyPI publish workflow shipped in #109. No functional changes — this release-candidate validates the OIDC trusted-publisher + tag-routing wiring end-to-end before the real `v0.7.0` ships Pattern W adoption (#107). (#111)
+
+[0.7.0rc1]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.7.0-rc1
+
 ## [0.6.0] - 2026-05-17
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.6.0"
+version = "0.7.0rc1"
 description = "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill."
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Bumps `pyproject.toml` and `.claude-plugin/plugin.json` to `0.7.0rc1` and adds a placeholder CHANGELOG entry so a `v0.7.0-rc1` tag push exercises the PyPI publish workflow (`.github/workflows/release.yml`, merged in #109) end-to-end against TestPyPI.

No functional changes — this rehearses the OIDC trusted-publisher + tag-routing wiring before the real `v0.7.0` ships Pattern W adoption (#107).

## Post-merge

1. Push tag `v0.7.0-rc1` (the `v*-*` pre-release route in `release.yml` → `testpypi` environment).
2. Watch the `release` workflow on the tag.
3. Verify `pip install --index-url https://test.pypi.org/simple/ claude-prospector==0.7.0rc1` succeeds.

Closes #111

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_