### PR TITLE
chore(release): v0.9.1 — fix --window default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-26
+
 ### Fixed
 
 - **Dashboard `--window` no longer filters out prior-period data needed for week-over-week comparison panes** (#188). The `dashboard` subcommand previously defaulted to `--window 7d`, which made the Economy v1 dashboard's recent-movers / burn-rate-trendline / "Why did total tokens change?" panes effectively unusable because the aggregator pre-dropped everything older than 7 days. Default is now "no window filter; aggregate the full session history". `--window` remains accepted as an explicit opt-in flag for users who want a scoped dashboard.
+
+[0.9.1]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.9.1
 
 ## [0.9.0] - 2026-05-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.9.0"
+version = "0.9.1"
 description = "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill."
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "claude-prospector"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Patch release shipping the single fix from PR #189 (issue #188): the `dashboard` subcommand no longer pre-filters with `--window 7d`, so the Economy v1 week-over-week comparison panes work.

## Version bump

| File | From | To |
|---|---|---|
| `pyproject.toml` | `0.9.0` | `0.9.1` |
| `.claude-plugin/plugin.json` | `0.9.0` | `0.9.1` |
| `uv.lock` (claude-prospector entry) | `0.9.0` | `0.9.1` |
| `CHANGELOG.md` | `[Unreleased]` `Fixed` entry | promoted to `[0.9.1] - 2026-05-26` |

## Pre-flight verification (local)

| Check | Result |
|---|---|
| `uv run ruff check src/ tests/` | clean |
| `uv run ruff format --check .` | 54 files already formatted |
| `uv run pytest` | **441 passed, 2 skipped** (1 warning, pre-existing) |
| `uv build --wheel` | `claude_prospector-0.9.1-py3-none-any.whl` built |
| Wheel — view renderers + vendor + template | all present |

CI gates remaining: Lint, Test Ubuntu/Windows, Skill Smoke Ubuntu/Windows.

## Release runbook position

Patch class per `docs/release-process.md` (no README change, no cache wipe — `source.repo` unchanged). After merge:

3. Tag `v0.9.1` annotated on the merge SHA
4. Push tag → triggers `release.yml` (build + wheel-smoke + publish-pypi)
5. Wait for all three jobs green
6. `git rev-parse 'v0.9.1^{commit}'`
7. Marketplace bump PR on `glitchwerks/claude-plugins`
8. Merge marketplace PR
9. Verify live pin

## Test plan

- [ ] CI green on `release/0.9.1`
- [ ] Squash-merge to `main`
- [ ] Tag + release workflow run successfully
- [ ] PyPI 0.9.1 published
- [ ] Marketplace bump PR opens against `glitchwerks/claude-plugins`

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_