### PR TITLE
release: bump to 0.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-05-18
+
+### Changed
+
+- Rewrote `description:` frontmatter for both plugin skills
+  (`usage-analysis`, `usage-dashboard`) to use "Use when..." activation
+  framing with explicit "Do NOT use ... (use other skill instead)"
+  boundaries. Trigger phrases now carry `Claude` / `prospector` / `token`
+  disambiguators to prevent false positives in cloud-billing or
+  API-quota contexts. (#119, closes #101)
+- README audited for correctness against v0.7.0 code and restructured
+  into 12 sections; "Why" section rewritten to acknowledge Claude
+  Code's built-in `/usage` command and clarify what `claude-prospector`
+  adds on top. (#118)
+
+### Removed
+
+- Empty `commands/` folder (deprecated surface — skills replaced
+  commands in v0.6.0). (#117)
+
 ## [0.7.0] - 2026-05-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.7.0"
+version = "0.7.1"
 description = "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill."
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Patch release covering docs/chore changes since v0.7.0. No code or behavior changes.

## Changes since v0.7.0

- **#117** — chore: remove empty `commands/` folder
- **#118** — docs: audit + restructure README for v0.7.0
- **#119** — docs(skills): sharpen activation descriptions (closes #101)

## This PR

- Bumps `pyproject.toml` and `.claude-plugin/plugin.json` to `0.7.1`
- Adds `## [0.7.1] - 2026-05-18` CHANGELOG entry

## Post-merge

- Push `v0.7.1` tag → release workflow publishes to PyPI
- Bump `glitchwerks/plugins` `marketplace.json` (sha + version)

Closes #121

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_