### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-prospector",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
   "author": {
     "name": "Christopher Beaulieu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-30
+
 ### Added
 
 - Added `audit` subcommand (`python -m claude_prospector audit`) that
   deterministically inventories agents/skills, detects name collisions,
   computes Jaccard semantic overlaps, detects tool-coupling mismatches,
   and flags cache hygiene issues (closes #191).
+- **cwd-first project names** in the dashboard: the leaf directory name
+  (e.g. `claude-prospector`) is derived from the `cwd` field recorded
+  in the session when available, falling back to the decoded directory
+  slug. Full decoded path is shown on hover. A `project_exclude_patterns`
+  list in `config.json` lets you hide noise directories (Electron
+  internals, Warp worktrees, etc.) from the project breakdown by
+  case-sensitive substring match against the session's full path
+  (#203, closes #205).
 
 ### Changed
 
@@ -25,12 +35,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   format that defers to the user's intent rather than prescribing
   changes (closes #193).
 
+### Fixed
+
+- **Today/daily activity bucketed by local timezone instead of UTC**
+  (#197, closes #199). The dashboard's "today" bucket and per-day
+  activity bars previously used UTC midnight as the day boundary,
+  causing sessions that ran after midnight UTC but before local midnight
+  to appear on the wrong day.
+- **Movers tab distinguishes "resumed" from "new" sessions** (#200,
+  closes #202). The recent-movers pane previously classified all
+  sessions that appeared in the current window as "new". Sessions that
+  were already present in the prior window are now marked "resumed" so
+  the pane reflects only genuinely new activity.
+- **`dashboard --output` creates parent directories and defaults to the
+  plugin data location** (#201, closes #204). Passing an `--output`
+  path whose parent directory did not yet exist previously raised an
+  error. Parent directories are now created automatically. When
+  `--output` is omitted, the dashboard is written to
+  `${CLAUDE_PLUGIN_DATA}/dashboard.html` rather than the current
+  working directory.
+- **Full-path hover tooltip extended to all project-name surfaces**
+  (#206, closes #207). The decoded-path tooltip introduced with
+  cwd-first project names was only wired to the byProject card; it now
+  appears on every surface that displays a project name (session
+  drill-down rows, Movers entries, etc.).
+
 ## [0.9.1] - 2026-05-26
 
 ### Fixed
 
 - **Dashboard `--window` no longer filters out prior-period data needed for week-over-week comparison panes** (#188). The `dashboard` subcommand previously defaulted to `--window 7d`, which made the Economy v1 dashboard's recent-movers / burn-rate-trendline / "Why did total tokens change?" panes effectively unusable because the aggregator pre-dropped everything older than 7 days. Default is now "no window filter; aggregate the full session history". `--window` remains accepted as an explicit opt-in flag for users who want a scoped dashboard.
 
+[0.10.0]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.10.0
 [0.9.1]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.9.1
 
 ## [0.9.0] - 2026-05-26

--- a/README.md
+++ b/README.md
@@ -266,6 +266,28 @@ python -m claude_prospector session-summary --path ~/.claude/projects/<hash>/<se
 
 On any non-zero exit, stdout is empty and stderr contains exactly one line.
 
+### `audit` — agent/skill inventory and hygiene report
+
+```bash
+python -m claude_prospector audit
+```
+
+Deterministically inventories all agents and skills visible in the effective
+Claude Code configuration (custom and plugin-provided), then reports:
+
+- **Name collisions** — agents or skills with identical names loaded from
+  different sources
+- **Jaccard semantic overlap** — pairs whose description tokens overlap above a
+  configurable threshold, signalling potential duplicate capability
+- **Tool-coupling mismatches** — agents declared without the tools they call,
+  or with tools they never reference
+- **Cache hygiene issues** — stale plugin cache entries that may shadow the
+  live install
+
+The subcommand is read-only — it never modifies files. Output is written to
+stdout; pipe to a file or redirect as needed. The `/claude-prospector:claude-audit`
+skill wraps this subcommand for conversational use inside Claude Code sessions.
+
 ### `config` — inspect configuration
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-prospector"
-version = "0.9.1"
+version = "0.10.0"
 description = "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill."
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## v0.10.0 — minor release

Bumps `pyproject.toml` and `.claude-plugin/plugin.json` to `0.10.0` and cuts the dated `CHANGELOG.md` section. Covers everything merged since v0.9.1.

### Added
- **`audit` subcommand** — deterministic agent/skill inventory, name-collision detection, Jaccard semantic overlap, tool-coupling mismatch, cache-hygiene flags (#191).
- **cwd-first project names** in the dashboard — readable leaf labels from the session `cwd` (decode fallback), full decoded path on hover, and a `project_exclude_patterns` config to hide noise dirs (#203/#205).

### Changed
- `usage-analysis` skill refocused on insights; drops content duplicated by `usage-dashboard` (#193).

### Fixed
- Today/daily activity bucketed by local timezone instead of UTC (#197).
- Movers tab distinguishes "resumed" from "new" sessions (#200).
- `dashboard --output` creates parent dirs and defaults to the plugin data location (#201).
- Full-path hover tooltip extended to all project-name surfaces, not just the byProject card (#206).

### Docs
- README gains an `audit` subcommand entry.

## Verification (local, `uv run`, Python 3.12)
- `uv run ruff format --check .` → clean
- `uv run ruff check src/ tests/` → clean
- `uv run pytest` → **529 passed, 2 skipped, 0 failed**
- `uv build --wheel` → `claude_prospector-0.10.0-py3-none-any.whl` builds with templates bundled

All referenced issues are already closed via their implementing PRs; no closing keywords needed here.

---
🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*