### PR TITLE
spike(telemetry): structured JSONL log of self-audit hook outcomes

### DIFF
--- a/hooks/lib/self_audit_telemetry.py
+++ b/hooks/lib/self_audit_telemetry.py
@@ -1,0 +1,108 @@
+"""Structured JSONL telemetry for the self-audit Stop hook.
+
+Appends one JSON line per hook invocation to
+``${CLAUDE_PLUGIN_DATA}/session-audit.jsonl``. The log persists across
+sessions so it can be queried with ``wc -l``, ``jq``, or Python after
+the fact.
+
+Fail-open contract: this module must never raise. Any write failure is
+silently swallowed. A broken telemetry write must not break the hook's
+fail-open contract.
+
+Public API:
+    log_outcome(state, transcript_path="") -> None
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Valid state identifiers (for documentation — not enforced at runtime).
+VALID_STATES: tuple[str, ...] = (
+    "stop_hook_active",
+    "no_transcript_path",
+    "transcript_missing",
+    "transcript_read_error",
+    "no_assistant_text",
+    "present",
+    "blocked",
+    "unexpected_error",
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_log_path() -> Path:
+    """Return the absolute path to the JSONL telemetry log file.
+
+    Resolves ``${CLAUDE_PLUGIN_DATA}/session-audit.jsonl``. Falls back to
+    ``~/.claude/session-audit.jsonl`` when the env var is absent.
+
+    Returns:
+        Absolute path to the log file. Not created by this call.
+    """
+    base = os.environ.get("CLAUDE_PLUGIN_DATA", "")
+    if base:
+        return Path(base) / "session-audit.jsonl"
+    return Path.home() / ".claude" / "session-audit.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def log_outcome(state: str, transcript_path: str = "") -> None:
+    """Append a structured telemetry line to the self-audit log.
+
+    Writes one JSON object per call to
+    ``${CLAUDE_PLUGIN_DATA}/session-audit.jsonl``, creating the file and
+    parent dirs if missing. Fields:
+
+        timestamp:   UTC ISO-8601 with 'Z' suffix, no microseconds.
+        state:       One of the eight defined states.
+        session_id:  ``Path(transcript_path).stem`` if *transcript_path*
+                     is non-empty, else ``None``.
+
+    Telemetry MUST never raise — the entire body is wrapped in
+    ``try/except`` and swallows all exceptions. A broken telemetry write
+    must not break the hook's fail-open contract.
+
+    Args:
+        state: One of ``"stop_hook_active"``, ``"no_transcript_path"``,
+            ``"transcript_missing"``, ``"transcript_read_error"``,
+            ``"no_assistant_text"``, ``"present"``, ``"blocked"``,
+            ``"unexpected_error"``.
+        transcript_path: Original Stop-hook ``transcript_path`` payload
+            value, used to derive ``session_id``. Pass an empty string
+            (or omit) when unavailable.
+    """
+    try:
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        session_id = Path(transcript_path).stem if transcript_path else None
+        entry = {
+            "timestamp": timestamp,
+            "state": state,
+            "session_id": session_id,
+        }
+
+        log_path = _get_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+    except Exception:  # noqa: BLE001
+        # Silently swallow — telemetry must never disrupt the hook.
+        pass

--- a/hooks/session-audit-prompt.py
+++ b/hooks/session-audit-prompt.py
@@ -45,6 +45,11 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
+# Import the telemetry helper from hooks/lib/ using the same sys.path idiom
+# used by other hooks in this repo.
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from self_audit_telemetry import log_outcome  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -127,6 +132,7 @@ def _extract_last_assistant_text(transcript_path: str) -> Optional[str]:
         sys.stderr.write(
             f"[session-audit-prompt] transcript not found:" f" {transcript_path}\n"
         )
+        log_outcome("transcript_missing", transcript_path)
         return None
 
     last_assistant_text: Optional[str] = None
@@ -160,6 +166,7 @@ def _extract_last_assistant_text(transcript_path: str) -> Optional[str]:
 
     except OSError as exc:
         sys.stderr.write(f"[session-audit-prompt] error reading transcript: {exc}\n")
+        log_outcome("transcript_read_error", transcript_path)
         return None
 
     return last_assistant_text
@@ -246,6 +253,7 @@ def main() -> int:
                 "[session-audit-prompt] stop_hook_active=True —"
                 " bailing out to prevent infinite loop\n"
             )
+            log_outcome("stop_hook_active")
             return 0
 
         # Step 3: locate transcript.
@@ -255,6 +263,7 @@ def main() -> int:
                 "[session-audit-prompt] transcript_path missing from"
                 " payload — allowing stop\n"
             )
+            log_outcome("no_transcript_path")
             return 0
 
         # Step 4: read last assistant message.
@@ -264,6 +273,7 @@ def main() -> int:
                 "[session-audit-prompt] could not read last assistant"
                 " message — allowing stop\n"
             )
+            log_outcome("no_assistant_text", transcript_path)
             return 0
 
         # Step 5: check for existing self-audit block.
@@ -271,17 +281,20 @@ def main() -> int:
             sys.stderr.write(
                 "[session-audit-prompt] <self-audit> block found —" " allowing stop\n"
             )
+            log_outcome("present", transcript_path)
             return 0
 
         # Step 6: block and elicit the audit.
         sys.stderr.write(
             "[session-audit-prompt] no <self-audit> block found —" " requesting audit\n"
         )
+        log_outcome("blocked", transcript_path)
         decision = json.dumps({"decision": "block", "reason": _AUDIT_PROMPT})
         sys.stdout.write(decision + "\n")
 
     except Exception as exc:
         sys.stderr.write(f"[session-audit-prompt] unexpected error: {exc}\n")
+        log_outcome("unexpected_error")
 
     return 0
 

--- a/tests/test_self_audit_hook_telemetry.py
+++ b/tests/test_self_audit_hook_telemetry.py
@@ -1,0 +1,55 @@
+"""Integration test: session-audit-prompt.py emits telemetry.
+
+Invokes the hook script with a synthetic ``stop_hook_active=True`` payload
+and a tmp ``CLAUDE_PLUGIN_DATA`` directory, then asserts that the
+telemetry JSONL file was written with the expected ``state`` field.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_SCRIPT = Path(__file__).parent.parent / "hooks" / "session-audit-prompt.py"
+
+
+class TestSessionAuditHookTelemetry:
+    """session-audit-prompt.py writes telemetry on each exit branch."""
+
+    def test_stop_hook_active_writes_telemetry(self, tmp_path: Path) -> None:
+        """stop_hook_active=True branch writes one telemetry entry."""
+        payload = json.dumps({"stop_hook_active": True})
+
+        result = subprocess.run(
+            [sys.executable, str(HOOK_SCRIPT)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            env={
+                **__import__("os").environ,
+                "CLAUDE_PLUGIN_DATA": str(tmp_path),
+            },
+        )
+
+        assert result.returncode == 0, (
+            f"Hook exited non-zero: {result.returncode}\n" f"stderr: {result.stderr}"
+        )
+
+        log_file = tmp_path / "session-audit.jsonl"
+        assert (
+            log_file.exists()
+        ), "Telemetry file not created — did the hook call log_outcome()?"
+
+        lines = [
+            line
+            for line in log_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1, f"Expected 1 telemetry entry, got {len(lines)}"
+
+        entry = json.loads(lines[0])
+        assert (
+            entry["state"] == "stop_hook_active"
+        ), f"Expected state='stop_hook_active', got {entry['state']!r}"

--- a/tests/unit/test_self_audit_telemetry.py
+++ b/tests/unit/test_self_audit_telemetry.py
@@ -1,0 +1,127 @@
+"""Unit tests for hooks/lib/self_audit_telemetry.py.
+
+Tests are written against the public ``log_outcome`` function. Each test
+covers a single behavior and is designed to fail before the module exists
+(TDD red phase).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module under test via sys.path manipulation, matching the idiom
+# used by the hooks themselves.
+# ---------------------------------------------------------------------------
+
+HOOKS_LIB = Path(__file__).parent.parent.parent / "hooks" / "lib"
+sys.path.insert(0, str(HOOKS_LIB))
+
+import self_audit_telemetry  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Return parsed JSON objects from a JSONL file."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLogOutcomeWritesEntry:
+    """log_outcome writes a well-formed JSONL entry."""
+
+    def test_log_outcome_writes_jsonl_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Single call produces one JSONL line with correct fields."""
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+
+        self_audit_telemetry.log_outcome("blocked", "/foo/bar/abc-123.jsonl")
+
+        log_file = tmp_path / "session-audit.jsonl"
+        assert log_file.exists(), "JSONL file was not created"
+
+        entries = _read_jsonl(log_file)
+        assert len(entries) == 1, "Expected exactly one JSONL entry"
+
+        entry = entries[0]
+        assert entry["state"] == "blocked"
+        assert entry["session_id"] == "abc-123"
+        assert _TIMESTAMP_RE.match(
+            entry["timestamp"]
+        ), f"timestamp {entry['timestamp']!r} does not match ISO-8601 Z format"
+
+    def test_log_outcome_appends(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two calls produce two JSONL lines (append, not overwrite)."""
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+
+        self_audit_telemetry.log_outcome("present", "/x/s1.jsonl")
+        self_audit_telemetry.log_outcome("blocked", "/x/s2.jsonl")
+
+        log_file = tmp_path / "session-audit.jsonl"
+        entries = _read_jsonl(log_file)
+        assert len(entries) == 2, "Expected two JSONL entries after two calls"
+        assert entries[0]["state"] == "present"
+        assert entries[1]["state"] == "blocked"
+
+    def test_log_outcome_creates_parent_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """log_outcome creates missing parent directories."""
+        nested = tmp_path / "nonexistent" / "subdir"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(nested))
+        assert not nested.exists(), "Precondition: dir must not exist yet"
+
+        self_audit_telemetry.log_outcome("no_transcript_path")
+
+        assert (nested / "session-audit.jsonl").exists()
+
+    def test_log_outcome_empty_transcript_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty transcript_path yields session_id = None in the entry."""
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+
+        self_audit_telemetry.log_outcome("present", "")
+
+        log_file = tmp_path / "session-audit.jsonl"
+        entries = _read_jsonl(log_file)
+        assert len(entries) == 1
+        assert entries[0]["session_id"] is None
+
+    def test_log_outcome_swallows_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A broken open() must not raise — telemetry is fail-open."""
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", "/this/path/does/not/exist")
+
+        # Monkeypatch open to raise unconditionally so we exercise the
+        # try/except inside log_outcome.
+        original_open = open
+
+        def _raise_always(*args, **kwargs):
+            # Allow reads (e.g. from pytest internals) but block writes.
+            if args and len(args) >= 2 and "a" in str(args[1]):
+                raise OSError("simulated write failure")
+            return original_open(*args, **kwargs)
+
+        with patch("builtins.open", side_effect=_raise_always):
+            # Must not raise.
+            self_audit_telemetry.log_outcome("present")


### PR DESCRIPTION
## Summary

Refs #129. **Base is `self-audit-spike-129`, NOT `main`** — spike branches never merge to main per the methodology doc (`docs/spikes/2026-05-19-self-audit-spike.md`).

Adds persisted, structured telemetry to the self-audit Stop hook so we can post-hoc analyze its behavior across sessions. Existing prose stderr lines are preserved (they're useful in-UI); a parallel JSONL channel writes one entry per invocation to `${CLAUDE_PLUGIN_DATA}/session-audit.jsonl`.

This is the prerequisite for actually answering the spike's question. Today, hook stderr vanishes into the "Ran N stop hooks" UI fold and clears on the next turn — we can't grep it, count firings, or correlate states with session IDs. After this lands, a few sessions of accumulation will fill in the methodology doc's empty results table.

See #129's two most recent comments (4530772694, 4530776259) for the full diagnosis.

## Changes

- `hooks/lib/self_audit_telemetry.py` (new) — `log_outcome(state, transcript_path="")` appends a JSONL entry. Fail-open: bare `except Exception: pass` so a broken telemetry write never breaks the hook.
- `hooks/session-audit-prompt.py` — `log_outcome` call added immediately after each existing `sys.stderr.write` at all 8 exit branches. Stderr lines preserved.
- `tests/unit/test_self_audit_telemetry.py` (new) — 5 unit tests covering happy-path write, append, parent-dir creation, empty-transcript-path case, error-swallow contract.
- `tests/test_self_audit_hook_telemetry.py` (new) — 1 integration test invoking the hook script with `stop_hook_active=True` and asserting `state == "stop_hook_active"` in the JSONL output.

## State enum

`stop_hook_active`, `no_transcript_path`, `transcript_missing`, `transcript_read_error`, `no_assistant_text`, `present`, `blocked`, `unexpected_error`.

## Test plan

- [x] `uv run pytest` — 348 passed (was 342, +6 as expected), 17 baseline-preserved failures (named tests verified identical on parent SHA `0be43ab`).
- [x] `uv run ruff check src/ tests/ hooks/` — clean.
- [x] `uv run ruff format --check .` — clean (52 files already formatted).
- [x] Telemetry fail-open contract test passes (`test_log_outcome_swallows_errors`).
- [ ] Post-merge: run a handful of varied sessions, then `wc -l ~/.claude/plugins/data/claude-prospector-claude-prospector-spike/session-audit.jsonl` + `jq` aggregation. Fill in the methodology doc's results table.

## Baseline-failure provenance

The 17 pre-existing failures on the spike branch fall into two buckets, both pre-dating this PR:

| Bucket | Tests | Cause |
|---|---:|---|
| `test_dashboard_regen_hook` | 7 | Spike pre-dates the autoregen schema work that just merged on main (PR #150 / #149) — these tests would pass on `main` |
| `test_renderer` + `test_e2e` (renderer/dashboard) + `test_check_prospector_setup` | 10 | Spike-rot from #148's dashboard-html visual refresh — divergence from `main` that the spike branch carries by design |

None block this PR; none are introduced by it.

## Out of scope

- Making the hook reliable (the spike's actual question). This PR is the prerequisite measurement infrastructure.
- Log rotation — spike telemetry grows monotonically, acceptable for the spike's scope.
- Fixing the 17 baseline failures — they exist on the spike branch independently of this PR.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
