### PR TITLE
refactor(hook): use dataclass for _base_dir resolution (closes #159)

### DIFF
--- a/hooks/dashboard-regen.py
+++ b/hooks/dashboard-regen.py
@@ -54,6 +54,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import json
 import os
 import subprocess
@@ -78,8 +79,23 @@ import setup_state  # noqa: E402
 # paths.py, so defaults are byte-for-byte compatible).
 
 
-def _base_dir() -> Path:
-    """Return the claude-prospector base directory.
+@dataclasses.dataclass(frozen=True)
+class BaseDirResolution:
+    """Result of the three-tier base-directory resolution.
+
+    A frozen dataclass so callers get a named type and an immutability
+    guarantee.  Only ``path`` is stored; source bookkeeping is omitted
+    because no current caller needs it (YAGNI).
+
+    Attributes:
+        path: The resolved claude-prospector base directory.
+    """
+
+    path: Path
+
+
+def _base_dir() -> BaseDirResolution:
+    """Return the claude-prospector base directory as a BaseDirResolution.
 
     Three-tier resolution (highest priority first):
 
@@ -91,15 +107,15 @@ def _base_dir() -> Path:
     ``claude_prospector.paths.base_dir()`` so it happens exactly once.
 
     Returns:
-        Resolved base directory path.
+        BaseDirResolution wrapping the resolved base directory path.
     """
     env_override = os.environ.get("CLAUDE_PROSPECTOR_BASE_DIR")
     if env_override:
-        return Path(env_override)
+        return BaseDirResolution(path=Path(env_override))
     plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA")
     if plugin_data:
-        return Path(plugin_data)
-    return Path.home() / ".claude" / "claude-prospector"
+        return BaseDirResolution(path=Path(plugin_data))
+    return BaseDirResolution(path=Path.home() / ".claude" / "claude-prospector")
 
 
 def _config_path() -> Path:
@@ -111,7 +127,7 @@ def _config_path() -> Path:
     env = os.environ.get("CLAUDE_PROSPECTOR_CONFIG")
     if env:
         return Path(env)
-    return _base_dir() / "config.json"
+    return _base_dir().path / "config.json"
 
 
 def _dashboard_path() -> Path:
@@ -123,7 +139,7 @@ def _dashboard_path() -> Path:
     env = os.environ.get("CLAUDE_PROSPECTOR_DASHBOARD")
     if env:
         return Path(env)
-    return _base_dir() / "dashboard.html"
+    return _base_dir().path / "dashboard.html"
 
 
 def _hook_log_path() -> Path:
@@ -135,7 +151,7 @@ def _hook_log_path() -> Path:
     env = os.environ.get("CLAUDE_PROSPECTOR_HOOK_LOG")
     if env:
         return Path(env)
-    return _base_dir() / "hook.log"
+    return _base_dir().path / "hook.log"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_base_dir_dataclass.py
+++ b/tests/unit/test_base_dir_dataclass.py
@@ -1,0 +1,137 @@
+"""Unit tests for the BaseDirResolution dataclass in hooks/dashboard-regen.py.
+
+Tests the three-tier resolution of _base_dir() via importlib so no
+changes to sys.path are required for package-level code.
+
+Resolution priority (highest first):
+    1. CLAUDE_PROSPECTOR_BASE_DIR  — explicit test/override path.
+    2. CLAUDE_PLUGIN_DATA          — Anthropic plugin state dir.
+    3. Legacy ~/.claude/claude-prospector/ fallback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import hook module via importlib (lives outside src/, not a package).
+# ---------------------------------------------------------------------------
+_WORKTREE = Path(__file__).parent.parent.parent
+_HOOK_PATH = _WORKTREE / "hooks" / "dashboard-regen.py"
+
+
+def _load_hook_module():
+    """Load hooks/dashboard-regen.py as a module without executing main().
+
+    Returns:
+        The loaded module object.
+    """
+    # Ensure hooks/lib is importable so setup_state (imported at module level
+    # in the hook) can be found.
+    hooks_lib = str(_WORKTREE / "hooks" / "lib")
+    if hooks_lib not in sys.path:
+        sys.path.insert(0, hooks_lib)
+
+    spec = importlib.util.spec_from_file_location("dashboard_regen_hook", _HOOK_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass decorator can resolve __module__.
+    sys.modules["dashboard_regen_hook"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load once at collection time.
+_hook = _load_hook_module()
+
+
+# ---------------------------------------------------------------------------
+# Tests for BaseDirResolution and _base_dir()
+# ---------------------------------------------------------------------------
+
+
+class TestBaseDirResolution:
+    """BaseDirResolution is a frozen dataclass with a single ``path`` field."""
+
+    def test_is_dataclass_with_path_field(self) -> None:
+        """BaseDirResolution has a ``path`` attribute of type Path."""
+        import dataclasses
+
+        assert dataclasses.is_dataclass(_hook.BaseDirResolution)
+        fields = {f.name: f for f in dataclasses.fields(_hook.BaseDirResolution)}
+        assert "path" in fields
+        assert fields["path"].type is Path or fields["path"].type == "Path"
+
+    def test_is_frozen(self) -> None:
+        """BaseDirResolution instances are immutable (frozen=True)."""
+        import dataclasses
+
+        # frozen dataclasses raise FrozenInstanceError on attribute assignment
+        instance = _hook.BaseDirResolution(path=Path("/some/path"))
+        with pytest.raises(
+            (dataclasses.FrozenInstanceError, TypeError, AttributeError)
+        ):
+            instance.path = Path("/other/path")  # type: ignore[misc]
+
+
+class TestBaseDirEnvOverride:
+    """When CLAUDE_PROSPECTOR_BASE_DIR is set it takes priority."""
+
+    def test_env_override_returns_that_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_BASE_DIR set → BaseDirResolution.path equals it."""
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_BASE_DIR", str(tmp_path))
+        monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+
+        result = _hook._base_dir()
+
+        assert isinstance(result, _hook.BaseDirResolution)
+        assert result.path == tmp_path
+
+    def test_env_override_takes_priority_over_plugin_data(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PROSPECTOR_BASE_DIR wins even when CLAUDE_PLUGIN_DATA is set."""
+        override_path = tmp_path / "override"
+        plugin_path = tmp_path / "plugin"
+        monkeypatch.setenv("CLAUDE_PROSPECTOR_BASE_DIR", str(override_path))
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_path))
+
+        result = _hook._base_dir()
+
+        assert result.path == override_path
+
+
+class TestBaseDirPluginData:
+    """When CLAUDE_PROSPECTOR_BASE_DIR is unset, CLAUDE_PLUGIN_DATA is used."""
+
+    def test_plugin_data_used_when_override_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """CLAUDE_PLUGIN_DATA set → BaseDirResolution.path equals it."""
+        monkeypatch.delenv("CLAUDE_PROSPECTOR_BASE_DIR", raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+
+        result = _hook._base_dir()
+
+        assert isinstance(result, _hook.BaseDirResolution)
+        assert result.path == tmp_path
+
+
+class TestBaseDirLegacyDefault:
+    """When both env vars are unset the legacy ~/.claude/claude-prospector/ is used."""
+
+    def test_legacy_default_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both vars unset → BaseDirResolution.path is ~/.claude/claude-prospector/."""
+        monkeypatch.delenv("CLAUDE_PROSPECTOR_BASE_DIR", raising=False)
+        monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+
+        result = _hook._base_dir()
+
+        assert isinstance(result, _hook.BaseDirResolution)
+        expected = Path.home() / ".claude" / "claude-prospector"
+        assert result.path == expected


### PR DESCRIPTION
Closes #159.

## Summary

Replaces the bare-`Path`-returning `_base_dir` function in `hooks/dashboard-regen.py` with a frozen `BaseDirResolution` dataclass. Three in-file callers (`_config_path`, `_dashboard_path`, `_hook_log_path`) updated to consume `.path`. Adds 6 unit tests under `tests/unit/test_base_dir_dataclass.py` covering all three resolution tiers (env override, plugin data dir, legacy default) plus dataclass structure (frozen, single `path` field).

Behavior-preserving: env-var precedence, names, and legacy fallback are unchanged from the callers' perspective.

## Verification

Mirrors CI exactly (project CLAUDE.md § CI gates + lessons from PR #160):

| Command                              | Result                            |
| ------------------------------------ | --------------------------------- |
| `uv run ruff format --check .`       | 50 files already formatted — pass |
| `uv run ruff check src/ tests/`      | All checks passed                 |
| `uv run pytest`                      | 366 passed, 2 skipped (+6 vs baseline) |

## Test plan

- [x] All three resolution branches covered (env override / `CLAUDE_PLUGIN_DATA` / legacy default)
- [x] Dataclass structure tested (frozen, has `path` field)
- [x] Full `uv run pytest` green from worktree
- [x] `uv run ruff format --check .` and `uv run ruff check src/ tests/` green

## Out-of-scope observations (flagged, not addressed)

- `_config_path`, `_dashboard_path`, and `_hook_log_path` each call `_base_dir()` independently — three separate resolutions per hook run. Pre-existing; a single shared `BaseDirResolution` per invocation would be more efficient but is a separate concern beyond #159's scope.
- The test's `_load_hook_module` helper registers the hook module in `sys.modules` as a collection side effect. If a future test imports the hook under a different key, a shared `conftest.py` fixture would be cleaner. Test-infrastructure improvement, not needed now.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_