### PR TITLE
fix(dashboard): show full-path tooltip on all project-name surfaces

### DIFF
--- a/src/claude_prospector/static/views/economics.js
+++ b/src/claude_prospector/static/views/economics.js
@@ -1008,11 +1008,13 @@
           else if (s._outlierTpm) flag = '<span class="flag">outlier · expensive/turn</span>';
           else if (s._isBench) flag = '<span class="flag bench">benchmark · cheap/turn</span>';
           const cls = s._outlierTpm ? 'outlier' : '';
+          const fp = s.project_path || '';
+          const ta = fp ? ` title="${fp.replace(/"/g, '&quot;')}"` : '';
           return `
             <div class="sess-row ${cls}">
               <div>
                 <div class="head">
-                  <div class="pn">${s.project}${flag}</div>
+                  <div class="pn"${ta}>${s.project}${flag}</div>
                   <div class="meta">${tStr} · ${CP.fmtDuration(s.duration_minutes)} · ${(s.agents || []).slice(0,3).join(', ')}${(s.agents||[]).length > 3 ? '…' : ''}</div>
                 </div>
               </div>

--- a/src/claude_prospector/static/views/layout-b-diag.js
+++ b/src/claude_prospector/static/views/layout-b-diag.js
@@ -516,7 +516,8 @@
       const pre = (p.byProject[name] && p.byProject[name].total_tokens) || 0;
       const authProj = window.DATA.by_project[name];
       const hasHistory = !!(authProj && authProj.total_tokens > cur);
-      return { name, cur, pre, delta: dlt(cur, pre, hasHistory) };
+      const full_path = (r.byProject[name] && r.byProject[name].full_path) || '';
+      return { name, cur, pre, delta: dlt(cur, pre, hasHistory), full_path };
     }).sort((a,b) => Math.abs(b.delta) - Math.abs(a.delta));
 
     const biggestUp = agents.filter(a => a.delta < 998 && a.delta > 0)
@@ -762,10 +763,12 @@
             const dt = new Date(s.start_time);
             const timeStr = dt.toLocaleString(undefined, { weekday:'short', month:'short', day:'numeric', hour:'numeric', minute:'2-digit' });
             const agents = (s.agents || []).map(a => `<span class="chip">${a}</span>`).join(' ');
+            const fp1 = s.project_path || '';
+            const ta1 = fp1 ? ` title="${fp1.replace(/"/g, '&quot;')}"` : '';
             return `
               <div class="row ${s._isOutlier ? 'outlier' : ''}">
                 <div>
-                  <div class="name">${s.project} ${s._isOutlier ? '<span class="outlier-flag">outlier</span>' : ''}</div>
+                  <div class="name"${ta1}>${s.project} ${s._isOutlier ? '<span class="outlier-flag">outlier</span>' : ''}</div>
                   <div class="meta">${timeStr} · ${CP.fmtDuration(s.duration_minutes)}</div>
                   <div class="agents">${agents}</div>
                 </div>
@@ -829,14 +832,17 @@
           <div class="movers-head">
             <div>Project</div><div class="r">7d</div><div class="r">prior 7d</div><div class="r">Δ</div>
           </div>
-          ${p.map(row => `
+          ${p.map(row => {
+            const fp3 = row.full_path || '';
+            const ta3 = fp3 ? ` title="${fp3.replace(/"/g, '&quot;')}"` : '';
+            return `
             <div class="movers-row">
-              <div class="nm proj">${row.name}</div>
+              <div class="nm proj"${ta3}>${row.name}</div>
               <div class="val">${CP.fmtTokens(row.cur)}</div>
               <div class="pre">${CP.fmtTokens(row.pre)}</div>
               ${dlt(row.delta)}
-            </div>
-          `).join('')}
+            </div>`;
+          }).join('')}
         </div>
       </div>`;
   }
@@ -1086,10 +1092,12 @@
             const parts = Object.entries(split).map(([m, t]) =>
               `<div style="width:${(t/splitTotal*100).toFixed(1)}%;background:${CP.modelColor(m)}"></div>`).join('');
             const agents = (s.agents || []).map(a => `<span class="chip">${a}</span>`).join(' ');
+            const fp2 = s.project_path || '';
+            const ta2 = fp2 ? ` title="${fp2.replace(/"/g, '&quot;')}"` : '';
             return `
               <div class="session-row">
                 <div class="time">${CP.fmtRelTime(s.start_time)}</div>
-                <div class="proj">${s.project}</div>
+                <div class="proj"${ta2}>${s.project}</div>
                 <div>${agents}</div>
                 <div class="tok">${CP.fmtTokens(s.total_tokens)}</div>
                 <div><div class="mini-bar">${parts}</div></div>


### PR DESCRIPTION
## Summary

Follow-up to #205. The full-path hover tooltip was only wired into the `byProject` card view ("Where your tokens went" tab); every other surface rendering a project name had no tooltip. This adds it consistently.

## Changes

- `static/views/layout-b-diag.js` — top-5 sessions / outlier list (`.name`): title from `s.project_path`.
- `static/views/layout-b-diag.js` — recent-sessions list (`.proj`): title from `s.project_path`.
- `static/views/layout-b-diag.js` — Movers → Projects rows (`.nm.proj`): threaded `full_path` from the `by_project` entry into the mover objects (`computeMovers`), then added the title.
- `static/views/economics.js` — session-economics card (`.pn`): title from `s.project_path`.

All sites reuse the existing `&quot;`-escaping pattern and omit the attribute when no path is available. `economics-basic.js` agent rows left untouched (they render agents, not projects).

## Verification (from the worktree root, Python 3.12 via `uv`)

- `uv run ruff format --check .` → clean
- `uv run ruff check src/ tests/` → clean
- `uv run pytest` → **529 passed, 2 skipped, 0 failed**
- Regenerated dashboard + grepped emitted HTML: `title=` now renders adjacent to the project-name elements at the movers and session-list sites, not just the `byProject` cards.

Closes #206

---
🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*