### PR TITLE
feat(skills): port claude-audit skill from user-global into the plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-prospector",
   "version": "0.7.1",
-  "description": "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill.",
+  "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
   "author": {
     "name": "Christopher Beaulieu",
     "email": "cmb_dev@outlook.com"
@@ -9,7 +9,7 @@
   "license": "MIT",
   "homepage": "https://github.com/glitchwerks/claude-prospector",
   "repository": "https://github.com/glitchwerks/claude-prospector",
-  "keywords": ["claude-code", "usage", "tokens", "billing", "dashboard", "observability"],
+  "keywords": ["claude-code", "usage", "tokens", "billing", "dashboard", "observability", "audit", "config-hygiene"],
   "userConfig": {
     "autoregen": {
       "type": "boolean",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `claude-audit` skill: audits your effective Claude Code configuration
+  (custom + plugin-provided agents and skills) and produces a structured
+  overlap / conflict report with keep / modify / drop recommendations
+  scoped to the project's stated objectives. Activates via
+  `/claude-prospector:claude-audit` or natural-language phrases like
+  "audit my claude config", "find overlap in my agents". Read-only —
+  produces a report only; does not modify any files. (#123)
+
+### Changed
+
+- Plugin and PyPI `description:` fields reframed from "token usage
+  analyzer" to "Claude Code efficiency and hygiene toolkit" to reflect
+  the broader scope (cost + config-hygiene angles). README "Why" section
+  updated with a per-skill responsibility table. (#123)
+
+### Notes
+
+- The user-global `~/.claude/skills/claude-audit/` directory should be
+  removed at release time, to avoid duplicate-activation noise. Do not
+  delete the user-global copy until this version is published. (#123)
+
 ## [0.7.1] - 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # claude-prospector
 
-Token usage analyzer for Claude Code that surfaces where your budget is going across all three billing windows, with per-model and per-agent attribution and concrete optimization recommendations.
+Claude Code efficiency and hygiene toolkit. Surfaces token spend across the three billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration for agent and skill overlap.
 
 ## Why
 
-Claude Code's built-in `/usage` shows current-session token totals and — for Max/Pro subscribers — plan-usage bars on the same screen. It doesn't surface multi-day history, per-agent attribution with sub-agent nesting, per-skill invocation counts, or per-project breakdowns, and there's no way to ask "where are my Sonnet-7d tokens going this week?" from inside the session.
+`claude-prospector` bundles a set of skills that target distinct angles of "is my Claude Code setup healthy?":
 
-`claude-prospector` reads Claude Code's local JSONL session files across all your sessions and generates a dashboard that breaks down where your tokens are going — by model, agent (with sub-agent nesting), skill, and project — across all three billing windows (5h rolling, 7d rolling, Sonnet-only 7d).
+| Skill | Angle |
+|---|---|
+| `usage-analysis` | where your tokens are going |
+| `usage-dashboard` | regenerate the cost dashboard surface |
+| `claude-audit` | where your config has agent / skill overlap or bloat |
+
+Claude Code's built-in `/usage` shows current-session token totals and — for Max/Pro subscribers — plan-usage bars on the same screen. It doesn't surface multi-day history, per-agent attribution with sub-agent nesting, per-skill invocation counts, or per-project breakdowns, and there's no way to ask "where are my Sonnet-7d tokens going this week?" from inside the session. There's also no built-in way to detect when two installed plugins ship overlapping `code-reviewer` agents or near-duplicate skills.
+
+`claude-prospector` reads Claude Code's local JSONL session files to break tokens down by model, agent (with sub-agent nesting), skill, and project across all three billing windows (5h rolling, 7d rolling, Sonnet-only 7d), and inventories your custom + plugin-provided agents and skills to produce a structured overlap / conflict report with keep / modify / drop recommendations.
 
 ## Install
 
@@ -63,6 +71,18 @@ The generated HTML dashboard includes:
 - **Skill usage** — invocation counts per skill
 - **Project breakdown** — tokens per project
 - **Session drill-down** — click a day to see individual sessions with agents, tokens, and model split
+
+### `claude-audit` skill
+
+Audits your project's effective Claude Code configuration — custom and plugin-provided agents and skills together — and produces a structured overlap / conflict report with keep / modify / drop recommendations scoped to the project's stated objectives. Triggered by `/claude-prospector:claude-audit` or natural-language phrases such as:
+
+- "audit my claude config"
+- "find overlap in my agents"
+- "check for skill conflicts"
+- "are any of my agents duplicates"
+- "what's redundant in my setup"
+
+The skill is read-only — it does not modify any files. All recommendations are presented for your review.
 
 ### `setup-prospector` skill
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "claude-prospector"
 version = "0.7.1"
-description = "Claude Code token usage analyzer with optimization recommendations. Surfaces what's eating your budget across the 5h / 7d / Sonnet-7d billing windows, with per-model and nested per-agent attribution and skill adoption tracking. Ships both an interactive dashboard and a conversational analysis skill."
+description = "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill."
 requires-python = ">=3.10"
 dependencies = [
     "jinja2>=3.1",

--- a/skills/claude-audit/SKILL.md
+++ b/skills/claude-audit/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: claude-audit
+description: >
+  Audit a project's effective Claude Code configuration — custom and plugin-provided agents and
+  skills — and produce a structured overlap/conflict report with keep / modify / drop
+  recommendations scoped to the project's stated objectives. Trigger this skill whenever the
+  user types `/claude-audit`, asks to "audit my claude config", "find overlap in my agents",
+  "check for skill conflicts", "are any of my agents duplicates", "what's redundant in my
+  setup", or any similar request to review the agent/skill surface for the current project.
+  Also trigger after a fresh plugin install when the user wants to verify nothing new collides
+  with what's already there.
+context-switch: false
+---
+
+# Claude Audit Skill
+
+Produce a deterministic overlap/conflict report for the project's effective Claude Code
+configuration. The audit considers user-scope (`~/.claude/`), project-scope
+(`<project>/.claude/`), and plugin-provided sources together — because that is what the agent
+actually loads at runtime.
+
+The output is a single markdown report. The skill itself does **not** modify any files. All
+recommendations are presented to the user; they decide what to change.
+
+---
+
+## Step 1: Discover the project objective
+
+Before evaluating overlaps, read the project's `CLAUDE.md` (and any `README.md`) at the repo
+root to understand what the project does. Specific things to extract:
+
+- **Domain** — web app, infra, mobile, ML, mod development, etc.
+- **Languages / frameworks** — informs which language skills are relevant
+- **Workflows codified in CLAUDE.md** — issue tracking, PR conventions, branching, testing
+
+Recommendations later are scoped to these. A `python` skill is not "redundant" just because
+the project also uses TypeScript — it might still be load-bearing for tooling scripts.
+
+If no project-level `CLAUDE.md` exists, fall back to the user-level `~/.claude/CLAUDE.md` and
+note that the audit is using the user-scope objective only.
+
+---
+
+## Step 2: Inventory all sources
+
+Enumerate every agent and skill that could be loaded:
+
+### User-scope custom
+
+```bash
+ls ~/.claude/agents/*.md            # custom agents
+ls ~/.claude/skills/*/SKILL.md      # custom skills
+```
+
+### Project-scope custom
+
+```bash
+ls <project>/.claude/agents/*.md    # if the dir exists
+ls <project>/.claude/skills/*/SKILL.md
+```
+
+### Plugin-provided
+
+1. Read `~/.claude/plugins/installed_plugins.json` to find the install path of every active
+   plugin.
+2. For each plugin's install path, list:
+   - `<install-path>/agents/*.md`
+   - `<install-path>/skills/*/SKILL.md`
+
+### Other plugin-managed sources
+
+If the user is on Windows running Claude Desktop, also check:
+
+```
+~/AppData/Roaming/Claude/local-agent-mode-sessions/skills-plugin/**/skills/*/SKILL.md
+```
+
+Skills loaded from there appear in the system reminder as `<plugin>:<skill>` and are real
+sources of overlap (e.g. `anthropic-skills:git` lives here).
+
+For each item discovered, parse the YAML frontmatter and capture:
+
+- `name`
+- `description` (collapse whitespace)
+- `tools` (if agent)
+- Source path
+- Source kind (custom-user / custom-project / plugin:`<plugin>`)
+
+---
+
+## Step 3: Detect direct name collisions
+
+Group all discovered items by `name`. Any group with more than one entry is a **direct
+collision**.
+
+For each collision, also capture:
+
+- Which sources own each entry
+- Whether the descriptions diverge or are near-identical (cheap signal: are they the same on
+  the first 100 chars after lowercasing and collapsing whitespace?)
+- Whether the `tools` lists differ (for agents)
+
+Direct collisions are the most actionable finding — Claude Code namespaces them, but they
+still pollute the agent picker and confuse routing.
+
+---
+
+## Step 4: Detect semantic overlaps
+
+For pairs of items with **different** names, compute a description similarity score. A simple
+bigram-Jaccard works well:
+
+1. Lowercase and tokenize description into bigrams of words
+2. Jaccard similarity = `|A ∩ B| / |A ∪ B|`
+3. Flag any pair with similarity ≥ 0.5
+
+Pairs scoring ≥ 0.5 should be inspected manually — they may be:
+
+- True duplicates with different names (drop one)
+- Overlapping triggers that compete (clarify trigger conditions)
+- Different concerns that happen to share vocabulary (false positive — ignore)
+
+Constrain the comparison to within a category (agent-vs-agent, skill-vs-skill) — not across
+— to keep noise down.
+
+---
+
+## Step 5: Detect tool-coupling mismatches
+
+For each agent, parse its `tools:` list. For each skill that names a tool in its body (e.g.
+"use `mcp__plugin_github_github__list_pull_requests`"), record the dependency.
+
+Then check: for any (agent, skill) pair where the skill is plausibly passed to the agent (by
+the router's routing rules), does the agent have the tools the skill needs?
+
+Common failure modes to flag:
+
+- Skill uses `mcp__plugin_github_github__*` but the agent's `tools:` only has `Bash` (no
+  GitHub MCP)
+- Skill uses `PowerShell` but the agent only has `Bash`
+- Skill uses `mcp__plugin_context7_context7__*` but the agent doesn't include Context7
+
+This is heuristic — the skill might guard with "use this tool if available." Surface as a
+warning, not an error.
+
+---
+
+## Step 6: Render the report
+
+Produce a single markdown document with these sections, in order:
+
+```markdown
+# Claude Config Audit — <project name or "user-scope only">
+
+## Project objective
+
+<one paragraph paraphrased from the project CLAUDE.md, or "User-scope audit — no project CLAUDE.md found.">
+
+## Inventory
+
+- **Custom agents**: N (`name1`, `name2`, ...)
+- **Custom skills**: N (`name1`, ...)
+- **Plugin agents**: N from M plugins
+- **Plugin skills**: N from M plugins
+- **Effective total exposed to runtime**: N agents, M skills
+
+## Direct name collisions
+
+| Name            | Sources                          | Descriptions diverge? | Tools diverge? | Recommendation                       |
+| --------------- | -------------------------------- | --------------------- | -------------- | ------------------------------------ |
+| `code-reviewer` | custom, superpowers, feature-dev | No (near-identical)   | Yes            | Keep custom; disable plugin variants |
+
+## Semantic overlaps
+
+| Pair                                     | Jaccard | Verdict                                       | Recommendation                                   |
+| ---------------------------------------- | ------- | --------------------------------------------- | ------------------------------------------------ |
+| `git` (custom) ↔ `anthropic-skills:git` | 0.92    | True duplicate with project-specific addendum | Extract addendum to dedicated skill, drop custom |
+
+## Tool-coupling concerns
+
+| Agent         | Skill passed in | Missing tool                   | Recommendation                                                                  |
+| ------------- | --------------- | ------------------------------ | ------------------------------------------------------------------------------- |
+| `code-writer` | `powershell`    | `PowerShell` (only has `Bash`) | Translate guidance to POSIX in delegation, or pass to agent that has PowerShell |
+
+## Recommendations summary
+
+| Item                      | Action                | Priority | Rationale                   |
+| ------------------------- | --------------------- | -------- | --------------------------- |
+| Drop `feature-dev` plugin | uninstall via /plugin | high     | 3 overlap items in one move |
+
+...
+```
+
+Order recommendations by **leverage** — a single action that resolves multiple overlaps
+should rank above a single-item fix. Where the user has stated objectives in their CLAUDE.md,
+mark recommendations that conflict with those objectives as "verify with user before
+acting" rather than asserting them.
+
+---
+
+## Step 7: Offer follow-ups
+
+After delivering the report, ask the user:
+
+1. Whether to open GitHub Issues for each "drop" / "modify" recommendation (using the
+   project's issue tracker per CLAUDE.md conventions)
+2. Whether to create a Milestone grouping them, if there are 3+ recommendations
+3. Whether to start on any specific recommendation now
+
+Do **not** start making changes without explicit user confirmation. This skill is read-only
+audit + recommendation; modifications are tracked separately.
+
+---
+
+## Reference
+
+### Why "effective" config, not just custom?
+
+A user might think "my config is fine, I only have 8 custom agents." But what loads at
+runtime includes ~50 plugin skills and ~5 plugin agents. Overlaps appear at the boundary
+between custom and plugin, and that boundary is invisible if you only audit one side.
+
+### Why scope to project objective?
+
+The same set of skills can be over-broad for one project and under-broad for another. A
+`python` skill is essential in a Python repo and dead weight in a pure-Rust repo. The audit
+should prefer keeping skills the project plausibly needs and dropping ones it does not —
+which requires knowing what the project does.
+
+### Related skills
+
+- `superpowers:writing-skills` — for authoring new skills if the audit recommends extracting
+  one
+- `claude-md-management:claude-md-improver` — for the CLAUDE.md side of the same hygiene work
+- `claude-prospector:usage-analysis` — for the cost-side view (which skills/agents are actually consumed)
+
+## Long-Form Artifact Discipline
+
+Audit reports are routinely 50–200 lines once every agent and skill is enumerated with a keep / modify / drop recommendation. Save the full report to `<repo>/.tmp/<YYYY-MM-DD>-claude-audit.md` and return a short chat reply listing:
+
+1. **Inventory totals** — N agents and M skills audited (custom + plugin combined).
+2. **Disposition counts** — keep / modify / drop tallies.
+3. **Top 2-3 most consequential overlaps or conflicts** — typically direct name collisions or high-Jaccard semantic duplicates that resolve multiple items in one action.
+4. **The file path** in backticks as the hand-off.
+
+Do NOT paste the full report body inline — the file is the artifact, the chat reply is the pointer. The user opens the file for the full keep/modify/drop tables; the reply surfaces only what shapes their next decision.


### PR DESCRIPTION
## Summary

Ports the `claude-audit` skill from `~/.claude/skills/claude-audit/` into the `claude-prospector` plugin so it ships alongside `usage-analysis` and `usage-dashboard`. Repositions the plugin from "token usage analyzer" to "Claude Code efficiency and hygiene toolkit" — each skill keeps its distinct angle (cost, dashboard, config audit) as a sibling, not merged.

Closes #123

## Changes

- **`skills/claude-audit/SKILL.md`** — new file ported from the user-global copy with two plugin-context adjustments:
  - "Related skills" cross-reference: `usage-analysis` → `claude-prospector:usage-analysis`
  - Replaced `@C:\Users\chris\.claude\standards\long-form-artifacts.md` import (user-local absolute path; does not resolve in plugin context) with an inline four-point summary discipline
- **`README.md`** — title-line reframing; Why section now leads with a per-skill responsibility table; new `claude-audit skill` subsection
- **`pyproject.toml` + `.claude-plugin/plugin.json`** — `description` field rewritten to match the reframing; plugin.json keywords expanded with `audit` + `config-hygiene`
- **`CHANGELOG.md`** — new `## [Unreleased]` block

## Deferred to release time

Per the issue ACs, the user-global `~/.claude/skills/claude-audit/` directory should be removed when this version is released (avoids duplicate activation on the same triggers). Captured as a note in the `[Unreleased]` CHANGELOG section so it's not forgotten at release-cut time.

## Test plan

- [ ] CI green (lint + test ubuntu/windows + skill smoke ubuntu/windows)
- [ ] After release: trigger `/claude-prospector:claude-audit` in a fresh session and confirm the skill activates from the plugin (not the user-global copy)
- [ ] After release: confirm natural-language triggers ("audit my claude config", "find overlap in my agents") activate the plugin copy

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_