### PR TITLE
fix(dashboard): apply user-provided JS fixes (negative fmt, active-days, pill hover, SVG sizing)

### DIFF
--- a/src/claude_prospector/static/cp-utils.js
+++ b/src/claude_prospector/static/cp-utils.js
@@ -31,9 +31,11 @@
   // ── Formatters ───────────────────────────────────────────────────────────
   function fmtTokens(n) {
     if (n == null) return '—';
-    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-    if (n >= 1000)      return (n / 1000).toFixed(n >= 10000 ? 0 : 1) + 'K';
-    return String(Math.round(n));
+    const sign = n < 0 ? '-' : '';
+    const a = Math.abs(n);
+    if (a >= 1_000_000) return sign + (a / 1_000_000).toFixed(1) + 'M';
+    if (a >= 1000)      return sign + (a / 1000).toFixed(a >= 10000 ? 0 : 1) + 'K';
+    return sign + String(Math.round(a));
   }
   function fmtTokensFull(n) {
     if (n == null) return '—';

--- a/src/claude_prospector/static/views/economics-basic.js
+++ b/src/claude_prospector/static/views/economics-basic.js
@@ -291,8 +291,15 @@
     const priorTotal  = sumT(prior);
     const pctChange = priorTotal > 0 ? (recentTotal - priorTotal) / priorTotal * 100 : 0;
 
-    // Distinct days with activity in recent 7d
-    const recentDays = new Set(recent.map(s => s.start_time.slice(0, 10))).size;
+    // Active days: of the last 7 calendar days (anchored on NOW),
+    // how many had any session activity.
+    const recentDateKeys = new Set();
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(NOW.getTime() - i * 86_400_000);
+      recentDateKeys.add(d.toISOString().slice(0, 10));
+    }
+    const sessionDateKeys = new Set(sessions.map(s => s.start_time.slice(0, 10)));
+    const recentDays = [...recentDateKeys].filter(k => sessionDateKeys.has(k)).length;
 
     // Daily totals for the last 14 days
     const daily = [];

--- a/src/claude_prospector/static/views/economics.js
+++ b/src/claude_prospector/static/views/economics.js
@@ -264,10 +264,14 @@
       display: inline-flex; align-items: center; gap: 4px;
       background: rgba(63,185,80,0.15); color: #3fb950;
       padding: 1px 6px; border-radius: 8px; font-size: 9px; text-transform: none; letter-spacing: 0;
+      border: 0;
+      cursor: default;
     }
+    .lec-style .score-col h4 .pill:hover { border-color: transparent; color: #3fb950; }
     .lec-style .score-col.regression h4 .pill {
       background: rgba(248,81,73,0.15); color: #f85149;
     }
+    .lec-style .score-col.regression h4 .pill:hover { color: #f85149; }
     .lec-style .score-row {
       display: grid;
       grid-template-columns: 1fr 80px 80px 80px;

--- a/src/claude_prospector/static/views/layout-b-diag.js
+++ b/src/claude_prospector/static/views/layout-b-diag.js
@@ -233,7 +233,13 @@
       padding-top: 14px;
     }
     .lbd-style .cumulative h4 { margin-bottom: 8px; }
-    .lbd-style .cumulative svg { width: 100%; height: 240px; display: block; }
+    .lbd-style .cumulative svg {
+      width: 100%;
+      height: auto;
+      aspect-ratio: 700 / 240;
+      max-height: 280px;
+      display: block;
+    }
 
     /* Top sessions */
     .lbd-style .topsess {
@@ -267,7 +273,13 @@
       margin-left: 6px;
     }
 
-    .lbd-style .histo svg { width: 100%; height: 240px; display: block; }
+    .lbd-style .histo svg {
+      width: 100%;
+      height: auto;
+      aspect-ratio: 700 / 240;
+      max-height: 280px;
+      display: block;
+    }
 
     /* Movers */
     .lbd-style .movers-row {
@@ -311,7 +323,17 @@
       gap: 20px;
     }
     @media (max-width: 1000px) { .lbd-style .quad-wrap { grid-template-columns: 1fr; } }
-    .lbd-style .quad svg { width: 100%; height: 360px; display: block; }
+    .lbd-style .quad {
+      width: 100%;
+      max-width: 560px;
+      justify-self: center;
+    }
+    .lbd-style .quad svg {
+      width: 100%;
+      height: auto;
+      aspect-ratio: 520 / 360;
+      display: block;
+    }
 
     .lbd-style .quad-legend { display: flex; flex-direction: column; gap: 10px; }
     .lbd-style .qblock {
@@ -798,7 +820,7 @@
 
       <div class="cumulative">
         <h4>Cumulative 7-day spend · projected against limit</h4>
-        <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+        <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
           ${limitLine}
           <!-- area under curve -->
           <path d="${path} L ${xAt(points.length - 1)} ${padT + innerH} L ${padL} ${padT + innerH} Z" fill="#58a6ff" fill-opacity="0.12"/>
@@ -831,7 +853,7 @@
       histo[i]++;
     }
     const histMax = Math.max(...histo);
-    const W = 360, H = 240, padL = 24, padR = 12, padT = 12, padB = 30;
+    const W = 700, H = 240, padL = 36, padR = 32, padT = 16, padB = 34;
     const innerW = W - padL - padR, innerH = H - padT - padB;
     const upperX = padL + (upper / max) * innerW;
 
@@ -856,7 +878,7 @@
         </div>
         <div class="histo">
           <h4>Session size distribution${outlierCount ? ' · <span style="color:#f85149">' + outlierCount + ' outlier' + (outlierCount === 1 ? '' : 's') + '</span>' : ''}</h4>
-          <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+          <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
             ${histo.map((c, i) => {
               const x = padL + (i / bins) * innerW;
               const w = (innerW / bins) * 0.86;


### PR DESCRIPTION
## Summary

Four client-side JS fixes applied verbatim from user-provided files (issue #176). No Python changes; all 437 tests pass unchanged.

## Changes per file

**`src/claude_prospector/static/cp-utils.js`**
Fix `fmtTokens` to handle negative values correctly: extract sign, operate on absolute value, and re-prefix the sign character. Previously negative numbers would render without the minus sign (or produce garbled output).

**`src/claude_prospector/static/views/economics-basic.js`**
Fix active-days count calculation: instead of counting distinct session date-keys in the `recent` array (which uses a 7-day token-window, not a calendar window), build the set of the last 7 calendar days anchored on `NOW` and intersect with session dates. This gives the correct "how many of the last 7 calendar days had activity" metric.

**`src/claude_prospector/static/views/economics.js`**
Fix pill hover styling in the LEC score column: add `border: 0` and `cursor: default` to the base pill rule, and add explicit `:hover` overrides for both the normal (green) and regression (red) pill variants so the border/color don't flash on mouseover.

**`src/claude_prospector/static/views/layout-b-diag.js`**
Fix SVG sizing for the cumulative spend chart, session-size histogram, and quadrant charts: replace fixed `height: 240px` / `height: 360px` with `height: auto` + `aspect-ratio` + `max-height` so the SVGs scale proportionally at different viewport widths. Also switch `preserveAspectRatio` from `none` to `xMidYMid meet` on the two chart SVGs, and expand the histogram viewBox from 360 × 240 to 700 × 240 (with matching padding) for better label legibility.

## Test plan

- [x] `uv run pytest` — 437 passed, 2 skipped, 0 failed (identical to baseline on `2d91c4f`)
- [x] `uv run ruff format --check .` — 63 files already formatted
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv build --wheel` — wheel built successfully; all 3 view JS files confirmed present in wheel
- [x] `python -m claude_prospector dashboard --no-open --output ...` — 739 KB HTML generated successfully

Closes #176

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_