### PR TITLE
fix(dashboard): restore median-based quadrant classification; anchor labels to corners

### DIFF
--- a/src/claude_prospector/static/views/layout-b-diag.js
+++ b/src/claude_prospector/static/views/layout-b-diag.js
@@ -952,32 +952,16 @@
     const maxY = Math.max(...q.points.map(p => p.invoked), 5);
     const xAt = v => padL + (v / maxX) * innerW;
     const yAt = v => padT + (1 - v / maxY) * innerH;
-    // Clamp midX/midY so each quadrant always occupies at least 20% of the
-    // chart width/height.  Without this, when all points cluster in one corner
-    // the opposite tiles collapse to zero pixels and their labels disappear.
-    const minQuadW = innerW * 0.20;
-    const minQuadH = innerH * 0.20;
-    const midX = Math.min(Math.max(xAt(q.passedMed),  padL + minQuadW), padL + innerW - minQuadW);
-    const midY = Math.min(Math.max(yAt(q.invokedMed), padT + minQuadH), padT + innerH - minQuadH);
-
-    // Re-classify points against the *clamped* midpoints so the dot colours
-    // and quadrant counts agree with the visual divider lines. Using the raw
-    // medians (as computeQuadrant does) drifts away from the rendered grid
-    // whenever the clamp is active — e.g. when the median sits near a corner
-    // and the divider snaps inward, a point above the raw median can plot
-    // visually inside the IDLE/DEAD tile.
-    const xThresh = (midX - padL) / innerW * maxX;
-    const yThresh = (1 - (midY - padT) / innerH) * maxY;
-    q.counts = { workhorse: 0, explicit: 0, dead: 0, idle: 0 };
-    for (const p of q.points) {
-      const hp = p.passed  >= xThresh;
-      const hi = p.invoked >= yThresh;
-      if      ( hp &&  hi) p.quad = 'workhorse';
-      else if (!hp &&  hi) p.quad = 'explicit';
-      else if ( hp && !hi) p.quad = 'dead';
-      else                 p.quad = 'idle';
-      q.counts[p.quad]++;
-    }
+    // Divider lines sit at the raw medians from computeQuadrant() so that
+    // a point's classification (above/below median on each axis) always
+    // matches the tile it visually falls into. Earlier versions clamped
+    // midX/midY to keep IDLE/DEAD labels readable when data clustered near
+    // a corner — but that clamp introduced a classification/visualisation
+    // mismatch (dots coloured for one quadrant rendered inside another).
+    // We solve the label-readability problem separately by anchoring labels
+    // to chart corners below, independent of where the divider lands.
+    const midX = xAt(q.passedMed);
+    const midY = yAt(q.invokedMed);
 
     const colors = {
       workhorse: '#3fb950',
@@ -1009,10 +993,10 @@
         ${empty ? `<text x="${x}" y="${y + 13}" fill="${col}" font-size="9" text-anchor="${anchor}" opacity="0.65">(no items)</text>` : ''}`;
     }
     const labels = `
-      ${quadLabel('EXPLICIT',  'explicit',  midX - 6, padT + 14,          'end'  )}
-      ${quadLabel('WORKHORSE', 'workhorse', midX + 6, padT + 14,          'start')}
-      ${quadLabel('IDLE',      'idle',      midX - 6, padT + innerH - 6,  'end'  )}
-      ${quadLabel('DEAD',      'dead',      midX + 6, padT + innerH - 6,  'start')}
+      ${quadLabel('EXPLICIT',  'explicit',  padL + 8,          padT + 14,         'start')}
+      ${quadLabel('WORKHORSE', 'workhorse', padL + innerW - 8, padT + 14,         'end'  )}
+      ${quadLabel('IDLE',      'idle',      padL + 8,          padT + innerH - 6, 'start')}
+      ${quadLabel('DEAD',      'dead',      padL + innerW - 8, padT + innerH - 6, 'end'  )}
     `;
 
     // Quadrant divider lines


### PR DESCRIPTION
## Background

The skill-adoption quadrant has two competing concerns:

1. **Classification semantics**: a skill is a workhorse if it's above the
   median on both axes (passed by Claude AND invoked by the user). This
   is what `computeQuadrant()` produces — the 50/50 baseline.
2. **Label readability**: when most skills cluster in one corner (typical
   for a fresh install with few data points), the median sits near a
   chart edge and the IDLE/DEAD label text collides with the divider line
   or runs off-chart.

An earlier render-time fix (#173) tried to solve (2) by clamping the divider
lines into the chart by 20%, but that pulled them away from the actual
median. A follow-up fix (#181) re-classified points against the clamped
thresholds to keep dot colors aligned — which solved the visual issue
but **silently rewrote the classification semantics**:

> The change has moved 90% of my skills from the green bucket to the
> idle bucket.

With the median near a corner, the clamped thresholds become "top 20% by
passes AND top 20% by invokes" — a much stricter rule than the median.
Skills that sit at or just above the median get re-bucketed as idle.

## Fix

Decouple the two concerns:

- **Divider lines** sit at the raw median (`xAt(q.passedMed)`,
  `yAt(q.invokedMed)`) — no clamp. Dots always land in the tile that
  matches their classification.
- **Labels** anchor to chart corners with fixed offsets from
  `padL` / `padL + innerW`, so they stay legible even when the divider
  is right next to an edge and a quadrant's coloured tile shrinks to a
  sliver.
- **`computeQuadrant()` is untouched** — `passedMed`, `invokedMed`, and
  `q.counts` keep their original median semantics.
- **`(no items)` sub-labels** still appear when a quadrant is genuinely
  empty (zero points above the relevant median on at least one axis).

The shrunken-tile case is now visually informative rather than broken:
if WORKHORSE is a sliver in the top-right, that's a real signal that
your data is heavily shifted away from the workhorse quadrant — the
label still sits at the top-right corner so you can read it.

### Scope

- `src/claude_prospector/static/views/layout-b-diag.js` — net −7 lines
  in `tabQuadrant()` (clamp + reclassification block out; corner-anchor
  label coords in).
- No API change. No test changes — existing quadrant tests assert
  against `computeQuadrant()` output, which is unchanged.

### Manual verification

Open `python -m claude_prospector dashboard`, switch to the Skills tab
of the Diagnostics card.

- Pre-fix (with the clamp + re-classification): most skills cluster
  inside IDLE, regardless of actual median position. `(no items)`
  labels appear on WORKHORSE/EXPLICIT despite green dots being visible.
- Post-fix: workhorse skills (above median on both axes) render with
  the green WORKHORSE colour and land in the top-right region defined
  by the divider lines. Labels remain readable in all four corners
  whether or not their region is large.

Closes #182

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_