### PR TITLE
chore(release): v0.9.0 — Economy v1 dashboard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-26
+
+### Added
+
+- **Economy v1 dashboard** (#144) — a three-tab dashboard shell (Overview / Breakdown / Advanced) replaces the single-view layout. (#170, #171)
+  - **Overview** (`economics-basic.js`) — top-line spend with "Where your tokens went" agent attribution.
+  - **Breakdown** (`layout-b-diag.js`) — cumulative spend, per-day histogram, top sessions, recent movers.
+  - **Advanced** (`economics.js`) — Goodhart decomposition, burn-rate projection, full diagnostic surface.
+  - Chart.js + chartjs-chart-treemap are vendored under `src/claude_prospector/static/` and shipped in the wheel via `[tool.setuptools.package-data]`.
+- **Per-token-type breakdowns** in `by_day` and `sessions` aggregator output (#166) — input / output / cache_read / cache_creation tokens are reported separately, enabling the dashboard's per-component cost lines.
+- **Per-agent token attribution** on session records (#174, fixed in #175). The aggregator now emits `agent_tokens: dict[str, int]` per session, which fixes a client-side over-attribution bug where the dashboard apportioned `session.total_tokens / session.agents.length` and reported sub-agent invocations (e.g. `ops` as a Haiku runner) at billions of tokens.
+
 ### Fixed
 
-- **`userConfig.autoregen` missing schema default** (#149). Added `"default": false` to the `autoregen` field in `.claude-plugin/plugin.json` so the plugin manager has an explicit default and does not prompt unexpectedly or treat a missing value as true.
+- **`userConfig.autoregen` missing schema default** (#149, fixed in #150). Added `"default": false` to the `autoregen` field in `.claude-plugin/plugin.json` so the plugin manager has an explicit default and does not prompt unexpectedly or treat a missing value as true.
+- **Goodhart decomposition mixed numeric notation** (#173) — some panes showed raw token counts while siblings used `k`/`M`/`B` suffixes; unified through `CP.fmtTokens`.
+- **Burn-rate chart vertically compressed** (#173) — raised the chart height so the 7-day cumulative projection is legible.
+- **Negative number formatting / active-days computation / pill hover state / SVG sizing** (#176, fixed in #177) — user-provided JS polish bundle applied as a drop-in.
+- **`msgs/session` sparkline rendered flat** (#179, fixed in #180) — the aggregator was not plumbing per-day `session_count`, so the sparkline divided messages by total sessions instead of per-day session counts.
+
+### Changed
+
+- **Removed the skill-adoption quadrant pane** from the Breakdown view (#185, removed in #186). Three iterative fix attempts (#173 clamp → #181 re-classify → #183 revert) produced three different broken layouts. Rather than ship a known-flaky chart, the quadrant is dropped from 0.9.0 and re-add work is tracked in **#184** (four design options enumerated: fixed-percentile thresholds, log axes, two-panel small-multiples, density heatmap).
+- **`_base_dir` resolution refactored** to a dataclass (#159, refactored in #164) — internal-only; no behavior change.
+
+### Notes
+
+- Release runbook (`docs/release-process.md`, #141) and project `CLAUDE.md` (#143) were added in the 0.9.0 cycle but are documentation-only and ship outside the user-facing surface.
+
+[0.9.0]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.9.0
 
 ## [0.8.2] - 2026-05-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.8.2"
+version = "0.9.0"
 description = "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill."
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "claude-prospector"
-version = "0.8.2"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Cuts **v0.9.0** of `claude-prospector`. The headline change is the **Economy v1 dashboard** (#144) — a three-tab shell (Overview / Breakdown / Advanced) replacing the single-view layout — plus the aggregator changes that back it (per-token-type breakdowns, per-agent attribution) and a handful of UX fixes from the Phase 4 polish cycle.

This PR contains only the version bump + CHANGELOG finalisation. All implementing work landed in earlier PRs already on `main`.

## Version bump

| File | From | To |
|---|---|---|
| `pyproject.toml` | `0.8.2` | `0.9.0` |
| `.claude-plugin/plugin.json` | `0.8.2` | `0.9.0` |
| `uv.lock` (claude-prospector entry) | `0.8.2` | `0.9.0` |
| `CHANGELOG.md` | `[Unreleased]` draft | `## [0.9.0] - 2026-05-26` |

## What ships in 0.9.0

**Added**
- Economy v1 dashboard — three-tab shell, Chart.js + treemap vendor assets, per-view renderers (#144, #170, #171)
- Per-token-type breakdowns in `by_day` / `sessions` aggregator output (#166)
- `agent_tokens: dict[str, int]` on session records — fixes the 1.23B-token `ops` over-attribution bug (#174, #175)

**Fixed**
- `userConfig.autoregen` schema default (#149 → #150)
- Goodhart mixed numeric notation + burn-rate chart height (#173)
- Negative formatting / active-days / pill hover / SVG sizing (#176 → #177)
- `msgs/session` sparkline flat (#179 → #180)

**Changed**
- Skills adoption quadrant pane removed from Breakdown view (#185 → #186). Re-add tracked in **#184** with four design options enumerated. Removed rather than shipped because three iterative fix attempts (#173 → #181 → #183) each produced a different broken layout.
- `_base_dir` resolution refactored to a dataclass (#159 → #164) — internal-only

See `CHANGELOG.md` for the full annotated entry.

## Pre-flight verification (local)

| Check | Result |
|---|---|
| `uv run ruff check src/ tests/` | clean |
| `uv run pytest` | **437 passed, 2 skipped** (1 warning, pre-existing) |
| `uv build --wheel` | `claude_prospector-0.9.0-py3-none-any.whl` built |
| Wheel contents — view renderers | `economics-basic.js`, `economics.js`, `layout-b-diag.js` all present |
| Wheel contents — vendor assets | `chart.umd.min.js`, `chartjs-chart-treemap.min.js` present |
| Wheel contents — template | `templates/dashboard.html` present |
| Visual sign-off on regenerated preview | ✅ (user-confirmed prior to opening this PR) |

CI must still confirm Lint, Test (Ubuntu + Windows), and Skill Smoke on this branch before merge per `docs/release-process.md` § Step 2.

## Release runbook position

This is **Step 1** of `docs/release-process.md`. Once CI is green and this PR is merged:

3. Tag merge commit `vX.Y.Z` (annotated)
4. Push tag — triggers `release.yml` (build → wheel-smoke → publish-pypi)
5. Wait for all three jobs green (wheel-smoke is the gate)
6. Dereference tag: `git rev-parse 'v0.9.0^{commit}'` (NOT bare — see Footguns)
7. Open marketplace bump PR on `glitchwerks/plugins`
8. Merge
9. Verify live pin

No cache wipe (step 10) — `source.repo` is unchanged.

## Test plan

- [ ] CI green on `release/0.9.0` (lint + test Ubuntu + test Windows + skill-smoke Ubuntu + skill-smoke Windows)
- [ ] Squash-merge to `main`
- [ ] `Closes #144` + `Closes #169` fire on merge (verify via auto-close)
- [ ] Tag + release workflow run successfully
- [ ] PyPI publish-pypi job green
- [ ] Marketplace bump PR opens against `glitchwerks/plugins`

## Closes

Closes #144
Closes #169

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_