### PR TITLE
docs(skills): sharpen activation descriptions (closes #101)

### DIFF
--- a/skills/usage-analysis/SKILL.md
+++ b/skills/usage-analysis/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: usage-analysis
 description: >
-  Analyzes Claude Code token usage and provides optimization recommendations.
-  Trigger phrases: "am I close to my limit", "how much Sonnet am I using",
-  "token budget", "where are my tokens going", "what's eating my budget",
-  "which agent uses the most".
+  Use when the user asks an interpretive question about their Claude Code
+  token spend — budget status across the 5h / 7d / Sonnet-7d billing buckets,
+  which agents/skills/projects are eating their budget, model-distribution
+  drift, or what to change to reduce spend. Regenerates the
+  `claude-prospector` dashboard as needed and reads the embedded data to
+  answer. Do NOT use for bare "regenerate the dashboard" requests with no
+  question attached (use `usage-dashboard` instead).
+  Trigger phrases: "am I close to my Claude limit", "how much Sonnet am I
+  using", "where are my Claude tokens going", "what's eating my Claude
+  budget", "which agent uses the most tokens", "why is my Claude spend so
+  high".
 ---
 
 ## Prerequisites

--- a/skills/usage-dashboard/SKILL.md
+++ b/skills/usage-dashboard/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: usage-dashboard
 description: >
-  Regenerates the Claude Code token usage HTML dashboard for the
-  `claude-prospector` plugin. Bare regeneration surface — writes the file and
-  reports the path; does not interpret the data.
-  Trigger phrases: "regenerate the dashboard", "rebuild my usage dashboard",
-  "refresh the usage dashboard", "regen the dashboard",
-  "regenerate the usage dashboard".
+  Use when the user explicitly asks to regenerate, rebuild, or refresh the
+  `claude-prospector` token-usage dashboard with no interpretive question
+  attached — runs `python -m claude_prospector dashboard`, writes the HTML
+  file, and reports the output path. Do NOT use when the user is asking what
+  the data means, where their budget stands, or what to change (use
+  `usage-analysis` instead — it regenerates as part of answering).
+  Trigger phrases: "regenerate the usage dashboard", "rebuild my
+  claude-prospector dashboard", "refresh the token dashboard", "regen the
+  prospector dashboard".
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

Rewrites `description:` frontmatter for both plugin skills (`usage-analysis`, `usage-dashboard`) to follow Claude Code's "Use when..." activation framing and explicitly delineate their boundaries.

## Audit findings

Both skills lacked `triggers.yml` sidecars — the `description:` field is the entire activation surface (this plugin doesn't ship its own wayfinder catalog, so Claude Code's native description-matching is what drives activation).

**`usage-analysis`** — solid trigger phrase list (the in-body table already de-risked false-positive phrases like "show usage" / "check my usage"), but:
- Opened with bare "Analyzes..." instead of "Use when..."
- No explicit "do not use for X" boundary against `usage-dashboard`
- Some trigger phrases ("token budget", "where are my tokens going") lacked Claude-specific qualifiers and risked false positives in cloud-billing or API-quota contexts

**`usage-dashboard`** — clear "does not interpret the data" body, but:
- "Bare regeneration surface" is jargon for an activation hint
- 4 of 5 trigger phrases were near-duplicates ("regenerate/rebuild/refresh/regen the dashboard")
- "the dashboard" bare is overloaded — every dashboard in any context

## Changes

Both descriptions now:

1. Lead with "Use when..." framing
2. Include an explicit "Do NOT use ... (use other skill instead)" boundary
3. Qualify trigger phrases with "Claude" / "prospector" / "token" disambiguators
4. Drop near-duplicate trigger phrases for variants with meaningful keyword diversity

No changes to skill bodies — activation surface only.

## Test plan

- [x] Manual smoke: confirm Claude activates `usage-analysis` (not `usage-dashboard`) on a sample interpretive prompt like "where are my Claude tokens going?"
- [x] Manual smoke: confirm Claude activates `usage-dashboard` (not `usage-analysis`) on a bare prompt like "regenerate the prospector dashboard"

Closes #101

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_