### PR TITLE
fix(dashboard): quadrant dot classification when median-divider clamps

### DIFF
--- a/src/claude_prospector/static/views/layout-b-diag.js
+++ b/src/claude_prospector/static/views/layout-b-diag.js
@@ -960,6 +960,25 @@
     const midX = Math.min(Math.max(xAt(q.passedMed),  padL + minQuadW), padL + innerW - minQuadW);
     const midY = Math.min(Math.max(yAt(q.invokedMed), padT + minQuadH), padT + innerH - minQuadH);
 
+    // Re-classify points against the *clamped* midpoints so the dot colours
+    // and quadrant counts agree with the visual divider lines. Using the raw
+    // medians (as computeQuadrant does) drifts away from the rendered grid
+    // whenever the clamp is active — e.g. when the median sits near a corner
+    // and the divider snaps inward, a point above the raw median can plot
+    // visually inside the IDLE/DEAD tile.
+    const xThresh = (midX - padL) / innerW * maxX;
+    const yThresh = (1 - (midY - padT) / innerH) * maxY;
+    q.counts = { workhorse: 0, explicit: 0, dead: 0, idle: 0 };
+    for (const p of q.points) {
+      const hp = p.passed  >= xThresh;
+      const hi = p.invoked >= yThresh;
+      if      ( hp &&  hi) p.quad = 'workhorse';
+      else if (!hp &&  hi) p.quad = 'explicit';
+      else if ( hp && !hi) p.quad = 'dead';
+      else                 p.quad = 'idle';
+      q.counts[p.quad]++;
+    }
+
     const colors = {
       workhorse: '#3fb950',
       explicit:  '#58a6ff',


### PR DESCRIPTION
The recent quadrant-render fix added a clamp on `midX` / `midY` so that
empty quadrants always occupy at least 20% of the chart — without this,
when all skills cluster in one corner, the opposite tiles collapse to
0 px and their labels disappear.

The clamp is layout-only, but **dot classification still uses the raw
`passedMed` / `invokedMed`** that `computeQuadrant()` returns. When the
data clusters low (typical: most skills have low pass/invoke counts), the
visual divider snaps inward to ~20% of chart width/height, but a point
classified `workhorse` (above the raw median) plots below the visual
divider and sits inside the IDLE/DEAD tile.

### Symptoms

- Green (workhorse) dots appear inside the IDLE tile.
- IDLE / DEAD show `(no items)` sub-labels while dots are clearly rendered
  in those tiles.
- Side-panel `+N more` / per-quadrant counts disagree with what's visible.

### Fix

Invert `xAt` / `yAt` at the clamped midpoint pixel positions to recover
the effective data-value thresholds the user actually sees, then
re-classify points and recompute `q.counts` against those. Now dot
colours, the `(no items)` sub-labels, and the side panel all agree with
the rendered grid.

`computeQuadrant()` is left untouched — `passedMed` / `invokedMed` are
still the raw medians and any future consumer is free to use them.
Re-classification is purely a render-time concern, scoped inside
`tabQuadrant()`.

### Scope

- `src/claude_prospector/static/views/layout-b-diag.js` — +19 lines, no
  API change.
- No test changes — existing quadrant tests assert against
  `computeQuadrant()`'s output, which is unchanged.

### Manual verification

Load `python -m claude_prospector dashboard` against a transcript where
most skills cluster low (any small/recent install). Open the Skills tab
of the Diagnostics card. Pre-fix: green dots in the IDLE tile + `(no
items)` labels. Post-fix: dots colour-match their visible tile, sub-labels
only appear when a quadrant is truly empty.

Closes #178

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_