### PR TITLE
fix(dashboard): drop default --window filter so week-over-week panes work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard `--window` no longer filters out prior-period data needed for week-over-week comparison panes** (#188). The `dashboard` subcommand previously defaulted to `--window 7d`, which made the Economy v1 dashboard's recent-movers / burn-rate-trendline / "Why did total tokens change?" panes effectively unusable because the aggregator pre-dropped everything older than 7 days. Default is now "no window filter; aggregate the full session history". `--window` remains accepted as an explicit opt-in flag for users who want a scoped dashboard.
+
 ## [0.9.0] - 2026-05-26
 
 ### Added

--- a/hooks/dashboard-regen.py
+++ b/hooks/dashboard-regen.py
@@ -410,7 +410,7 @@ def _regen_failed_page(stderr_output: str) -> str:
 <p>Captured error output:</p>
 <pre>{escaped}</pre>
 <p>To diagnose, run manually:</p>
-<pre>python -m claude_prospector dashboard --window 7d</pre>
+<pre>python -m claude_prospector dashboard</pre>
 """
     return _html_page(
         "Dashboard regeneration failed — claude-prospector",
@@ -575,14 +575,15 @@ def main() -> int:
             return 0
 
         # Step 4: run the regen.
+        # Note: no --window flag — the dashboard subcommand aggregates the
+        # full session history by default (issue #188).  Users who want a
+        # scoped dashboard can pass --window explicitly via the CLI.
         regen_result = subprocess.run(
             [
                 _venv_python,
                 "-m",
                 "claude_prospector",
                 "dashboard",
-                "--window",
-                "7d",
                 "--output",
                 str(dashboard),
                 "--no-open",

--- a/skills/usage-dashboard/SKILL.md
+++ b/skills/usage-dashboard/SKILL.md
@@ -26,7 +26,7 @@ For interpretation (budget status, top consumers, recommendations), point the us
 
 ## Default behavior
 
-If the user passes no arguments, run the **7-day rolling** window (matches the most useful billing bucket) and write the dashboard to the platform-appropriate path:
+If the user passes no arguments, regenerate against the **full aggregated session history** and write the dashboard to the platform-appropriate path:
 
 - POSIX: `$HOME/.claude/claude-prospector/dashboard.html`
 - Windows: `%USERPROFILE%\.claude\claude-prospector\dashboard.html`
@@ -35,10 +35,10 @@ Pass `--no-open` so the file lands at the known path without spawning a browser 
 
 ```bash
 # POSIX
-python -m claude_prospector dashboard --window 7d --output "$HOME/.claude/claude-prospector/dashboard.html" --no-open
+python -m claude_prospector dashboard --output "$HOME/.claude/claude-prospector/dashboard.html" --no-open
 
 # Windows
-python -m claude_prospector dashboard --window 7d --output "%USERPROFILE%\.claude\claude-prospector\dashboard.html" --no-open
+python -m claude_prospector dashboard --output "%USERPROFILE%\.claude\claude-prospector\dashboard.html" --no-open
 ```
 
 The CLI prints `Dashboard written to <path>` to stdout on success. Echo that line back to the user so they have the absolute path to open or read.
@@ -49,8 +49,8 @@ The user may pass any of these. Forward them through to the underlying CLI; do n
 
 | Argument | Behavior |
 | --- | --- |
-| `--window 5h` | 5-hour rolling window — useful for "how am I doing right now in this session". |
-| `--window 7d` | 7-day rolling window (default). |
+| `--window 5h` | 5-hour rolling window — scopes the dashboard to the last 5 hours. |
+| `--window 7d` | 7-day rolling window — scopes the dashboard to the last 7 days. |
 | `--window 30d` | 30-day rolling window — useful for monthly trend context. Larger windows are slower; flag that if `--window` exceeds 30d. |
 | `--from YYYY-MM-DD --to YYYY-MM-DD` | Explicit date range. Mutually exclusive with `--window`. If both are supplied, surface the conflict and ask which one to use. |
 | Any other CLI flag (`--limit-5h`, `--limit-7d`, `--limit-sonnet-7d`, `--format json`, `--data-dir`, etc.) | Forward verbatim. See `python -m claude_prospector dashboard --help` for the full surface. |

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
+
+import pytest
+
+from claude_prospector.cli.dashboard import build_parser
 
 
 def _run(*args: str) -> subprocess.CompletedProcess[str]:
@@ -45,3 +50,40 @@ def test_old_flag_only_form_exits_nonzero() -> None:
     """
     result = _run("--format", "json")
     assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #188 — dashboard subcommand must NOT default --window to 7d
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_no_window_flag_yields_none() -> None:
+    """Invoking 'dashboard' with no --window flag must parse window as None.
+
+    Previously the dashboard subcommand defaulted to 7d, causing the
+    aggregator to drop prior-period data needed for week-over-week
+    comparison panes (issue #188). The default must be None (no filter).
+    """
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers()
+    build_parser(sub)
+    args = top.parse_args(["dashboard"])
+    assert args.window is None, (
+        f"Expected args.window to be None when --window is omitted, "
+        f"got {args.window!r}. "
+        f"The dashboard subcommand must not default --window to any value "
+        f"(issue #188)."
+    )
+
+
+def test_dashboard_explicit_window_flag_still_works() -> None:
+    """Passing '--window 7d' must still set args.window (opt-in preserved)."""
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers()
+    build_parser(sub)
+    args = top.parse_args(["dashboard", "--window", "7d"])
+    # 7d = 168 hours
+    assert args.window == pytest.approx(168.0), (
+        f"Expected args.window == 168.0 when --window 7d is passed, "
+        f"got {args.window!r}."
+    )

--- a/tests/test_dashboard_regen_no_window.py
+++ b/tests/test_dashboard_regen_no_window.py
@@ -198,9 +198,9 @@ class TestRegenSubprocessNoWindow:
         )
 
         result = _run_hook(env)
-        assert result.returncode == 0, (
-            f"Hook exited non-zero. stderr: {result.stderr!r}"
-        )
+        assert (
+            result.returncode == 0
+        ), f"Hook exited non-zero. stderr: {result.stderr!r}"
         assert argv_file.exists(), (
             f"Spy argv file was not written — hook may not have reached "
             f"the regen step. hook returncode={result.returncode}, "
@@ -249,9 +249,9 @@ class TestRegenSubprocessNoWindow:
 
         _run_hook(env)
 
-        assert argv_file.exists(), (
-            "Spy argv file not written — hook did not reach the regen step."
-        )
+        assert (
+            argv_file.exists()
+        ), "Spy argv file not written — hook did not reach the regen step."
 
         all_calls = [
             json.loads(line)
@@ -264,9 +264,9 @@ class TestRegenSubprocessNoWindow:
             f"got {len(regen_calls)} from {all_calls!r}"
         )
         regen_argv = regen_calls[0]
-        assert "--output" in regen_argv, (
-            f"Regen command must still contain '--output'; got: {regen_argv!r}"
-        )
-        assert "--no-open" in regen_argv, (
-            f"Regen command must still contain '--no-open'; got: {regen_argv!r}"
-        )
+        assert (
+            "--output" in regen_argv
+        ), f"Regen command must still contain '--output'; got: {regen_argv!r}"
+        assert (
+            "--no-open" in regen_argv
+        ), f"Regen command must still contain '--no-open'; got: {regen_argv!r}"

--- a/tests/test_dashboard_regen_no_window.py
+++ b/tests/test_dashboard_regen_no_window.py
@@ -1,0 +1,272 @@
+"""Regression test for issue #188 — dashboard-regen hook must not pass --window.
+
+The hook previously passed ``--window 7d`` to the dashboard subcommand,
+causing the aggregator to drop prior-period data needed by the Economy v1
+week-over-week comparison panes.  After the fix the regen subprocess must
+be invoked without any ``--window`` argument.
+
+Strategy: we inject a fake ``claude_prospector`` module via ``PYTHONPATH``
+that records its argv to a JSON file and exits 0.  Then we run the hook as
+a subprocess, let it fire the regen step, and inspect the recorded argv for
+the absence of ``--window``.  This exercises the full hook subprocess path
+without depending on the real dashboard command.
+
+The ``valid_setup_state`` fixture is reused here so the version-check step
+passes and the hook reaches the regen step rather than short-circuiting on
+a version mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_WORKTREE = Path(__file__).parent.parent
+_HOOK_PATH = _WORKTREE / "hooks" / "dashboard-regen.py"
+
+# Ensure the hook's lib/ directory is importable (same as other hook tests).
+sys.path.insert(0, str(_WORKTREE / "hooks" / "lib"))
+import setup_state as _setup_state  # noqa: E402
+
+_MANIFEST_VERSION = _setup_state.get_current_version()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_env(
+    tmp_path: Path,
+    *,
+    manifest_version: str = _MANIFEST_VERSION,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build environment dict for a hook invocation with autoregen=true.
+
+    Sets up all required env vars so the hook reaches the regen step.
+
+    Args:
+        tmp_path: pytest per-test temporary directory.
+        manifest_version: Version string to embed in the plugin manifest.
+        extra: Extra vars to merge (last wins).
+
+    Returns:
+        Environment dict with all CLAUDE_PROSPECTOR_* vars set.
+    """
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"autoregen": True}), encoding="utf-8")
+
+    dashboard_file = tmp_path / "dashboard.html"
+    hook_log = tmp_path / "hook.log"
+
+    plugin_root = tmp_path / "plugin-root"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    (plugin_root / "plugin.json").write_text(
+        json.dumps({"version": manifest_version}), encoding="utf-8"
+    )
+    claude_plugin_dir = plugin_root / ".claude-plugin"
+    claude_plugin_dir.mkdir(parents=True, exist_ok=True)
+    (claude_plugin_dir / "plugin.json").write_text(
+        json.dumps({"version": _MANIFEST_VERSION}), encoding="utf-8"
+    )
+
+    env = {
+        **os.environ,
+        "CLAUDE_PROSPECTOR_CONFIG": str(cfg_path),
+        "CLAUDE_PROSPECTOR_DASHBOARD": str(dashboard_file),
+        "CLAUDE_PROSPECTOR_HOOK_LOG": str(hook_log),
+        "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+    }
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _write_spy_module(spy_dir: Path, argv_file: Path) -> None:
+    """Write a fake ``claude_prospector`` package that records its argv.
+
+    The hook calls ``[python, "-m", "claude_prospector", "dashboard", ...]``
+    for the regen step and ``[python, "-m", "claude_prospector", "--version"]``
+    for the version-check step.  This fake package's ``__main__.py`` appends
+    each invocation's ``sys.argv`` to *argv_file* as a JSON lines file, so we
+    can inspect all calls the hook made.
+
+    Args:
+        spy_dir: Directory to create the fake package inside.
+        argv_file: Path where recorded argv lists will be appended as JSONL.
+    """
+    pkg_dir = spy_dir / "claude_prospector"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+
+    # __init__.py — empty, just makes it a package.
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    # __main__.py — appends sys.argv as a JSON line, then responds to the
+    # hook's version-check (--version) with the current package version so
+    # the version gate passes, and exits 0 for all other invocations.
+    main_code = textwrap.dedent(f"""\
+        import json
+        import sys
+        from pathlib import Path
+
+        argv_file = Path({str(argv_file)!r})
+        # Append this invocation's argv as a JSON line.
+        with argv_file.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(sys.argv) + "\\n")
+
+        # Satisfy the hook's --version check.
+        if "--version" in sys.argv:
+            import importlib.metadata
+            try:
+                ver = importlib.metadata.version("claude-prospector")
+            except Exception:
+                ver = "0.0.0"
+            sys.stdout.write(f"claude-prospector {{ver}}\\n")
+
+        sys.exit(0)
+    """)
+    (pkg_dir / "__main__.py").write_text(main_code, encoding="utf-8")
+
+
+def _run_hook(
+    env: dict[str, str],
+    stdin_payload: dict | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the dashboard-regen hook as a subprocess.
+
+    Args:
+        env: Environment dict (from _make_env).
+        stdin_payload: JSON payload to write to stdin. Defaults to ``{}``.
+
+    Returns:
+        CompletedProcess with stdout, stderr, returncode.
+    """
+    payload = json.dumps(stdin_payload or {})
+    cmd = [sys.executable, str(_HOOK_PATH)]
+    return subprocess.run(
+        cmd,
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(_WORKTREE),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #188 regression: regen subprocess must not include --window
+# ---------------------------------------------------------------------------
+
+
+class TestRegenSubprocessNoWindow:
+    """The dashboard-regen hook must not pass --window to the dashboard cmd.
+
+    Regression for issue #188: the hook previously hardcoded ``--window 7d``
+    in the subprocess call, causing the aggregator to drop the prior-period
+    data required by Economy v1 week-over-week comparison panes.
+    """
+
+    def test_regen_command_does_not_contain_window_flag(
+        self,
+        tmp_path: Path,
+        valid_setup_state: Path,
+    ) -> None:
+        """The subprocess regen call must not include '--window' in its argv.
+
+        This is the primary regression test for issue #188.  We inject a
+        spy ``claude_prospector`` package via PYTHONPATH so the hook's
+        version-check and regen calls both succeed without the real package,
+        and the regen argv is captured to a JSON file for inspection.
+        """
+        argv_file = tmp_path / "regen_argv.json"
+        spy_dir = tmp_path / "spy"
+        _write_spy_module(spy_dir, argv_file)
+
+        env = _make_env(tmp_path)
+        # Prepend spy_dir to PYTHONPATH so Python finds our fake package
+        # ahead of the real claude_prospector.
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            str(spy_dir) + os.pathsep + existing_pythonpath
+            if existing_pythonpath
+            else str(spy_dir)
+        )
+
+        result = _run_hook(env)
+        assert result.returncode == 0, (
+            f"Hook exited non-zero. stderr: {result.stderr!r}"
+        )
+        assert argv_file.exists(), (
+            f"Spy argv file was not written — hook may not have reached "
+            f"the regen step. hook returncode={result.returncode}, "
+            f"stderr={result.stderr!r}"
+        )
+
+        all_calls = [
+            json.loads(line)
+            for line in argv_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        # Find the dashboard regen call (argv contains "dashboard").
+        regen_calls = [a for a in all_calls if "dashboard" in a]
+        assert len(regen_calls) == 1, (
+            f"Expected exactly one dashboard regen call; "
+            f"got {len(regen_calls)} from {all_calls!r}"
+        )
+        regen_argv = regen_calls[0]
+        assert "--window" not in regen_argv, (
+            f"The dashboard-regen hook must not pass '--window' to the "
+            f"dashboard subcommand (issue #188). "
+            f"Captured regen argv: {regen_argv!r}"
+        )
+
+    def test_regen_command_contains_output_and_no_open(
+        self,
+        tmp_path: Path,
+        valid_setup_state: Path,
+    ) -> None:
+        """Regen command must still contain --output and --no-open after fix.
+
+        Sanity-check that removing --window did not accidentally remove
+        other required arguments from the hook's subprocess call.
+        """
+        argv_file = tmp_path / "regen_argv.json"
+        spy_dir = tmp_path / "spy"
+        _write_spy_module(spy_dir, argv_file)
+
+        env = _make_env(tmp_path)
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            str(spy_dir) + os.pathsep + existing_pythonpath
+            if existing_pythonpath
+            else str(spy_dir)
+        )
+
+        _run_hook(env)
+
+        assert argv_file.exists(), (
+            "Spy argv file not written — hook did not reach the regen step."
+        )
+
+        all_calls = [
+            json.loads(line)
+            for line in argv_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        regen_calls = [a for a in all_calls if "dashboard" in a]
+        assert len(regen_calls) == 1, (
+            f"Expected exactly one dashboard regen call; "
+            f"got {len(regen_calls)} from {all_calls!r}"
+        )
+        regen_argv = regen_calls[0]
+        assert "--output" in regen_argv, (
+            f"Regen command must still contain '--output'; got: {regen_argv!r}"
+        )
+        assert "--no-open" in regen_argv, (
+            f"Regen command must still contain '--no-open'; got: {regen_argv!r}"
+        )


### PR DESCRIPTION
## Summary

The `dashboard` subcommand's auto-regen hook (`hooks/dashboard-regen.py`) and the plugin's `usage-dashboard` skill were hardcoding `--window 7d` in their default invocations. The aggregator filters `--window` at ingest time, so prior-period data was being dropped before the Economy v1 dashboard's week-over-week comparison panes (recent movers, burn-rate trendlines, "Why did total tokens change?" decomposition) could compute their deltas.

The CLI's argparse default was already `None` (a new test asserts this) — only the two callers needed fixing. `--window` remains fully functional as an explicit opt-in flag; only the implicit-default behavior changes.

## Changes

| File | Change |
|---|---|
| `hooks/dashboard-regen.py` | Removed `"--window", "7d"` from the regen subprocess argv; updated the failure-page "run manually" snippet to match |
| `skills/usage-dashboard/SKILL.md` | Default invocation now runs without `--window`; argument-table annotation updated (no more "(default)" on the `--window 7d` row) |
| `skills/usage-analysis/SKILL.md` | No change — its `--window 7d` mentions are intentional scoped-billing-bucket analysis examples, not regen defaults |
| `tests/test_dashboard_regen_no_window.py` (new) | Spy-based regression test: runs the hook as a subprocess, asserts `--window` is absent from the captured regen argv while `--output` + `--no-open` are still present |
| `tests/test_cli_subcommands.py` | Two new argparse-level tests: `args.window is None` when `--window` is omitted; `--window 7d` still parses to 168.0 hours |
| `CHANGELOG.md` | `[Unreleased] → Fixed` entry for #188 |

## Verification

```
ruff check src/ tests/                  →  All checks passed!
uv run pytest (full suite)              →  441 passed, 2 skipped, 1 warning  (87.82s)
```

Test-count delta: **+4** vs the v0.9.0 baseline (437 passed → 441 passed). Same 2 skips as baseline. No pre-existing tests changed behavior.

## Closes

Closes #188

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_