### PR TITLE
fix(aggregator): add agent_tokens to session records; fix ops over-attribution (#174)

### DIFF
--- a/src/claude_prospector/aggregator.py
+++ b/src/claude_prospector/aggregator.py
@@ -132,6 +132,18 @@ def aggregate(
             }
             agents_in_session = sorted(leaf_path_keys)
 
+            # Per-agent actual token totals for this session (issue #174).
+            # The leaf-only ``agents`` list excludes parent path-keys when
+            # sub-agents exist, so client code that apportions
+            # ``session.total_tokens / session.agents.length`` equally
+            # over-attributes every parent token to the sub-agent.
+            # ``agent_tokens`` maps EVERY observed path-key (not just leaves)
+            # to its real accumulated tokens from this session so clients
+            # can use accurate attribution instead of the equal-share heuristic.
+            session_agent_tokens: dict[str, int] = defaultdict(int)
+            for m in session_messages:
+                session_agent_tokens[_path_key(m)] += m.total_tokens
+
             result.sessions.append(
                 {
                     "session_id": session.session_id,
@@ -141,6 +153,7 @@ def aggregate(
                     ).isoformat(),
                     "root_agent": session.root_agent,
                     "agents": agents_in_session,
+                    "agent_tokens": dict(session_agent_tokens),
                     "total_tokens": sum(m.total_tokens for m in session_messages),
                     "input_tokens": sum(m.input_tokens for m in session_messages),
                     "output_tokens": sum(m.output_tokens for m in session_messages),

--- a/src/claude_prospector/static/cp-utils.js
+++ b/src/claude_prospector/static/cp-utils.js
@@ -113,13 +113,25 @@
         byDay[d].by_model[m] = (byDay[d].by_model[m] || 0) + t;
       }
 
-      for (const agent of (s.agents || [])) {
+      // Fix #174: use agent_tokens (accurate per-agent totals) when available.
+      // The old equal-apportionment (total / agents.length) over-attributed parent
+      // tokens to sub-agents; agent_tokens was added to the aggregator output to
+      // provide accurate per-agent breakdowns per session.
+      const agentKeys = Object.keys(s.agent_tokens || {}).length > 0
+        ? Object.keys(s.agent_tokens)
+        : (s.agents || []);
+      for (const agent of agentKeys) {
         if (!byAgent[agent]) byAgent[agent] = { total_tokens: 0, session_count: 0, primary_model: null, _modelTokens: {} };
         byAgent[agent].session_count += 1;
-        const share = Math.round(s.total_tokens / Math.max(1, s.agents.length));
-        byAgent[agent].total_tokens += share;
+        const agentShare = s.agent_tokens && s.agent_tokens[agent] != null
+          ? s.agent_tokens[agent]
+          : Math.round(s.total_tokens / Math.max(1, agentKeys.length));
+        byAgent[agent].total_tokens += agentShare;
+        // Model split: apportion by this agent's token fraction of session total.
+        const sessionTotal = s.total_tokens || 1;
+        const agentFraction = agentShare / sessionTotal;
         for (const [m, t] of Object.entries(s.model_split || {})) {
-          byAgent[agent]._modelTokens[m] = (byAgent[agent]._modelTokens[m] || 0) + Math.round(t / Math.max(1, s.agents.length));
+          byAgent[agent]._modelTokens[m] = (byAgent[agent]._modelTokens[m] || 0) + Math.round(t * agentFraction);
         }
       }
     }

--- a/src/claude_prospector/static/views/economics-basic.js
+++ b/src/claude_prospector/static/views/economics-basic.js
@@ -305,14 +305,28 @@
       daily.push({ day: key, date: d, total: dayTokens, isToday: i === 0 });
     }
 
-    // Top agents in recent 7d
+    // Top agents in recent 7d — fix #174: use agent_tokens (accurate per-agent
+    // totals from the aggregator) instead of equal-apportionment heuristic.
+    // Equal-apportionment (total_tokens / agents.length) over-attributed parent
+    // tokens to sub-agents: when ops was the only leaf, it absorbed all Opus
+    // context tokens, inflating its 7-day total from ~tens of M to 1.23 B.
     const agentTotals = {};
     for (const s of recent) {
-      const agents = s.agents && s.agents.length ? s.agents : ['(unspecified)'];
-      const share = s.total_tokens / agents.length;
-      for (const a of agents) {
-        if (a === 'general') continue;
-        agentTotals[a] = (agentTotals[a] || 0) + share;
+      if (s.agent_tokens && Object.keys(s.agent_tokens).length > 0) {
+        // Prefer accurate per-agent breakdown supplied by the aggregator.
+        for (const [a, t] of Object.entries(s.agent_tokens)) {
+          if (a === 'general') continue;
+          agentTotals[a] = (agentTotals[a] || 0) + t;
+        }
+      } else {
+        // Fallback for session records that pre-date agent_tokens (e.g. stale
+        // JSON cache): fall back to equal-apportionment over leaf agents.
+        const agents = s.agents && s.agents.length ? s.agents : ['(unspecified)'];
+        const share = s.total_tokens / agents.length;
+        for (const a of agents) {
+          if (a === 'general') continue;
+          agentTotals[a] = (agentTotals[a] || 0) + share;
+        }
       }
     }
     const topAgents = Object.entries(agentTotals)

--- a/src/claude_prospector/static/views/economics.js
+++ b/src/claude_prospector/static/views/economics.js
@@ -753,6 +753,10 @@
   // Artifact original approximated client-side via mock-injected _recent_total
   // etc. fields on by_agent. We now compute these by iterating sessions,
   // filtering to recent/prior 7-day windows, and accumulating per agent.
+  // Fix #174: use agent_tokens (accurate per-agent totals from aggregator)
+  // instead of equal-apportionment. Equal-apportionment divided session
+  // total_tokens by agents.length, inflating sub-agents like ops that were the
+  // sole leaf while the parent held large cache-heavy context.
   function computeAgentPeriods(sessions, now) {
     const c7  = new Date(now.getTime() - 7  * 86_400_000);
     const c14 = new Date(now.getTime() - 14 * 86_400_000);
@@ -764,18 +768,27 @@
       const isPrior  = t >= c14 && t < c7;
       if (!isRecent && !isPrior) continue;
       const bucket = isRecent ? recent : prior;
-      for (const agent of (s.agents || [])) {
+      // Prefer agent_tokens (accurate breakdown) over equal-apportionment.
+      const agentKeys = s.agent_tokens && Object.keys(s.agent_tokens).length > 0
+        ? Object.keys(s.agent_tokens)
+        : (s.agents || []);
+      const share = Math.max(1, agentKeys.length);
+      const sessionTotal = s.total_tokens || 1;
+      for (const agent of agentKeys) {
         if (!bucket[agent]) {
           bucket[agent] = {
             total_tokens: 0, message_count: 0,
             cache_creation_tokens: 0,
           };
         }
-        const share = Math.max(1, s.agents.length);
-        bucket[agent].total_tokens          += Math.round(s.total_tokens / share);
-        bucket[agent].message_count         += Math.round(s.message_count / share);
+        const agentTokens = s.agent_tokens && s.agent_tokens[agent] != null
+          ? s.agent_tokens[agent]
+          : Math.round(s.total_tokens / share);
+        const agentFraction = agentTokens / sessionTotal;
+        bucket[agent].total_tokens          += agentTokens;
+        bucket[agent].message_count         += Math.round(s.message_count * agentFraction);
         bucket[agent].cache_creation_tokens += Math.round(
-          (s.cache_creation_tokens || 0) / share
+          (s.cache_creation_tokens || 0) * agentFraction
         );
       }
     }

--- a/src/claude_prospector/static/views/layout-b-diag.js
+++ b/src/claude_prospector/static/views/layout-b-diag.js
@@ -492,17 +492,30 @@
   }
 
   // Per-agent tokens-per-minute and total minutes (sessions where they appear)
+  // Fix #174: use agent_tokens for accurate per-agent totals rather than
+  // dividing total_tokens equally across agents (equal-apportionment inflated
+  // sub-agents like ops that were the sole leaf while the parent held large
+  // context).
   function computeEfficiency(sessions) {
     const out = {};
     for (const s of sessions) {
-      const n = (s.agents || []).length || 1;
-      for (const a of (s.agents || [])) {
+      // Prefer agent_tokens (accurate) over equal-apportionment over leaf agents.
+      const agentKeys = s.agent_tokens && Object.keys(s.agent_tokens).length > 0
+        ? Object.keys(s.agent_tokens)
+        : (s.agents || []);
+      const n = agentKeys.length || 1;
+      const sessionTotal = s.total_tokens || 1;
+      for (const a of agentKeys) {
         if (!out[a]) out[a] = { tokens: 0, minutes: 0, sessions: 0, modelMix: {} };
-        out[a].tokens  += s.total_tokens / n;
+        const agentShare = s.agent_tokens && s.agent_tokens[a] != null
+          ? s.agent_tokens[a]
+          : s.total_tokens / n;
+        out[a].tokens  += agentShare;
         out[a].minutes += s.duration_minutes;
         out[a].sessions += 1;
+        const agentFraction = agentShare / sessionTotal;
         for (const [m, t] of Object.entries(s.model_split || {})) {
-          out[a].modelMix[m] = (out[a].modelMix[m] || 0) + (t / n);
+          out[a].modelMix[m] = (out[a].modelMix[m] || 0) + (t * agentFraction);
         }
       }
     }

--- a/tests/fixtures/dashboard_snapshot_pre_refactor.json
+++ b/tests/fixtures/dashboard_snapshot_pre_refactor.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-08T02:11:50.823585+00:00",
+  "generated_at": "2026-05-26T15:36:42.179476+00:00",
   "total_tokens": 15,
   "total_messages": 1,
   "total_sessions": 1,
@@ -55,6 +55,9 @@
       "agents": [
         "main"
       ],
+      "agent_tokens": {
+        "main": 15
+      },
       "total_tokens": 15,
       "input_tokens": 10,
       "output_tokens": 5,

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -410,6 +410,196 @@ class TestAggregateByAgentPath:
             ), f"by_agent['{key}'] is missing 'session_count'"
 
 
+class TestSessionAgentTokens:
+    """Regression tests for issue #174: ops sub-agent over-attribution.
+
+    The root cause: the aggregator emits only leaf path-keys in
+    ``session["agents"]``.  When a session's only leaf is a sub-agent
+    (e.g. ``"general-purpose→ops"``), the parent ``"general-purpose"``
+    is excluded because it is a proper prefix of the leaf.  Client-side
+    code that apportions ``session.total_tokens / session.agents.length``
+    then attributes ALL session tokens to the sub-agent — including the
+    large cache-heavy parent turns — producing a wildly inflated figure
+    (1.23 B was observed for ``ops`` in the user's 7-day window).
+
+    The fix: the aggregator adds an ``"agent_tokens"`` dict to each
+    session record mapping every path-key to its actual accumulated
+    tokens from that session.  Client-side JS uses this dict instead of
+    the equal-apportionment approximation.
+    """
+
+    def test_session_carries_agent_tokens_dict(self):
+        """Each session summary must contain an ``agent_tokens`` key."""
+        sessions = [
+            _session(
+                [_msg(agent="general-purpose", input_t=100, output_t=50)],
+            )
+        ]
+        result = aggregate(sessions)
+        assert len(result.sessions) == 1
+        assert "agent_tokens" in result.sessions[0], (
+            "Session summary must carry 'agent_tokens' dict for accurate "
+            "per-agent attribution (fixes issue #174 ops overcount)"
+        )
+
+    def test_agent_tokens_reflects_actual_per_agent_contribution(self):
+        """``agent_tokens`` maps each path-key to its real token total.
+
+        Constructs the exact pattern that caused the #174 over-count:
+        - ``general-purpose`` parent: 1 000 000 tokens (large Opus context)
+        - ``ops`` sub-agent: 1 000 tokens (tiny Haiku query)
+
+        ``agent_tokens`` must report these accurately rather than the
+        equal-apportionment approximation that would give each agent
+        500 500 tokens.
+        """
+        SEP = AGENT_PATH_SEPARATOR
+        parent_tokens = 1_000_000  # input + output
+        ops_tokens = 1_000
+
+        sessions = [
+            _session(
+                [
+                    # Large parent messages (general-purpose)
+                    _make_path_msg(
+                        ("general-purpose",),
+                        input_t=700_000,
+                        output_t=300_000,
+                    ),
+                    # Tiny ops sub-agent messages
+                    _make_path_msg(
+                        ("general-purpose", "ops"),
+                        model="claude-haiku-4-5-20251001",
+                        input_t=700,
+                        output_t=300,
+                    ),
+                ],
+            )
+        ]
+        result = aggregate(sessions)
+        assert len(result.sessions) == 1
+        sess = result.sessions[0]
+
+        gp_key = "general-purpose"
+        ops_key = f"general-purpose{SEP}ops"
+
+        assert "agent_tokens" in sess, "Session must carry 'agent_tokens' dict"
+        at = sess["agent_tokens"]
+
+        assert gp_key in at, (
+            f"'general-purpose' must appear in agent_tokens "
+            f"(got keys: {sorted(at)})"
+        )
+        assert ops_key in at, (
+            f"'{ops_key}' must appear in agent_tokens " f"(got keys: {sorted(at)})"
+        )
+
+        assert at[gp_key] == parent_tokens, (
+            f"general-purpose agent_tokens should be {parent_tokens:,} "
+            f"(its actual messages), not {at[gp_key]:,}"
+        )
+        assert at[ops_key] == ops_tokens, (
+            f"ops agent_tokens should be {ops_tokens:,} "
+            f"(its actual messages), not {at[ops_key]:,}. "
+            f"This is the #174 over-attribution bug if ops gets "
+            f"the parent's {parent_tokens:,} tokens."
+        )
+
+    def test_ops_not_over_attributed_when_only_leaf(self):
+        """ops must not absorb parent tokens just because it's the only leaf.
+
+        This is the exact scenario from issue #174:
+        ``session.agents = ['general-purpose→ops']`` (parent excluded by
+        the leaf rule), so equal-apportionment gives ops all session tokens.
+
+        ``agent_tokens`` must break this by carrying the accurate split.
+        """
+        SEP = AGENT_PATH_SEPARATOR
+        ops_key = f"general-purpose{SEP}ops"
+
+        sessions = [
+            _session(
+                [
+                    _make_path_msg(
+                        ("general-purpose",),
+                        input_t=500_000,
+                        output_t=200_000,
+                    ),
+                    _make_path_msg(
+                        ("general-purpose", "ops"),
+                        model="claude-haiku-4-5-20251001",
+                        input_t=100,
+                        output_t=50,
+                    ),
+                ],
+            )
+        ]
+        result = aggregate(sessions)
+        sess = result.sessions[0]
+
+        # The leaf rule leaves only ops in agents — verify the buggy
+        # equal-apportionment would inflate ops:
+        assert sess["agents"] == [
+            ops_key
+        ], f"Expected ops to be the sole leaf agent; got {sess['agents']}"
+
+        # With the fix, agent_tokens must reflect the accurate split:
+        at = sess["agent_tokens"]
+        ops_actual = 100 + 50  # input + output for ops messages only
+        parent_actual = 500_000 + 200_000  # input + output for parent messages
+
+        assert at.get(ops_key, 0) == ops_actual, (
+            f"ops agent_tokens must be {ops_actual} (its actual messages). "
+            f"Got {at.get(ops_key, 0):,}. "
+            f"If this equals ~{parent_actual:,}, the #174 over-attribution "
+            f"bug is present."
+        )
+
+    def test_agent_tokens_present_for_depth_one_session(self):
+        """Depth-1 sessions (no sub-agents) also carry agent_tokens."""
+        sessions = [
+            _session(
+                [_msg(agent="main", input_t=200, output_t=100)],
+            )
+        ]
+        result = aggregate(sessions)
+        sess = result.sessions[0]
+        assert "agent_tokens" in sess
+        assert sess["agent_tokens"] == {"main": 300}
+
+    def test_agent_tokens_sums_match_session_total(self):
+        """Sum of all agent_tokens values equals session total_tokens."""
+        sessions = [
+            _session(
+                [
+                    _make_path_msg(
+                        ("general-purpose",),
+                        input_t=100,
+                        output_t=50,
+                    ),
+                    _make_path_msg(
+                        ("general-purpose", "code-writer"),
+                        input_t=200,
+                        output_t=100,
+                    ),
+                    _make_path_msg(
+                        ("general-purpose", "ops"),
+                        model="claude-haiku-4-5-20251001",
+                        input_t=10,
+                        output_t=5,
+                    ),
+                ],
+            )
+        ]
+        result = aggregate(sessions)
+        sess = result.sessions[0]
+        at_sum = sum(sess["agent_tokens"].values())
+        assert at_sum == sess["total_tokens"], (
+            f"agent_tokens sum {at_sum:,} must equal session "
+            f"total_tokens {sess['total_tokens']:,}"
+        )
+
+
 def _make_path_msg(
     path: tuple[str, ...],
     model: str = "claude-opus-4-6",


### PR DESCRIPTION
## Root cause

When a session has both parent messages (`general-purpose`) and sub-agent messages (`general-purpose→ops`), the aggregator's deepest-leaf rule correctly excludes `general-purpose` from `session["agents"]` — because it is a proper prefix of the leaf path `general-purpose→ops`. This prevents double-counting in the equal-apportionment formula `total_tokens / agents.length`.

**But this creates the inverse bug:** when `ops` is the session's only leaf agent, `agents.length === 1`, so equal-apportionment gives ops 100% of session tokens — including the large Opus context window of the parent. Across 97 sessions in the 7-day window (where `ops` is always dispatched early), this inflated ops from its real ~98 M to **1.23 B tokens**.

Concrete evidence — the client-side simulation before the fix:
```
#1  'general-purpose→ops'   1,231,550,069 tokens   ← inflated by parent Opus context
#2  'general-purpose→code-writer'  1,059,352,173 tokens
```

After the fix:
```
#1  'general-purpose'         2,642,030,344 tokens   ← correct: holds the Opus turns
#4  'general-purpose→ops'        98,437,915 tokens   ← plausible: Haiku GitHub queries
```

## Fix

**Aggregator (`aggregator.py`):** Each session record now includes `agent_tokens: dict[str, int]` — a mapping from every observed path-key (not just leaf keys) to its actual accumulated token count from that session. This is computed from the same per-message iteration used for `by_agent`, so it is always accurate.

**Client-side JS (all four sites):** `economics-basic.js`, `economics.js` (`computeAgentPeriods`), `layout-b-diag.js` (`computeEfficiency`), and `cp-utils.js` (`reAggregate`) now prefer `session.agent_tokens[agent]` over the equal-apportionment heuristic. The old heuristic is retained as a fallback for any session record that pre-dates this field.

## Before / after top-10 agent rankings

### Before (server-side `by_agent` — always accurate, unchanged)
| # | Agent | Tokens | Model |
|---|-------|--------|-------|
| 1 | `general-purpose` | 13.3 B | opus |
| 2 | `general-purpose→code-writer` | 3.3 B | sonnet |
| 3 | `general-purpose→ops` | 385 M | haiku |
| 4 | `general-purpose→Explore` | 338 M | haiku |

### Before (client-side 7-day agentTotals — buggy equal-apportionment)
| # | Agent | Tokens |
|---|-------|--------|
| 1 | `general-purpose→ops` | **1.23 B** ← bug |
| 2 | `general-purpose→code-writer` | 1.06 B |

### After (client-side 7-day agentTotals — using agent_tokens)
| # | Agent | Tokens |
|---|-------|--------|
| 1 | `general-purpose` | 2.64 B |
| 2 | `general-purpose→code-writer` | 835 M |
| 3 | `general-purpose→Explore` | 107 M |
| 4 | `general-purpose→ops` | 98 M |

## Regression tests

Added `TestSessionAgentTokens` (5 tests) in `tests/test_aggregator.py`:
- `test_session_carries_agent_tokens_dict` — field always present
- `test_agent_tokens_reflects_actual_per_agent_contribution` — parent 1M tokens, ops 1K; each bucket must match exactly
- `test_ops_not_over_attributed_when_only_leaf` — reproduces the #174 scenario directly; ops gets 150 tokens, not the parent's 700K
- `test_agent_tokens_present_for_depth_one_session` — depth-1 sessions work correctly
- `test_agent_tokens_sums_match_session_total` — sum invariant across multi-agent sessions

Dashboard JSON snapshot updated to include the new `agent_tokens` field.

Test counts: 432 → 437 passed, 2 skipped, 0 failed.

Closes #174

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_