### PR TITLE
fix(plugin): default userConfig.autoregen to false (fixes #149)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,6 +13,7 @@
   "userConfig": {
     "autoregen": {
       "type": "boolean",
+      "default": false,
       "title": "Auto-regenerate dashboard on session end",
       "description": "When enabled, automatically regenerates the HTML usage dashboard at the end of every Claude Code session. Toggle via the plugin manager (/plugin reconfigure claude-prospector) or at install time."
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`userConfig.autoregen` missing schema default** (#149). Added `"default": false` to the `autoregen` field in `.claude-plugin/plugin.json` so the plugin manager has an explicit default and does not prompt unexpectedly or treat a missing value as true.
+
 ## [0.8.2] - 2026-05-20
 
 ### Fixed

--- a/tests/unit/test_plugin_manifest.py
+++ b/tests/unit/test_plugin_manifest.py
@@ -1,0 +1,52 @@
+"""Tests for .claude-plugin/plugin.json schema correctness.
+
+Regression guards for issue #149 and related manifest field requirements.
+These tests load the raw JSON so that structural edits to plugin.json are
+caught immediately, without requiring an installed package.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# Resolve the repo root relative to this test file's location.
+# Layout: tests/unit/test_plugin_manifest.py  ->  repo-root/.claude-plugin/
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_PLUGIN_JSON = _REPO_ROOT / ".claude-plugin" / "plugin.json"
+
+
+def _load_plugin_json() -> dict:
+    """Load and parse .claude-plugin/plugin.json.
+
+    Returns:
+        Parsed JSON content as a dict.
+
+    Raises:
+        FileNotFoundError: If plugin.json is missing from the repo root.
+        json.JSONDecodeError: If the file is not valid JSON.
+    """
+    return json.loads(_PLUGIN_JSON.read_text(encoding="utf-8"))
+
+
+def test_autoregen_default_is_false() -> None:
+    """userConfig.autoregen must carry an explicit ``default: false`` field.
+
+    Regression guard for issue #149.  Without this field the Claude Code
+    plugin manager has no schema-declared default and may behave differently
+    across installations (e.g. treating a missing value as true, or
+    prompting on every install).  The default must be the boolean ``False``,
+    not the integer ``0`` or the string ``"false"`` — hence ``is False``
+    rather than ``== False`` to catch type drift.
+    """
+    data = _load_plugin_json()
+    autoregen = data["userConfig"]["autoregen"]
+    assert "default" in autoregen, (
+        "userConfig.autoregen is missing a 'default' key in plugin.json. "
+        "Add `\"default\": false` to fix issue #149."
+    )
+    assert autoregen["default"] is False, (
+        f"userConfig.autoregen.default must be the boolean False, "
+        f"got {autoregen['default']!r} (type {type(autoregen['default']).__name__}). "
+        "Ensure the value is JSON `false`, not 0 or \"false\"."
+    )

--- a/tests/unit/test_plugin_manifest.py
+++ b/tests/unit/test_plugin_manifest.py
@@ -43,7 +43,7 @@ def test_autoregen_default_is_false() -> None:
     autoregen = data["userConfig"]["autoregen"]
     assert "default" in autoregen, (
         "userConfig.autoregen is missing a 'default' key in plugin.json. "
-        "Add `\"default\": false` to fix issue #149."
+        'Add `"default": false` to fix issue #149.'
     )
     assert autoregen["default"] is False, (
         f"userConfig.autoregen.default must be the boolean False, "


### PR DESCRIPTION
## Summary

Fixes #149.

Stop hook was failing on every fresh install with `Plugin option "autoregen" isn't set` because `.claude-plugin/plugin.json` declared the userConfig key without a `default`, and `hooks/hooks.json` references `${user_config.autoregen}` in the Stop hook command. With no value to substitute, Claude Code rejected the hook before `dashboard-regen.py` could no-op.

One-line schema fix + regression-guard unit test.

## Changes

- `.claude-plugin/plugin.json` — added `"default": false` to `userConfig.autoregen`. `false` matches the script's own falsy-default behavior and preserves the opt-in design.
- `tests/unit/test_plugin_manifest.py` (new) — asserts `userConfig.autoregen.default is False` using identity comparison so type drift (`0`, `"false"`, etc.) is caught.
- `CHANGELOG.md` — `[Unreleased]` patch-level bug-fix entry.

## Test plan

- [x] `uv run pytest` — 360 passed, 2 skipped (was 359 passed before; exactly one new test).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] New test confirmed in collection: `tests/unit/test_plugin_manifest.py::test_autoregen_default_is_false`.
- [x] TDD cycle verified: RED first (failed with `AssertionError: userConfig.autoregen is missing a 'default' key`), then GREEN after schema edit.
- [ ] Fresh install verification — covered by acceptance criteria but requires either a new prospector release + reinstall or a `--plugin-dir` local install; not gated on this PR.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
