### PR TITLE
release: bump to 0.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-19
+
+### Changed
+
+- Dashboard template replaced with a new visual model: refreshed layout,
+  panel structure, and styling. The renderer contract is unchanged — same
+  `data_json` / `limits_json` / `generated_at` Jinja bindings, no API
+  impact. (#130, #131)
+
 ## [0.8.0] - 2026-05-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.8.0"
+version = "0.8.1"
 description = "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill."
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Patch release. PR #131 replaced the dashboard HTML template wholesale — refreshed layout, panel structure, and styling. Renderer contract is unchanged, so this is a patch bump (0.8.0 → 0.8.1).

## Changes since v0.8.0

- **#130 / PR #131** — Dashboard template replaced with a new visual model; same `data_json` / `limits_json` / `generated_at` Jinja bindings, no API or skill-surface changes

## This PR

- Bumps `pyproject.toml` and `.claude-plugin/plugin.json` to `0.8.1`
- Inserts `## [0.8.1] - 2026-05-19` section in `CHANGELOG.md` above the `[0.8.0]` block

## Post-merge checklist

- Push `v0.8.1` tag → release workflow publishes to PyPI
- Create GitHub Release
- Bump `glitchwerks/plugins` `marketplace.json` (sha + version)

Closes #132

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
