### PR TITLE
fix(dashboard): unify Goodhart numeric notation, expand burn-rate chart, clamp empty quadrant min size

### DIFF
--- a/src/claude_prospector/static/views/economics.js
+++ b/src/claude_prospector/static/views/economics.js
@@ -12,13 +12,9 @@
 
   // ── Helpers ─────────────────────────────────────────────────────────────
   function safeDiv(a, b) { return b > 0 ? a / b : 0; }
-  function fmtSig(n) {
-    if (n == null) return '—';
-    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-    if (n >= 10_000)    return Math.round(n / 1000) + 'K';
-    if (n >= 1000)      return (n / 1000).toFixed(1) + 'K';
-    return Math.round(n).toLocaleString();
-  }
+  // Use the shared CP.fmtTokens formatter throughout (suffixed: 1.2M, 450K)
+  // so every numeric cell in the Goodhart pane uses the same notation.
+  var fmtSig = CP.fmtTokens;
   // Δ chip — supports semantics where lower-is-better (cost metrics) flips
   // colors.
   function deltaChip(cur, prev, opts = {}) {

--- a/src/claude_prospector/static/views/layout-b-diag.js
+++ b/src/claude_prospector/static/views/layout-b-diag.js
@@ -233,7 +233,7 @@
       padding-top: 14px;
     }
     .lbd-style .cumulative h4 { margin-bottom: 8px; }
-    .lbd-style .cumulative svg { width: 100%; height: 140px; display: block; }
+    .lbd-style .cumulative svg { width: 100%; height: 240px; display: block; }
 
     /* Top sessions */
     .lbd-style .topsess {
@@ -776,7 +776,7 @@
       running += ctx.allAgg.byDay[d].total_tokens;
       return { day: d, total: running };
     });
-    const W = 700, H = 140, padL = 40, padR = 20, padT = 12, padB = 24;
+    const W = 700, H = 240, padL = 40, padR = 20, padT = 12, padB = 24;
     const innerW = W - padL - padR, innerH = H - padT - padB;
     const finalTotal = points.length ? points[points.length - 1].total : 0;
     const maxY = Math.max(limit7d || 0, finalTotal) * 1.05 || 1;
@@ -930,8 +930,13 @@
     const maxY = Math.max(...q.points.map(p => p.invoked), 5);
     const xAt = v => padL + (v / maxX) * innerW;
     const yAt = v => padT + (1 - v / maxY) * innerH;
-    const midX = xAt(q.passedMed);
-    const midY = yAt(q.invokedMed);
+    // Clamp midX/midY so each quadrant always occupies at least 20% of the
+    // chart width/height.  Without this, when all points cluster in one corner
+    // the opposite tiles collapse to zero pixels and their labels disappear.
+    const minQuadW = innerW * 0.20;
+    const minQuadH = innerH * 0.20;
+    const midX = Math.min(Math.max(xAt(q.passedMed),  padL + minQuadW), padL + innerW - minQuadW);
+    const midY = Math.min(Math.max(yAt(q.invokedMed), padT + minQuadH), padT + innerH - minQuadH);
 
     const colors = {
       workhorse: '#3fb950',
@@ -952,12 +957,21 @@
       `<rect x="${midX}" y="${midY}" width="${(padL + innerW) - midX}" height="${(padT + innerH) - midY}" fill="${colors.dead}" opacity="0.07"/>`,
     ].join('');
 
-    // Labels in quadrants
+    // Labels in quadrants — always shown even when the quadrant has no items.
+    // When a quadrant is empty a "(no items)" sub-label is appended so the
+    // four-quadrant framing remains legible.
+    function quadLabel(label, quadKey, x, y, anchor) {
+      const empty = q.counts[quadKey] === 0;
+      const col = colors[quadKey];
+      return `
+        <text x="${x}" y="${y}" fill="${col}" font-size="10" text-anchor="${anchor}" font-weight="500">${label}</text>
+        ${empty ? `<text x="${x}" y="${y + 13}" fill="${col}" font-size="9" text-anchor="${anchor}" opacity="0.65">(no items)</text>` : ''}`;
+    }
     const labels = `
-      <text x="${midX - 6}" y="${padT + 14}" fill="${colors.explicit}" font-size="10" text-anchor="end" font-weight="500">EXPLICIT</text>
-      <text x="${midX + 6}" y="${padT + 14}" fill="${colors.workhorse}" font-size="10" text-anchor="start" font-weight="500">WORKHORSE</text>
-      <text x="${midX - 6}" y="${padT + innerH - 6}" fill="${colors.idle}" font-size="10" text-anchor="end" font-weight="500">IDLE</text>
-      <text x="${midX + 6}" y="${padT + innerH - 6}" fill="${colors.dead}" font-size="10" text-anchor="start" font-weight="500">DEAD</text>
+      ${quadLabel('EXPLICIT',  'explicit',  midX - 6, padT + 14,          'end'  )}
+      ${quadLabel('WORKHORSE', 'workhorse', midX + 6, padT + 14,          'start')}
+      ${quadLabel('IDLE',      'idle',      midX - 6, padT + innerH - 6,  'end'  )}
+      ${quadLabel('DEAD',      'dead',      midX + 6, padT + innerH - 6,  'start')}
     `;
 
     // Quadrant divider lines


### PR DESCRIPTION
## Summary

Three targeted visual fixes to Phase 3 dashboard renderers (no behavior changes outside the listed panes).

## Fix 1 — Goodhart decomposition: unified numeric notation

**Problem:** The Goodhart waterfall pane (`economics.js`) had a local `fmtSig` helper that formatted numbers slightly differently from the shared `CP.fmtTokens` (different branching for 10K–1M range), causing some cells to render with suffixes and others with raw digits.

**Solution:** Replaced `fmtSig` with a direct alias to `CP.fmtTokens` so every numeric cell — waterfall bar labels, legend values, axis ticks, KPI strip, area-chart y-axis — uses the same suffixed notation (e.g. `1.2M`, `450K`).

**File:** `src/claude_prospector/static/views/economics.js` — lines 15–21 (fmtSig declaration replaced with `var fmtSig = CP.fmtTokens;`)

## Fix 2 — Burn rate chart: vertically expanded

**Problem:** The "Cumulative 7-day spend · projected against limit" SVG chart had `H = 140` in the JS and `height: 140px` in the CSS, making the curve squat and hard to read.

**Solution:** Increased to `H = 240` in the SVG viewBox and the matching `.lbd-style .cumulative svg` CSS rule, matching the `chart-container` height used by the Chart.js daily bar chart in the same view.

**File:** `src/claude_prospector/static/views/layout-b-diag.js` — CSS rule (line ~236) + `tabBurnRate` JS constant (line ~766)

## Fix 3 — Skill adoption quadrant: empty quadrants stay visible

**Problem:** The quadrant scatter plot placed its vertical/horizontal dividers at the median `passed`/`invoked` values. When all skills cluster in one corner (e.g. all newly-added skills with zero passes), the median collapses to 0 and the opposite quadrant tiles have zero/near-zero dimensions — labels disappear.

**Solution:**
1. Clamp `midX`/`midY` so each quadrant always occupies ≥20% of the chart area.
2. Added a `quadLabel` helper that appends a `(no items)` sub-label in the SVG when a quadrant's count is 0, so the four-quadrant framing remains legible even when a quadrant is empty.

**File:** `src/claude_prospector/static/views/layout-b-diag.js` — `tabQuadrant` function (~line 913)

## Test plan

- [x] `uv run pytest` — 432 passed, 2 skipped (identical to pre-implementation baseline on `e3a097e`)
- [x] `uv run ruff format --check .` — 53 files already formatted
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv build --wheel` — wheel built successfully; `economics.js` and `layout-b-diag.js` confirmed present in artifact
- [x] Dashboard regenerated against real session data (366 sessions, ~19B tokens) — generated successfully at 670 KB; `height: 240px` and `no items` text confirmed present in output HTML. Visual verification is JS-side only; no committed preview artifact.

Closes #172

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_