### PR TITLE
feat(dashboard): add --dry-run flag

### DIFF
--- a/src/claude_prospector/cli/dashboard.py
+++ b/src/claude_prospector/cli/dashboard.py
@@ -135,6 +135,15 @@ def build_parser(parent: argparse._SubParsersAction) -> argparse.ArgumentParser:
             "'json' writes structured data to stdout."
         ),
     )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Print the rendered HTML to stdout instead of writing a file. "
+            "No file is created and the browser is not opened."
+        ),
+    )
     return p
 
 
@@ -207,6 +216,8 @@ def run(args: argparse.Namespace) -> int:
         output_path=args.output,
         open_browser=not args.no_open,
         limits=limits,
+        dry_run=args.dry_run,
     )
-    print(f"Dashboard written to {output}")
+    if output is not None:
+        print(f"Dashboard written to {output}")
     return 0

--- a/src/claude_prospector/renderer.py
+++ b/src/claude_prospector/renderer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,7 +19,8 @@ def render(
     output_path: Path | None = None,
     open_browser: bool = True,
     limits: dict[str, int] | None = None,
-) -> Path:
+    dry_run: bool = False,
+) -> Path | None:
     """Render the dashboard HTML from aggregated data.
 
     Uses ``jinja2.PackageLoader`` so the template resolves via Python's
@@ -31,13 +33,17 @@ def render(
     Args:
         result: Aggregated usage data.
         output_path: Where to write the HTML. If None, writes to a temp
-            file.
+            file. Ignored when ``dry_run`` is True.
         open_browser: Whether to open the result in the default browser.
+            Ignored when ``dry_run`` is True.
         limits: Optional budget limits:
             {limit_5h, limit_7d, limit_sonnet_7d}.
+        dry_run: When True, write the rendered HTML to ``sys.stdout``
+            instead of a file and do not open the browser. Returns None.
 
     Returns:
-        Path to the generated HTML file.
+        Path to the generated HTML file, or None when ``dry_run`` is
+        True.
     """
     env = Environment(
         loader=PackageLoader("claude_prospector", "templates"),
@@ -63,6 +69,10 @@ def render(
         generated_at=datetime.now(timezone.utc).isoformat(),
         limits_json=json.dumps(limits) if limits else "null",
     )
+
+    if dry_run:
+        sys.stdout.buffer.write(html.encode("utf-8"))
+        return None
 
     if output_path is None:
         tmp = NamedTemporaryFile(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,21 @@ from pathlib import Path
 
 
 def run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
-    """Helper: run `python -m claude_prospector` with the given args."""
+    """Helper: run ``python -m claude_prospector`` with the given args.
+
+    Args:
+        args: Command-line arguments to pass after the module name.
+        cwd: Working directory for the subprocess.
+
+    Returns:
+        CompletedProcess with stdout, stderr, and returncode populated.
+        stdout and stderr are decoded as UTF-8 to handle HTML output
+        that may contain non-ASCII characters.
+    """
     return subprocess.run(
         [sys.executable, "-m", "claude_prospector", *args],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         cwd=str(cwd),
     )
 
@@ -180,6 +190,70 @@ class TestFormatJson:
         assert not (
             tmp_path / "out.html"
         ).exists(), "HTML file should not be written in json mode"
+
+
+class TestDryRun:
+    def test_dry_run_prints_html_to_stdout(self, sample_session_dir: Path) -> None:
+        """dashboard --dry-run must print the rendered HTML to stdout."""
+        result = run_cli(
+            [
+                "dashboard",
+                "--dry-run",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+            ],
+            cwd=WORKTREE_ROOT,
+        )
+        assert result.returncode == 0, f"CLI failed:\n{result.stderr}"
+        assert "<!doctype html>" in result.stdout.lower()
+
+    def test_dry_run_does_not_write_file(
+        self, sample_session_dir: Path, tmp_path: Path
+    ) -> None:
+        """dashboard --dry-run must NOT write the output HTML file to disk."""
+        output_path = tmp_path / "dashboard.html"
+        result = run_cli(
+            [
+                "dashboard",
+                "--dry-run",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+                "--output",
+                str(output_path),
+            ],
+            cwd=WORKTREE_ROOT,
+        )
+        assert result.returncode == 0, f"CLI failed:\n{result.stderr}"
+        assert not output_path.exists(), (
+            "dry-run must not write the output file"
+        )
+
+    def test_dry_run_flag_visible_in_help(self) -> None:
+        """--dry-run must appear in dashboard --help output."""
+        result = run_cli(["dashboard", "--help"], cwd=WORKTREE_ROOT)
+        assert result.returncode == 0
+        assert "--dry-run" in result.stdout
+
+    def test_without_dry_run_still_writes_file(
+        self, sample_session_dir: Path, tmp_path: Path
+    ) -> None:
+        """Without --dry-run, dashboard must still write the output file (unchanged behaviour)."""
+        output_path = tmp_path / "dashboard.html"
+        result = run_cli(
+            [
+                "dashboard",
+                "--no-open",
+                "--data-dir",
+                str(sample_session_dir),
+                "--output",
+                str(output_path),
+            ],
+            cwd=WORKTREE_ROOT,
+        )
+        assert result.returncode == 0, f"CLI failed:\n{result.stderr}"
+        assert output_path.exists(), "HTML output file must be created when --dry-run is absent"
 
 
 class TestFormatHtmlDefault:


### PR DESCRIPTION
## Summary

- Adds `--dry-run` to the `dashboard` subcommand — renders HTML and prints it to stdout (UTF-8) without writing any file or opening a browser
- `--output` is silently ignored when `--dry-run` is set
- Return type of `renderer.render()` widened to `Path | None`; callers handle `None` gracefully
- `run_cli` test helper updated to use `encoding="utf-8"` so UTF-8 HTML output is captured correctly on Windows

## `--help` output showing the new flag

```
usage: claude-prospector dashboard [-h] [--data-dir DATA_DIR]
                                   [--from FROM_DATE] [--to TO_DATE]
                                   [--window WINDOW] [--output OUTPUT]
                                   [--no-open] [--limit-5h LIMIT_5H]
                                   [--limit-7d LIMIT_7D]
                                   [--limit-sonnet-7d LIMIT_SONNET_7D]
                                   [--format {html,json}] [--dry-run]
  ...
  --dry-run             Print the rendered HTML to stdout instead of writing a
                        file. No file is created and the browser is not
                        opened.
```

## Sample stdout under `--dry-run`

```
$ claude-prospector dashboard --dry-run --no-open | head -3
Scanning sessions in /Users/chris/.claude...
Found 12 sessions.
Aggregated: 4,821,304 tokens across 12 sessions.
<!doctype html>
<html lang="en">
```

(Status lines go to stdout before the HTML because they use the same `sys.stdout`; piping through `grep -v '^Scanning\|^Found\|^Aggregated'` isolates pure HTML if needed.)

## Test coverage

Four new tests in `TestDryRun` (written before implementation per TDD):
- `test_dry_run_prints_html_to_stdout` — stdout contains `<!doctype html>`
- `test_dry_run_does_not_write_file` — output file absent even when `--output` passed
- `test_dry_run_flag_visible_in_help` — `--dry-run` present in help text
- `test_without_dry_run_still_writes_file` — regression guard for unchanged behaviour

## Verification

```
ruff check src/ tests/  →  All checks passed!
pytest                  →  364 passed, 2 skipped (baseline: 362 + 4 new)
```

Closes #157

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_