### PR TITLE
test(models): regression coverage for model-version token counting

### DIFF
--- a/src/claude_prospector/models.py
+++ b/src/claude_prospector/models.py
@@ -48,7 +48,20 @@ class MessageRecord:
 
     @property
     def model_short(self) -> str:
-        """Extract short model name: 'opus', 'sonnet', 'haiku', or full name."""
+        """Extract the model-tier name from the full model ID string.
+
+        Uses substring matching so the classification is version-agnostic:
+        ``claude-opus-4-7``, ``claude-opus-4-8``, ``claude-opus-5-0``, etc.
+        all return ``"opus"`` because ``"opus"`` appears in the model ID.
+        This avoids hardcoded version numbers and keeps working correctly
+        after a model-version bump (issue #196).
+
+        Returns:
+            ``"opus"``, ``"sonnet"``, or ``"haiku"`` when the tier name is
+            found as a substring of :attr:`model`.  Returns the full
+            :attr:`model` string when no known tier name is present (e.g. a
+            hypothetical future model ID that omits the tier name entirely).
+        """
         for name in ("opus", "sonnet", "haiku"):
             if name in self.model:
                 return name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,8 +157,26 @@ def _assistant_line(
     output_tokens: int,
     uuid: str,
     timestamp: str,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
 ) -> dict:
-    """Build a minimal assistant message dict for JSONL."""
+    """Build a minimal assistant message dict for JSONL.
+
+    Args:
+        session_id: The session identifier.
+        model: Full model ID string (e.g. ``"claude-opus-4-8"``).
+        input_tokens: Prompt token count.
+        output_tokens: Completion token count.
+        uuid: Message UUID.
+        timestamp: ISO 8601 timestamp string.
+        cache_read_input_tokens: Tokens served from the prompt cache.
+            Defaults to 0 so existing callers are unaffected.
+        cache_creation_input_tokens: Tokens written to the prompt cache.
+            Defaults to 0 so existing callers are unaffected.
+
+    Returns:
+        A dict shaped like a real Claude Code JSONL assistant entry.
+    """
     return {
         "type": "assistant",
         "timestamp": timestamp,
@@ -171,8 +189,8 @@ def _assistant_line(
             "usage": {
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
-                "cache_read_input_tokens": 0,
-                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": cache_read_input_tokens,
+                "cache_creation_input_tokens": cache_creation_input_tokens,
             },
         },
     }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -531,9 +531,7 @@ class TestNewModelVersionTokenCounting:
         )
         return tmp_path
 
-    def test_opus_4_8_tokens_counted_in_opus_bucket(
-        self, tmp_path: Path
-    ) -> None:
+    def test_opus_4_8_tokens_counted_in_opus_bucket(self, tmp_path: Path) -> None:
         """claude-opus-4-8 messages must aggregate into by_model["opus"].
 
         The ``model_short`` property uses substring matching so any model
@@ -562,9 +560,7 @@ class TestNewModelVersionTokenCounting:
             f"got {result.by_model['opus']['total_tokens']}"
         )
 
-    def test_opus_4_8_cache_tokens_included_in_total(
-        self, tmp_path: Path
-    ) -> None:
+    def test_opus_4_8_cache_tokens_included_in_total(self, tmp_path: Path) -> None:
         """Cache tokens from claude-opus-4-8 must reach the tier totals.
 
         Real 4-8 Opus sessions use prompt caching heavily (>96% of tokens
@@ -617,18 +613,16 @@ class TestNewModelVersionTokenCounting:
         # include cache tokens so computeBuckets gets accurate session totals.
         assert len(result.sessions) == 1
         model_split = result.sessions[0]["model_split"]
-        assert "opus" in model_split, (
-            "model_split must contain 'opus' key for claude-opus-4-8 sessions."
-        )
+        assert (
+            "opus" in model_split
+        ), "model_split must contain 'opus' key for claude-opus-4-8 sessions."
         assert model_split["opus"] == expected_total, (
             f"model_split['opus'] must equal {expected_total:,} "
             f"(input + output + cache_read + cache_creation), "
             f"got {model_split.get('opus', 0):,}."
         )
 
-    def test_sonnet_4_8_tokens_counted_in_sonnet_bucket(
-        self, tmp_path: Path
-    ) -> None:
+    def test_sonnet_4_8_tokens_counted_in_sonnet_bucket(self, tmp_path: Path) -> None:
         """claude-sonnet-4-8 messages must aggregate into by_model["sonnet"].
 
         The ``sonnet7d`` budget bucket in the JS reads ``s.model_split.sonnet``.
@@ -665,9 +659,9 @@ class TestNewModelVersionTokenCounting:
 
         assert len(result.sessions) == 1
         model_split = result.sessions[0]["model_split"]
-        assert "sonnet" in model_split, (
-            "model_split must contain 'sonnet' key for claude-sonnet-4-8 sessions."
-        )
+        assert (
+            "sonnet" in model_split
+        ), "model_split must contain 'sonnet' key for claude-sonnet-4-8 sessions."
 
     def test_future_version_suffix_does_not_break_tier_classification(
         self, tmp_path: Path
@@ -745,9 +739,9 @@ class TestNewModelVersionTokenCounting:
                 "Expected 'window.DATA = ' or 'const DATA = '."
             )
 
-        assert len(data["sessions"]) == 1, (
-            f"Expected 1 session in DATA, got {len(data['sessions'])}."
-        )
+        assert (
+            len(data["sessions"]) == 1
+        ), f"Expected 1 session in DATA, got {len(data['sessions'])}."
         session_total = data["sessions"][0]["total_tokens"]
         assert session_total == expected_total, (
             f"DATA.sessions[0].total_tokens must be {expected_total:,} "

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,6 +7,12 @@ from claude_prospector.aggregator import AggregateResult, aggregate
 from claude_prospector.parser import parse_sessions
 from claude_prospector.renderer import render
 
+# Helpers imported from conftest via pytest fixture injection; the
+# _assistant_line and _write_jsonl helpers are module-level functions
+# in conftest.py and not auto-imported — import them directly here
+# when used outside a fixture.
+from tests.conftest import _assistant_line, _write_jsonl
+
 
 class TestEndToEnd:
     def test_full_pipeline(self, sample_session_dir: Path, tmp_path: Path):
@@ -450,4 +456,314 @@ class TestChartLabelSkip:
         assert has_old_pattern or has_new_pattern, (
             "Rendered HTML must handle many-category display: either via "
             "parentElement.style.height (old) or an overflow-y scroll container (new)."
+        )
+
+
+class TestNewModelVersionTokenCounting:
+    """Regression guard for issue #196: new model-version IDs must be counted.
+
+    After a model bump from ``claude-*-4-7`` to ``claude-*-4-8`` the dashboard
+    showed drastically lower totals.  Root cause: no end-to-end test verified
+    that sessions with the new version suffix AND non-zero cache tokens are
+    correctly parsed and aggregated into the correct tier bucket.
+
+    The fix is:
+    1. ``_assistant_line`` now accepts ``cache_read_input_tokens`` and
+       ``cache_creation_input_tokens`` so fixtures can exercise the full
+       token-type breakdown.
+    2. These tests assert that ``claude-opus-4-8`` (and any future version
+       suffix) is classified as ``"opus"`` in ``by_model`` AND that its
+       cache tokens appear in the per-tier totals — not just
+       ``input + output``.
+
+    The approach is deliberately version-agnostic: no model-specific logic is
+    added; the existing substring-based ``model_short`` property handles all
+    ``opus/sonnet/haiku``-named models regardless of version number, and
+    these tests ensure that property (and the downstream aggregation) are
+    exercised for a ``4-8`` version ID with realistic usage data.
+    """
+
+    def _build_model_version_dir(
+        self,
+        tmp_path: Path,
+        model: str,
+        input_tokens: int = 100,
+        output_tokens: int = 50,
+        cache_read: int = 0,
+        cache_creation: int = 0,
+    ) -> Path:
+        """Create a single-session JSONL fixture for the given model string.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+            model: Full model ID (e.g. ``"claude-opus-4-8"``).
+            input_tokens: Input token count for the assistant message.
+            output_tokens: Output token count.
+            cache_read: ``cache_read_input_tokens`` value.
+            cache_creation: ``cache_creation_input_tokens`` value.
+
+        Returns:
+            The root ``tmp_path`` suitable for ``parse_sessions``.
+        """
+        project_dir = tmp_path / "projects" / "C--Users-chris--myproject"
+        project_dir.mkdir(parents=True)
+        session_id = "sess-model-ver"
+
+        _write_jsonl(
+            project_dir / f"{session_id}.jsonl",
+            [
+                {
+                    "type": "agent-setting",
+                    "agentSetting": "general-purpose",
+                    "sessionId": session_id,
+                },
+                _assistant_line(
+                    session_id=session_id,
+                    model=model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    uuid="mv-msg-1",
+                    timestamp="2026-05-29T12:00:00.000Z",
+                    cache_read_input_tokens=cache_read,
+                    cache_creation_input_tokens=cache_creation,
+                ),
+            ],
+        )
+        return tmp_path
+
+    def test_opus_4_8_tokens_counted_in_opus_bucket(
+        self, tmp_path: Path
+    ) -> None:
+        """claude-opus-4-8 messages must aggregate into by_model["opus"].
+
+        The ``model_short`` property uses substring matching so any model
+        containing ``"opus"`` maps to the ``"opus"`` tier regardless of
+        version.  This test pins that behaviour for the ``4-8`` version
+        suffix so a future regression (e.g. a switch to a model name that
+        no longer contains the tier string) fails loudly here.
+        """
+        data_dir = self._build_model_version_dir(
+            tmp_path,
+            model="claude-opus-4-8",
+            input_tokens=200,
+            output_tokens=100,
+        )
+        sessions = parse_sessions(data_dir)
+        result = aggregate(sessions)
+
+        assert "opus" in result.by_model, (
+            "claude-opus-4-8 must be classified as 'opus' in by_model. "
+            "If this key is absent the model version is being treated as "
+            "an unknown tier, causing its tokens to be invisible to "
+            "tier-keyed budget buckets."
+        )
+        assert result.by_model["opus"]["total_tokens"] == 300, (
+            f"claude-opus-4-8: expected 300 total tokens (200 input + 100 output), "
+            f"got {result.by_model['opus']['total_tokens']}"
+        )
+
+    def test_opus_4_8_cache_tokens_included_in_total(
+        self, tmp_path: Path
+    ) -> None:
+        """Cache tokens from claude-opus-4-8 must reach the tier totals.
+
+        Real 4-8 Opus sessions use prompt caching heavily (>96% of tokens
+        are cache reads/writes).  If ``cache_read_input_tokens`` or
+        ``cache_creation_input_tokens`` are silently dropped the dashboard
+        will show ~4 M instead of the expected hundreds of millions.
+
+        This test exercises the full parse→aggregate pipeline with nonzero
+        cache token values to assert they are:
+        1. Included in ``result.total_tokens``.
+        2. Surfaced in ``by_model["opus"]["cache_read_tokens"]`` and
+           ``by_model["opus"]["cache_creation_tokens"]``.
+        3. Included in the per-session ``model_split["opus"]`` total.
+        """
+        cache_read = 500_000
+        cache_creation = 200_000
+        input_t = 100
+        output_t = 50
+        expected_total = input_t + output_t + cache_read + cache_creation  # 700_150
+
+        data_dir = self._build_model_version_dir(
+            tmp_path,
+            model="claude-opus-4-8",
+            input_tokens=input_t,
+            output_tokens=output_t,
+            cache_read=cache_read,
+            cache_creation=cache_creation,
+        )
+        sessions = parse_sessions(data_dir)
+        result = aggregate(sessions)
+
+        assert result.total_tokens == expected_total, (
+            f"Cache tokens must be included in total. "
+            f"Expected {expected_total:,}, got {result.total_tokens:,}. "
+            f"Difference of {expected_total - result.total_tokens:,} tokens is "
+            f"consistent with cache tokens being dropped (issue #196)."
+        )
+
+        opus = result.by_model.get("opus", {})
+        assert opus.get("cache_read_tokens") == cache_read, (
+            f"by_model['opus']['cache_read_tokens'] must be {cache_read:,}, "
+            f"got {opus.get('cache_read_tokens', 0):,}."
+        )
+        assert opus.get("cache_creation_tokens") == cache_creation, (
+            f"by_model['opus']['cache_creation_tokens'] must be {cache_creation:,}, "
+            f"got {opus.get('cache_creation_tokens', 0):,}."
+        )
+
+        # The per-session model_split used by the JS budget buckets must also
+        # include cache tokens so computeBuckets gets accurate session totals.
+        assert len(result.sessions) == 1
+        model_split = result.sessions[0]["model_split"]
+        assert "opus" in model_split, (
+            "model_split must contain 'opus' key for claude-opus-4-8 sessions."
+        )
+        assert model_split["opus"] == expected_total, (
+            f"model_split['opus'] must equal {expected_total:,} "
+            f"(input + output + cache_read + cache_creation), "
+            f"got {model_split.get('opus', 0):,}."
+        )
+
+    def test_sonnet_4_8_tokens_counted_in_sonnet_bucket(
+        self, tmp_path: Path
+    ) -> None:
+        """claude-sonnet-4-8 messages must aggregate into by_model["sonnet"].
+
+        The ``sonnet7d`` budget bucket in the JS reads ``s.model_split.sonnet``.
+        If a new Sonnet version is misclassified (e.g. because the model name
+        no longer contains ``"sonnet"``), the Sonnet budget will silently show
+        0 instead of the real consumption.
+        """
+        cache_read = 300_000
+        cache_creation = 50_000
+        input_t = 10
+        output_t = 90
+        expected_total = input_t + output_t + cache_read + cache_creation
+
+        data_dir = self._build_model_version_dir(
+            tmp_path,
+            model="claude-sonnet-4-8",
+            input_tokens=input_t,
+            output_tokens=output_t,
+            cache_read=cache_read,
+            cache_creation=cache_creation,
+        )
+        sessions = parse_sessions(data_dir)
+        result = aggregate(sessions)
+
+        assert "sonnet" in result.by_model, (
+            "claude-sonnet-4-8 must be classified as 'sonnet' in by_model. "
+            "If absent, the JS sonnet7d budget bucket will silently under-count."
+        )
+        assert result.by_model["sonnet"]["total_tokens"] == expected_total, (
+            f"claude-sonnet-4-8: expected {expected_total:,} total tokens "
+            f"(input + output + cache), "
+            f"got {result.by_model['sonnet']['total_tokens']:,}."
+        )
+
+        assert len(result.sessions) == 1
+        model_split = result.sessions[0]["model_split"]
+        assert "sonnet" in model_split, (
+            "model_split must contain 'sonnet' key for claude-sonnet-4-8 sessions."
+        )
+
+    def test_future_version_suffix_does_not_break_tier_classification(
+        self, tmp_path: Path
+    ) -> None:
+        """A hypothetical future version like claude-opus-4-9 maps to 'opus'.
+
+        This test does NOT hardcode version numbers — it uses a synthetic
+        version suffix to prove the classification is purely tier-name-based
+        (substring match) and will work for 4-9, 5-0, or any future suffix
+        as long as the tier name (opus/sonnet/haiku) remains in the model ID.
+        """
+        for version_suffix in ("4-8", "4-9", "5-0", "5-1"):
+            model = f"claude-opus-{version_suffix}"
+            inner_tmp = tmp_path / f"v{version_suffix.replace('-', '')}"
+            data_dir = self._build_model_version_dir(
+                inner_tmp,
+                model=model,
+                input_tokens=100,
+                output_tokens=50,
+                cache_read=10_000,
+                cache_creation=5_000,
+            )
+            sessions = parse_sessions(data_dir)
+            result = aggregate(sessions)
+
+            assert "opus" in result.by_model, (
+                f"{model} must map to 'opus' tier in by_model. "
+                f"Keys found: {sorted(result.by_model)}."
+            )
+            assert result.by_model["opus"]["total_tokens"] == 15_150, (
+                f"{model}: expected 15,150 total tokens, "
+                f"got {result.by_model['opus']['total_tokens']:,}."
+            )
+
+    def test_new_model_version_included_in_dashboard_total(
+        self, tmp_path: Path
+    ) -> None:
+        """Full parse→aggregate→render pipeline works for claude-opus-4-8.
+
+        Regression guard: the rendered dashboard must embed the session's
+        correct token total (including cache) in the DATA JSON blob so the
+        JS budget buckets receive accurate values.
+        """
+        cache_read = 800_000
+        cache_creation = 150_000
+        input_t = 50
+        output_t = 200
+        expected_total = input_t + output_t + cache_read + cache_creation
+
+        data_dir = self._build_model_version_dir(
+            tmp_path,
+            model="claude-opus-4-8",
+            input_tokens=input_t,
+            output_tokens=output_t,
+            cache_read=cache_read,
+            cache_creation=cache_creation,
+        )
+        sessions = parse_sessions(data_dir)
+        result = aggregate(sessions)
+
+        output_path = tmp_path / "dashboard-4-8.html"
+        rendered = render(result, output_path=output_path, open_browser=False)
+        html = rendered.read_text(encoding="utf-8")
+
+        # Extract the DATA JSON blob from the rendered HTML.
+        for marker in ("window.DATA = ", "const DATA = "):
+            if marker in html:
+                start = html.index(marker) + len(marker)
+                end = html.index(";\n", start)
+                data = json.loads(html[start:end])
+                break
+        else:
+            raise AssertionError(
+                "DATA blob not found in rendered HTML. "
+                "Expected 'window.DATA = ' or 'const DATA = '."
+            )
+
+        assert len(data["sessions"]) == 1, (
+            f"Expected 1 session in DATA, got {len(data['sessions'])}."
+        )
+        session_total = data["sessions"][0]["total_tokens"]
+        assert session_total == expected_total, (
+            f"DATA.sessions[0].total_tokens must be {expected_total:,} "
+            f"(includes cache tokens for claude-opus-4-8). "
+            f"Got {session_total:,}. "
+            f"If this is only input+output ({input_t + output_t:,}), "
+            f"cache tokens are being silently dropped (issue #196)."
+        )
+
+        model_split = data["sessions"][0].get("model_split", {})
+        assert "opus" in model_split, (
+            "DATA.sessions[0].model_split must contain 'opus' key for "
+            "claude-opus-4-8. The JS budget buckets read model_split to "
+            "compute per-tier token totals."
+        )
+        assert model_split["opus"] == expected_total, (
+            f"DATA.sessions[0].model_split['opus'] must equal {expected_total:,}. "
+            f"Got {model_split.get('opus', 0):,}."
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -254,9 +254,7 @@ class TestAgentPath:
 
     def test_model_short_opus_4_8(self) -> None:
         """claude-opus-4-8 must classify as 'opus' (issue #196)."""
-        record = self._make(
-            agent_path=("general-purpose",), model="claude-opus-4-8"
-        )
+        record = self._make(agent_path=("general-purpose",), model="claude-opus-4-8")
         assert record.model_short == "opus", (
             "claude-opus-4-8 must map to 'opus' via substring match. "
             "If this fails, the model_short property no longer recognises "
@@ -265,9 +263,7 @@ class TestAgentPath:
 
     def test_model_short_sonnet_4_8(self) -> None:
         """claude-sonnet-4-8 must classify as 'sonnet' (issue #196)."""
-        record = self._make(
-            agent_path=("general-purpose",), model="claude-sonnet-4-8"
-        )
+        record = self._make(agent_path=("general-purpose",), model="claude-sonnet-4-8")
         assert record.model_short == "sonnet", (
             "claude-sonnet-4-8 must map to 'sonnet' via substring match. "
             "If this fails, the JS sonnet7d budget bucket will show 0 "
@@ -276,9 +272,7 @@ class TestAgentPath:
 
     def test_model_short_haiku_4_8(self) -> None:
         """claude-haiku-4-8 must classify as 'haiku' (issue #196)."""
-        record = self._make(
-            agent_path=("general-purpose",), model="claude-haiku-4-8"
-        )
+        record = self._make(agent_path=("general-purpose",), model="claude-haiku-4-8")
         assert record.model_short == "haiku"
 
     def test_model_short_opus_future_versions(self) -> None:
@@ -293,8 +287,7 @@ class TestAgentPath:
             model = f"claude-opus-{suffix}"
             record = self._make(agent_path=("general-purpose",), model=model)
             assert record.model_short == "opus", (
-                f"{model!r} must map to 'opus'. "
-                f"Got {record.model_short!r} instead."
+                f"{model!r} must map to 'opus'. " f"Got {record.model_short!r} instead."
             )
 
     def test_parallel_field_independence(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -245,6 +245,58 @@ class TestAgentPath:
         )
         assert record.model_short == "claude-future-model-9"
 
+    # ── Version-bump regression guards (issue #196) ───────────────────────
+    # The model_short property uses substring matching, not version-specific
+    # logic.  These tests pin the property's behaviour for the 4-8 version
+    # suffix (and a few hypothetical future ones) so any regression — e.g.
+    # Anthropic renaming a tier — causes an explicit failure here rather than
+    # a silent under-count in the dashboard.
+
+    def test_model_short_opus_4_8(self) -> None:
+        """claude-opus-4-8 must classify as 'opus' (issue #196)."""
+        record = self._make(
+            agent_path=("general-purpose",), model="claude-opus-4-8"
+        )
+        assert record.model_short == "opus", (
+            "claude-opus-4-8 must map to 'opus' via substring match. "
+            "If this fails, the model_short property no longer recognises "
+            "the 4-8 version suffix and tokens will be under-counted."
+        )
+
+    def test_model_short_sonnet_4_8(self) -> None:
+        """claude-sonnet-4-8 must classify as 'sonnet' (issue #196)."""
+        record = self._make(
+            agent_path=("general-purpose",), model="claude-sonnet-4-8"
+        )
+        assert record.model_short == "sonnet", (
+            "claude-sonnet-4-8 must map to 'sonnet' via substring match. "
+            "If this fails, the JS sonnet7d budget bucket will show 0 "
+            "instead of real Sonnet consumption."
+        )
+
+    def test_model_short_haiku_4_8(self) -> None:
+        """claude-haiku-4-8 must classify as 'haiku' (issue #196)."""
+        record = self._make(
+            agent_path=("general-purpose",), model="claude-haiku-4-8"
+        )
+        assert record.model_short == "haiku"
+
+    def test_model_short_opus_future_versions(self) -> None:
+        """Future Opus version suffixes (4-9, 5-0, etc.) remain classified as 'opus'.
+
+        The tier classification is purely substring-based, so any model ID
+        that contains 'opus' maps to 'opus' regardless of the version number.
+        This test documents that intent explicitly so a future renaming of
+        Opus to something without 'opus' in the ID would fail loudly here.
+        """
+        for suffix in ("4-8", "4-9", "5-0", "5-1"):
+            model = f"claude-opus-{suffix}"
+            record = self._make(agent_path=("general-purpose",), model=model)
+            assert record.model_short == "opus", (
+                f"{model!r} must map to 'opus'. "
+                f"Got {record.model_short!r} instead."
+            )
+
     def test_parallel_field_independence(self):
         """agent_type and agent_path are stored independently — neither derived.
 


### PR DESCRIPTION
## Summary

Adds regression coverage for token counting across Claude model-version bumps (e.g. `4-7` → `4-8` → future `4-9`/`5-0`). **No behavior change** — the only non-test edit is a docstring expansion on `model_short`.

## Background

Investigated under #196 after a `4-8`-day dashboard showed ~4M tokens. Root cause turned out to be **prompt-cache warm-up** on a fresh session, not a counting bug — the existing substring-based `model_short` and allowlist-free parser already handle new model IDs correctly. These tests lock that behavior in so a future regression (cache tokens dropped for an unrecognized model ID) would be caught immediately.

## Changes

- `tests/test_e2e.py` — `TestNewModelVersionTokenCounting` (5 tests): `4-8` opus/sonnet bucketing, cache-token inclusion in totals, future version-suffix tolerance, dashboard-total inclusion.
- `tests/test_models.py` — `model_short` cases for `4-8` and future suffixes.
- `tests/conftest.py` — `_assistant_line` fixture now accepts cache-token params (default 0, backward compatible) so cache handling is exercised end-to-end.
- `src/claude_prospector/models.py` — docstring only, documenting the version-agnostic substring approach.

The key guard is `test_opus_4_8_cache_tokens_included_in_total`: a fixture with 500K cache-read + 200K cache-creation tokens asserting the total includes them — it would fail with exactly the originally-reported symptom if cache tokens were ever dropped for a new model ID.

## Verification

- `uv run ruff check src/ tests/` → clean
- `uv run pytest` → 466 passed, 2 skipped (baseline 457 passed; +9 new)

Fixes #196

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_