### PR TITLE
fix(dashboard): create --output parent dir and default to plugin data location

### DIFF
--- a/skills/usage-dashboard/SKILL.md
+++ b/skills/usage-dashboard/SKILL.md
@@ -26,12 +26,15 @@ For interpretation (budget status, top consumers, recommendations), point the us
 
 ## Default behavior
 
-If the user passes no arguments, regenerate against the **full aggregated session history** and write the dashboard to the platform-appropriate path:
+If the user passes no arguments, regenerate against the **full aggregated session history** and write the dashboard to a known path. Pass `--no-open` so the file lands at the known path without spawning a browser tab — that side effect is usually unwanted from inside a Claude Code session.
 
-- POSIX: `$HOME/.claude/claude-prospector/dashboard.html`
-- Windows: `%USERPROFILE%\.claude\claude-prospector\dashboard.html`
+When `$CLAUDE_PLUGIN_DATA` is set (the normal plugin context), the CLI automatically defaults `--output` to `$CLAUDE_PLUGIN_DATA/dashboard.html` and creates the parent directory if needed — you can omit `--output` entirely:
 
-Pass `--no-open` so the file lands at the known path without spawning a browser tab — that side effect is usually unwanted from inside a Claude Code session.
+```bash
+python -m claude_prospector dashboard --no-open
+```
+
+When running outside the plugin context (`$CLAUDE_PLUGIN_DATA` is unset), pass `--output` explicitly to control where the file lands:
 
 ```bash
 # POSIX
@@ -55,7 +58,7 @@ The user may pass any of these. Forward them through to the underlying CLI; do n
 | `--from YYYY-MM-DD --to YYYY-MM-DD` | Explicit date range. Mutually exclusive with `--window`. If both are supplied, surface the conflict and ask which one to use. |
 | Any other CLI flag (`--limit-5h`, `--limit-7d`, `--limit-sonnet-7d`, `--format json`, `--data-dir`, etc.) | Forward verbatim. See `python -m claude_prospector dashboard --help` for the full surface. |
 
-Always include `--output <path>` and `--no-open` in the final command line, even when the user passed neither — they are quality-of-life defaults for the skill's invocation context.
+Always include `--no-open` in the final command line. When `$CLAUDE_PLUGIN_DATA` is set (the normal plugin context), omitting `--output` is fine — the CLI defaults to `$CLAUDE_PLUGIN_DATA/dashboard.html` automatically. Only pass `--output <path>` explicitly when the user requests a custom path or when running outside the plugin context.
 
 ## When the dashboard already exists
 

--- a/src/claude_prospector/cli/dashboard.py
+++ b/src/claude_prospector/cli/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -185,6 +186,17 @@ def run(args: argparse.Namespace) -> int:
             "limit_sonnet_7d": args.limit_sonnet_7d,
         }
 
+    # Resolve default --output path.  The argparse default is None so that
+    # render() can distinguish "caller omitted --output" (use temp file) from
+    # an explicit path.  When $CLAUDE_PLUGIN_DATA is set we resolve a
+    # persistent, plugin-owned location here in the handler; otherwise we
+    # leave output_path as None and let render() pick a temp file.
+    output_path: Path | None = args.output
+    if output_path is None:
+        plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA")
+        if plugin_data:
+            output_path = Path(plugin_data) / "dashboard.html"
+
     if args.output_format == "json":
         payload = {
             "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -204,7 +216,7 @@ def run(args: argparse.Namespace) -> int:
 
     output = render(
         result,
-        output_path=args.output,
+        output_path=output_path,
         open_browser=not args.no_open,
         limits=limits,
     )

--- a/src/claude_prospector/renderer.py
+++ b/src/claude_prospector/renderer.py
@@ -121,6 +121,7 @@ def render(
         tmp.close()
         output_path = Path(tmp.name)
     else:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(html, encoding="utf-8")
 
     if open_browser:

--- a/tests/test_cli_dashboard_default.py
+++ b/tests/test_cli_dashboard_default.py
@@ -1,0 +1,146 @@
+"""Tests for dashboard --output default-path resolution (issue #201).
+
+When ``$CLAUDE_PLUGIN_DATA`` is set, omitting ``--output`` must resolve to
+``$CLAUDE_PLUGIN_DATA/dashboard.html`` (a persistent, plugin-owned location).
+When the env var is unset, the CLI must fall back to the existing
+``render(output_path=None)`` temp-file path — preserving the contract that
+``render()`` interprets ``None`` as "write to a temp file".
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from claude_prospector.cli.dashboard import build_parser, run
+
+
+class TestDefaultOutputPathResolution:
+    """dashboard --output default resolves to plugin-data dir or temp file."""
+
+    def _make_args(
+        self,
+        tmp_path: Path,
+        output: Path | None = None,
+        data_dir: Path | None = None,
+    ) -> argparse.Namespace:
+        """Build a minimal Namespace for the dashboard ``run()`` handler.
+
+        Args:
+            tmp_path: Pytest temporary directory (used as ``--data-dir``
+                when ``data_dir`` is not provided).
+            output: Value for ``args.output``. ``None`` simulates omitting
+                ``--output`` (the argparse default).
+            data_dir: Override the ``--data-dir`` value.
+
+        Returns:
+            An ``argparse.Namespace`` suitable for passing to ``run()``.
+        """
+        return argparse.Namespace(
+            data_dir=data_dir if data_dir is not None else tmp_path,
+            from_date=None,
+            to_date=None,
+            window=None,
+            output=output,
+            no_open=True,
+            limit_5h=None,
+            limit_7d=None,
+            limit_sonnet_7d=None,
+            output_format="html",
+        )
+
+    def test_plugin_data_set_resolves_to_plugin_data_dashboard(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """With CLAUDE_PLUGIN_DATA set, omitting --output writes to plugin dir.
+
+        The output path must be ``$CLAUDE_PLUGIN_DATA/dashboard.html`` and
+        the file must be created (including its parent directory if needed).
+        """
+        plugin_data_dir = tmp_path / "plugin-data"
+        # Intentionally do NOT create the directory here — run() must create it
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_data_dir))
+
+        args = self._make_args(tmp_path)
+        # --output omitted → args.output is None
+        assert args.output is None
+
+        run(args)
+
+        expected = plugin_data_dir / "dashboard.html"
+        assert expected.exists(), (
+            f"With CLAUDE_PLUGIN_DATA={plugin_data_dir}, omitting --output "
+            f"must write the dashboard to {expected}. "
+            f"File was not found — default-path resolution or mkdir is broken."
+        )
+
+    def test_plugin_data_unset_falls_back_to_temp_file(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """With CLAUDE_PLUGIN_DATA unset, omitting --output writes a temp file.
+
+        The temp-file fallback must produce a file on disk (the existing
+        render(output_path=None) contract). The test asserts the command
+        exits without error and does NOT write to a plugin-data path, since
+        that env var is absent.
+        """
+        monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+
+        args = self._make_args(tmp_path)
+        assert args.output is None
+
+        # run() returns 0 on success; any exception here is a failure.
+        exit_code = run(args)
+        assert exit_code == 0, (
+            "run() must succeed (return 0) when CLAUDE_PLUGIN_DATA is unset "
+            "and --output is omitted — temp-file fallback should be used."
+        )
+
+    def test_explicit_output_still_respected_with_plugin_data_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Passing --output explicitly overrides the CLAUDE_PLUGIN_DATA default.
+
+        When the user explicitly provides --output, the file must be written
+        to that path regardless of $CLAUDE_PLUGIN_DATA.
+        """
+        plugin_data_dir = tmp_path / "plugin-data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_data_dir))
+
+        explicit_output = tmp_path / "explicit" / "out.html"
+        args = self._make_args(tmp_path, output=explicit_output)
+
+        run(args)
+
+        assert explicit_output.exists(), (
+            "Explicit --output must be honoured even when " "CLAUDE_PLUGIN_DATA is set."
+        )
+        assert not (
+            plugin_data_dir / "dashboard.html"
+        ).exists(), "Plugin-data path must NOT be written when --output is explicit."
+
+    def test_plugin_data_default_parser_output_still_none(self) -> None:
+        """argparse default for --output remains None after the change.
+
+        The default-path resolution must happen in the command handler
+        (``run()``), NOT as the argparse ``default=`` value. This keeps the
+        ``render()`` contract intact: ``None`` still means "temp file" at
+        the ``render()`` call site; the handler resolves the plugin-data path
+        before calling ``render()``.
+        """
+        top = argparse.ArgumentParser()
+        sub = top.add_subparsers()
+        build_parser(sub)
+        args = top.parse_args(["dashboard"])
+        assert args.output is None, (
+            "argparse default for --output must remain None. "
+            "Default-path resolution belongs in run(), not the arg default."
+        )

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -303,3 +303,68 @@ def test_real_data_depth3_renders_correct_by_agent_values(
     assert entry["session_count"] == 1, (
         f"Depth-3 leaf session_count must be 1. " f"Got: {entry['session_count']!r}"
     )
+
+
+class TestRenderMkdirParent:
+    """render() must create the output path's parent directory automatically.
+
+    The documented default invocation writes to
+    ``~/.claude/claude-prospector/dashboard.html``. That directory is not
+    created by any other part of the package, so ``render()`` must call
+    ``output_path.parent.mkdir(parents=True, exist_ok=True)`` before the
+    write — otherwise a first-run ``FileNotFoundError`` breaks out-of-the-box
+    usage (issue #201).
+    """
+
+    def test_render_creates_missing_parent_directory(self, tmp_path: Path) -> None:
+        """render() succeeds when the output path's parent does not exist yet.
+
+        Uses a two-level nested path that pytest's ``tmp_path`` has NOT
+        created, so the test confirms the directory is created by ``render()``
+        rather than by the test harness.
+        """
+        nonexistent_parent = tmp_path / "subdir" / "nested"
+        output_path = nonexistent_parent / "dashboard.html"
+        assert (
+            not nonexistent_parent.exists()
+        ), "Pre-condition: parent directory must not exist before render()."
+
+        result = AggregateResult()
+        rendered = render(result, output_path=output_path, open_browser=False)
+
+        assert (
+            nonexistent_parent.exists()
+        ), "render() must create the parent directory when it does not exist."
+        assert rendered.exists(), "HTML file must be written after parent creation."
+        assert rendered.read_text(
+            encoding="utf-8"
+        ).strip(), "Written HTML file must not be empty."
+
+    def test_render_existing_parent_still_works(self, tmp_path: Path) -> None:
+        """render() must not raise when the parent directory already exists.
+
+        ``exist_ok=True`` is required — a second render to the same path
+        (e.g. dashboard regeneration) must not raise ``FileExistsError``.
+        """
+        output_path = tmp_path / "dashboard.html"
+        result = AggregateResult()
+        # First render — creates the file
+        render(result, output_path=output_path, open_browser=False)
+        # Second render — parent already exists; must not raise
+        rendered = render(result, output_path=output_path, open_browser=False)
+        assert rendered.exists()
+
+    def test_render_temp_file_branch_unchanged(self, tmp_path: Path) -> None:
+        """render() with output_path=None still uses a temp file (no regression).
+
+        The ``output_path is None`` branch writes to a NamedTemporaryFile and
+        must remain untouched by the mkdir fix.
+        """
+        result = AggregateResult()
+        rendered = render(result, output_path=None, open_browser=False)
+        assert (
+            rendered.exists()
+        ), "render(output_path=None) must still produce a temp file."
+        assert rendered.read_text(
+            encoding="utf-8"
+        ).strip(), "Temp-file HTML must not be empty."


### PR DESCRIPTION
## Summary

`dashboard --output <path>` raised `FileNotFoundError` when `<path>`'s parent dir didn't exist, because `render()` wrote the file without creating the parent first. The documented default (writing under `~/.claude/claude-prospector/`) failed out of the box since nothing owned that dir.

## Changes

1. **`renderer.py`** — `render()` now `output_path.parent.mkdir(parents=True, exist_ok=True)` before the explicit-path `write_text` (kept the explicit `encoding="utf-8"`). The `output_path is None → temp file` branch is untouched.
2. **`cli/dashboard.py`** — when `--output` is omitted, the command handler defaults to `$CLAUDE_PLUGIN_DATA/dashboard.html` (persistent, plugin-owned). When `CLAUDE_PLUGIN_DATA` is unset it leaves `output_path` as `None`, preserving `render()`'s temp-file fallback. The argparse `--output` default stays `None`, so `render()`'s `None→temp` contract is intact.
3. **`skills/usage-dashboard/SKILL.md`** — documented default aligned with the CLI: `--output` is optional inside the plugin context (where `$CLAUDE_PLUGIN_DATA` is set), only required outside it or for custom paths.

## Tests

- `tests/test_renderer.py::TestRenderMkdirParent` (3) — missing nested parent is created; re-render to same path doesn't raise (`exist_ok`); `output_path=None` still uses a temp file.
- `tests/test_cli_dashboard_default.py` (4, new) — env-var-set resolves to `$CLAUDE_PLUGIN_DATA/dashboard.html`; env-var-unset falls back to temp; explicit `--output` wins; argparse default remains `None`.

TDD: 3 RED before implementation → all 7 GREEN after.

## Verification (all CI gates, whole-repo `.` scope)

- `uv run ruff format --check .` → 59 files already formatted
- `uv run ruff check .` → All checks passed
- `uv run pytest` → 497 passed, 2 skipped (baseline 490 + 7 new, 0 regressions)

Closes #201

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_