### PR TITLE
release: bump to 0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-05-19
 
 ### Added
 
@@ -22,13 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin and PyPI `description:` fields reframed from "token usage
   analyzer" to "Claude Code efficiency and hygiene toolkit" to reflect
   the broader scope (cost + config-hygiene angles). README "Why" section
-  updated with a per-skill responsibility table. (#123)
+  updated with a per-skill responsibility table. Plugin keywords
+  expanded with `audit` + `config-hygiene`. (#123)
 
-### Notes
+### Upgrade notes
 
-- The user-global `~/.claude/skills/claude-audit/` directory should be
-  removed at release time, to avoid duplicate-activation noise. Do not
-  delete the user-global copy until this version is published. (#123)
+- If you had `~/.claude/skills/claude-audit/` as a user-global skill
+  before upgrading, remove it after this version installs. Keeping both
+  copies causes duplicate activation on the same trigger phrases.
 
 ## [0.7.1] - 2026-05-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.7.1"
+version = "0.8.0"
 description = "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill."
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Minor release. Adds the `claude-audit` skill to the plugin and reframes prospector from "token usage analyzer" to "Claude Code efficiency and hygiene toolkit". New skill surface → minor bump (0.7.1 → 0.8.0).

## Changes since v0.7.1

- **#123 / PR #124** — feat(skills): port `claude-audit` skill from user-global into the plugin; README + pyproject + plugin.json description reframed to cover both cost and config-hygiene angles

## This PR

- Bumps `pyproject.toml` and `.claude-plugin/plugin.json` to `0.8.0`
- Promotes `[Unreleased]` CHANGELOG block to `## [0.8.0] - 2026-05-19`, rewords the user-global-removal note as a user-facing upgrade note

## Post-merge

- Push `v0.8.0` tag → release workflow publishes to PyPI
- Create GitHub Release
- Bump `glitchwerks/plugins` `marketplace.json` (sha + version)
- Delete `~/.claude/skills/claude-audit/` directory (per #123 ACs)

Closes #125

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_