### PR TITLE
fix(spike): adapt test_renderer + test_e2e assertions to refreshed dashboard.html (fixes #152)

### DIFF
--- a/hooks/session-audit-prompt.py
+++ b/hooks/session-audit-prompt.py
@@ -101,9 +101,7 @@ def _read_stdin() -> dict[str, Any]:
         raw = sys.stdin.read()
         return json.loads(raw) if raw.strip() else {}
     except Exception as exc:
-        sys.stderr.write(
-            f"[session-audit-prompt] failed to parse stdin: {exc}\n"
-        )
+        sys.stderr.write(f"[session-audit-prompt] failed to parse stdin: {exc}\n")
         return {}
 
 
@@ -127,8 +125,7 @@ def _extract_last_assistant_text(transcript_path: str) -> Optional[str]:
     path = Path(transcript_path)
     if not path.exists():
         sys.stderr.write(
-            f"[session-audit-prompt] transcript not found:"
-            f" {transcript_path}\n"
+            f"[session-audit-prompt] transcript not found:" f" {transcript_path}\n"
         )
         return None
 
@@ -162,9 +159,7 @@ def _extract_last_assistant_text(transcript_path: str) -> Optional[str]:
                     last_assistant_text = text
 
     except OSError as exc:
-        sys.stderr.write(
-            f"[session-audit-prompt] error reading transcript: {exc}\n"
-        )
+        sys.stderr.write(f"[session-audit-prompt] error reading transcript: {exc}\n")
         return None
 
     return last_assistant_text
@@ -274,25 +269,19 @@ def main() -> int:
         # Step 5: check for existing self-audit block.
         if _has_self_audit(last_text):
             sys.stderr.write(
-                "[session-audit-prompt] <self-audit> block found —"
-                " allowing stop\n"
+                "[session-audit-prompt] <self-audit> block found —" " allowing stop\n"
             )
             return 0
 
         # Step 6: block and elicit the audit.
         sys.stderr.write(
-            "[session-audit-prompt] no <self-audit> block found —"
-            " requesting audit\n"
+            "[session-audit-prompt] no <self-audit> block found —" " requesting audit\n"
         )
-        decision = json.dumps(
-            {"decision": "block", "reason": _AUDIT_PROMPT}
-        )
+        decision = json.dumps({"decision": "block", "reason": _AUDIT_PROMPT})
         sys.stdout.write(decision + "\n")
 
     except Exception as exc:
-        sys.stderr.write(
-            f"[session-audit-prompt] unexpected error: {exc}\n"
-        )
+        sys.stderr.write(f"[session-audit-prompt] unexpected error: {exc}\n")
 
     return 0
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-from claude_prospector.aggregator import AggregateResult, aggregate
+from claude_prospector.aggregator import aggregate
 from claude_prospector.parser import parse_sessions
 from claude_prospector.renderer import render
 
@@ -92,7 +92,9 @@ class TestSkillAdoptionE2E:
         render(result, output_path=output, open_browser=False)
 
         html = output.read_text(encoding="utf-8")
-        assert "Skill Adoption" in html
+        # The refreshed template (#148) uses "Skill adoption quadrant" (lower-case
+        # 'a') rather than "Skill Adoption" as the heading text.
+        assert "Skill adoption" in html or "skill_adoption" in html
         assert "python" in html
 
 
@@ -247,8 +249,9 @@ class TestSubagentModelAttribution:
         render(result, output_path=output_path, open_browser=False)
         html = output_path.read_text(encoding="utf-8")
 
-        # Extract the DATA JSON blob embedded in the HTML
-        marker = "const DATA = "
+        # Extract the DATA JSON blob embedded in the HTML.
+        # The refreshed template (#148) uses window.DATA = instead of const DATA =.
+        marker = "window.DATA = "
         start = html.index(marker) + len(marker)
         # Find the matching closing brace by scanning for the semicolon after the JSON object
         end = html.index(";\n", start)
@@ -329,90 +332,8 @@ class TestSeparatorSanitizationE2E:
             )
 
 
-class TestChartLabelSkip:
-    """Regression test for issue #7: category-axis labels skipped on Tokens by Agent
-    and Skill Invocations charts.
-
-    Chart.js defaults autoSkip=true on tick axes, which causes every other label to
-    vanish when the chart height is small relative to the number of categories.  The
-    fix sets ticks: { autoSkip: false } on the y-axis of every horizontal bar chart so
-    that all labels are always rendered.  This test verifies the rendered HTML contains
-    that config by inspecting the template source.
-    """
-
-    def _build_large_result(self, n: int = 20) -> AggregateResult:
-        """Build an AggregateResult with *n* agents and *n* skills — enough to
-        trigger label-skipping at the default 260 px chart height."""
-        result = AggregateResult()
-        result.total_tokens = n * 1000
-        result.total_sessions = n
-
-        for i in range(n):
-            agent = f"agent-{i:02d}"
-            result.by_agent[agent] = {
-                "total_tokens": (n - i) * 1000,
-                "primary_model": "sonnet",
-                "session_count": 1,
-            }
-            skill = f"skill-{i:02d}"
-            result.by_skill[skill] = {"invocation_count": n - i}
-            project = f"project-{i:02d}"
-            result.by_project[project] = {
-                "total_tokens": (n - i) * 500,
-                "primary_model": "sonnet",
-            }
-
-        return result
-
-    def test_agent_bar_chart_has_auto_skip_false(self, tmp_path: Path) -> None:
-        """Rendered dashboard must contain autoSkip: false on the agentBar y-axis.
-
-        With 20 agents and a fixed-height container, Chart.js would skip every
-        other label unless autoSkip is explicitly disabled.
-        """
-        result = self._build_large_result(20)
-        output = tmp_path / "dashboard.html"
-        render(result, output_path=output, open_browser=False)
-
-        html = output.read_text(encoding="utf-8")
-
-        # The template contains the literal JS source for both charts.
-        # We verify the autoSkip: false config is present in the output.
-        assert "autoSkip: false" in html, (
-            "Rendered HTML must contain 'autoSkip: false' — Chart.js will skip "
-            "category-axis labels at the default chart height without it."
-        )
-
-    def test_skill_bar_chart_has_auto_skip_false(self, tmp_path: Path) -> None:
-        """renderSkillBar must also have autoSkip: false on its y-axis."""
-        result = self._build_large_result(20)
-        output = tmp_path / "dashboard.html"
-        render(result, output_path=output, open_browser=False)
-
-        html = output.read_text(encoding="utf-8")
-
-        # Count occurrences — there should be one per horizontal bar chart
-        # (agentBar, skillBar, projectBar, skillAdoption = 4 charts).
-        count = html.count("autoSkip: false")
-        assert count >= 2, (
-            f"Expected at least 2 occurrences of 'autoSkip: false' (agentBar + skillBar), "
-            f"found {count}. Both charts need the config to fix label skipping."
-        )
-
-    def test_dynamic_height_set_for_many_categories(self, tmp_path: Path) -> None:
-        """Rendered HTML must set container height dynamically based on item count.
-
-        Without dynamic height, disabling autoSkip alone causes labels to overlap.
-        The template sets canvas.parentElement.style.height proportionally.
-        """
-        result = self._build_large_result(20)
-        output = tmp_path / "dashboard.html"
-        render(result, output_path=output, open_browser=False)
-
-        html = output.read_text(encoding="utf-8")
-
-        assert "parentElement.style.height" in html, (
-            "Rendered HTML must contain parentElement.style.height — "
-            "dynamic container sizing is required to prevent label overlap "
-            "after disabling autoSkip."
-        )
+# Removed TestChartLabelSkip (test_agent_bar_chart_has_auto_skip_false,
+# test_skill_bar_chart_has_auto_skip_false, test_dynamic_height_set_for_many_categories):
+# The horizontal agentBar/skillBar/projectBar charts and their autoSkip: false /
+# parentElement.style.height logic are no longer in dashboard.html as of #148.
+# The refreshed template uses a stacked vertical bar chart (lbd-daily) only.

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -69,32 +69,37 @@ class TestResponsiveness:
         ), "Viewport meta tag must include width=device-width."
 
     def test_gauge_grid_uses_auto_fill(self, tmp_path: Path) -> None:
-        """Gauge grid must use auto-fill or responsive grid-template-columns.
+        """Budget grid must use auto-fill/auto-fit or a responsive @media rule.
 
-        A fixed ``repeat(3, 1fr)`` column definition will not wrap on narrow
-        screens. The fix uses ``repeat(auto-fill, minmax(...))`` or media
-        queries to allow the grid to collapse.
+        The refreshed dashboard (#148) uses ``.budgets`` (not ``.gauges``) for
+        the three budget cards.  A fixed ``repeat(3, 1fr)`` definition will not
+        wrap on narrow screens; the fix is either ``repeat(auto-fill, ...)`` or
+        a ``@media`` query targeting the budget grid class.
         """
         html = _render_html(tmp_path)
         has_autofill = "auto-fill" in html or "auto-fit" in html
-        has_gauge_media = "@media" in html and ".gauges" in html
-        assert has_autofill or has_gauge_media, (
-            "Gauge grid must use auto-fill/auto-fit or a media query so it "
-            "collapses from 3 columns to fewer on narrow screens."
+        # The refreshed template uses .budgets with an @media collapse rule.
+        has_budget_media = "@media" in html and ".budgets" in html
+        assert has_autofill or has_budget_media, (
+            "Budget grid must use auto-fill/auto-fit or a @media query so it "
+            "collapses from 3 columns to fewer on narrow screens. "
+            "The refreshed template (PR #148) uses .budgets, not .gauges."
         )
 
     def test_grid2_collapses_on_narrow_screens(self, tmp_path: Path) -> None:
         """Two-column card sections must collapse to one column via @media.
 
-        The .grid-2 class currently uses a fixed two-column layout. On
-        screens below ~800 px it must become a single column.
+        The refreshed dashboard (#148) uses ``.row`` (not ``.grid-2``) for the
+        two-column daily-chart + skills layout.  A ``@media`` query targeting
+        that class must be present so the layout collapses on narrow screens.
         """
         html = _render_html(tmp_path)
-        # The template must define a breakpoint that makes .grid-2
-        # single-column. We accept any media query that references grid-2.
-        assert "@media" in html and "grid-2" in html, (
-            "A @media query targeting .grid-2 must be present to collapse "
-            "the two-column layout on narrow screens."
+        # The refreshed template uses .lbd-style .row for the 2-column layout;
+        # accept any media query that references the .row class.
+        assert "@media" in html and ".row" in html, (
+            "A @media query targeting .row must be present to collapse the "
+            "two-column layout on narrow screens. "
+            "The refreshed template (PR #148) uses .row, not .grid-2."
         )
 
     def test_session_list_responsive(self, tmp_path: Path) -> None:
@@ -202,9 +207,9 @@ def test_path_keys_render_through(tmp_path: Path) -> None:
     # --- Assertion 2: JSON payload round-trip ---
     # Parse the embedded DATA block to confirm the key decodes back to the
     # original Python string (U+2192 codepoint, not a literal backslash-u).
-    # The template renders: const DATA = {{ data_json | safe }};
+    # The refreshed template (#148) renders: window.DATA = {{ data_json | safe }};
     # json.JSONDecoder.raw_decode handles \uXXXX escapes transparently.
-    data_line_marker = "const DATA = "
+    data_line_marker = "window.DATA = "
     data_start = html.index(data_line_marker) + len(data_line_marker)
     decoder = json.JSONDecoder()
     data_obj, _ = decoder.raw_decode(html, data_start)
@@ -254,7 +259,8 @@ def test_real_data_depth3_renders_correct_by_agent_values(
 
     # Extract the embedded DATA JSON payload the same way test_path_keys_render_through
     # does — raw_decode handles the → JSON-escape transparently.
-    data_line_marker = "const DATA = "
+    # The refreshed template (#148) uses window.DATA = instead of const DATA =.
+    data_line_marker = "window.DATA = "
     data_start = html.index(data_line_marker) + len(data_line_marker)
     decoder = json.JSONDecoder()
     data_obj, _ = decoder.raw_decode(html, data_start)


### PR DESCRIPTION
## Summary

Fixes #152. **Base is `self-audit-spike-129`, NOT `main`** — these test changes would be wrong on main (main carries the old template the tests were written for; the new template only exists on the spike branch).

Resolves the 9 spike-rot test failures introduced when #148 refreshed `dashboard.html`. Investigation classified each into Option A (update assertion) or Option B (delete — feature gone).

## Classification

**Option A — assertion updated, feature still present (6 tests):**

| Test | New locator |
|---|---|
| `test_renderer.py::TestResponsiveness::test_gauge_grid_uses_auto_fill` | `.gauges` → `.budgets` (CSS class renamed) |
| `test_renderer.py::TestResponsiveness::test_grid2_collapses_on_narrow_screens` | `grid-2` → `.row` (class renamed) |
| `test_renderer.py::test_path_keys_render_through` | `const DATA = ` → `window.DATA = ` (JS variable form) |
| `test_renderer.py::test_real_data_depth3_renders_correct_by_agent_values` | Same `window.DATA = ` marker fix |
| `test_e2e.py::TestSubagentModelAttribution::test_rendered_html_embeds_correct_primary_model_for_subagent` | Same `window.DATA = ` marker fix |
| `test_e2e.py::TestSkillAdoptionE2E::test_adoption_data_in_rendered_html` | `"Skill Adoption"` → `"Skill adoption"` (heading casing) |

**Option B — deleted, feature removed in #148 (3 tests, entire `TestChartLabelSkip` class):**

- `test_agent_bar_chart_has_auto_skip_false` — horizontal agentBar/skillBar charts removed; new template has only the stacked `lbd-daily` vertical chart
- `test_skill_bar_chart_has_auto_skip_false` — same
- `test_dynamic_height_set_for_many_categories` — `parentElement.style.height` dynamic sizing was tied to the removed horizontal bar charts

Lost coverage: dynamic Chart.js label-skip and height-grow behavior for many-category horizontal bars. The category of chart that needed those settings no longer exists; the surviving stacked-vertical chart has its own layout discipline.

## Test plan

- [x] Spot-check: the 6 Option-A tests pass when run in isolation (10/10 including sibling tests in their classes).
- [x] `uv run pytest` — 348 pass / 8 fail / 2 skip. The 8 remaining failures are the Windows-host-only environmental failures (`test_dashboard_regen_hook.py` ×7, `test_check_prospector_setup.py` ×1) explicitly out of scope per #152. CI's clean runner will show 0 failures.
- [x] `uv run ruff check src/ tests/ hooks/` — clean.
- [x] `uv run ruff format --check .` — clean (49 files already formatted, including `hooks/session-audit-prompt.py` after the in-this-PR format fix).
- [x] Baseline failure list verified: the 9 listed tests no longer appear in pytest output (6 pass, 3 deleted).

## Drive-by: ruff format on `hooks/session-audit-prompt.py`

The parent SHA `0be43ab` was already format-dirty for `hooks/session-audit-prompt.py` — line-wrapped stderr calls that ruff's current formatter prefers as single-line. Without this fix, the PR would have failed `ruff format --check` despite all the test work being clean. Included in the same commit; ~7 lines of pure formatting.

This will require a manual `git rebase` touch on PR #151 (telemetry) since both PRs modify the same stderr lines — but git should auto-resolve cleanly because PR #151's edits add `log_outcome(...)` calls *after* each stderr write, not in place of them.

## After this merges

PR #151 (telemetry) rebases onto the new `self-audit-spike-129` HEAD, re-pushes, CI passes cleanly (modulo the 8 environmental tests which are CI-skipped). At that point the spike branch has both a green CI baseline AND structured telemetry — ready to actually run the 5-shape methodology and fill in the results table.

## Out of scope

- The 8 Windows-host environmental test failures.
- Cherry-picking the autoregen default fix from PR #150 onto the spike.
- Any change to `dashboard.html` itself.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
