### PR TITLE
feat: deterministic session-audit extractor (1a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,72 @@ python -m claude_prospector session-summary --path ~/.claude/projects/<hash>/<se
 
 On any non-zero exit, stdout is empty and stderr contains exactly one line.
 
+### `session-audit` — ask-vs-action extraction at zero LLM cost
+
+```bash
+python -m claude_prospector session-audit --path <transcript.jsonl>
+```
+
+Reads a single Claude Code session transcript (`.jsonl`) and emits
+structured data capturing what was asked and what file edits were made,
+with **no API calls**.
+
+#### Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--path <file>` | *(required)* | Path to the transcript JSONL file |
+| `--format json\|text` | `json` | Output format |
+| `--batch` | off | *(not yet implemented)* Walk `~/.claude/projects/**/*.jsonl` and emit per-session array |
+
+#### JSON schema (`--format json`)
+
+```json
+{
+    "original_ask": "<string or null>",
+    "prior_asks":   ["<string>", "..."],
+    "actions":      [
+        {"tool": "<Edit|Write|NotebookEdit>", "file_path": "<string>"},
+        "..."
+    ]
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `original_ask` | `string \| null` | Verbatim text of the **first** non-system, non-tool-result external user message. `null` when absent. |
+| `prior_asks` | `string[]` | Verbatim text of each subsequent distinct user ask, in transcript order. Empty array for single-ask sessions. |
+| `actions` | `object[]` | Chronologically ordered `Edit`/`Write`/`NotebookEdit` tool_use events. Bash invocations excluded. |
+
+#### Example output
+
+```json
+{
+  "original_ask": "Add a --dry-run flag to the CLI.",
+  "prior_asks": [
+    "Now also write tests for it.",
+    "close the pr"
+  ],
+  "actions": [
+    {"tool": "Edit", "file_path": "src/claude_prospector/__main__.py"},
+    {"tool": "Write", "file_path": "tests/test_dry_run.py"}
+  ]
+}
+```
+
+#### Exit codes
+
+| Code | Meaning | stderr |
+|---|---|---|
+| `0` | Success — output written to stdout | *(silent)* |
+| `1` | IO failure reading `--path` (file missing, permission denied, etc.) | `session-audit: cannot read transcript at '<path>': <OSError class>: <message>` |
+| `2` | File readable but contains no external user turns | `session-audit: transcript '<path>' contains no user turns` |
+| `3` | File has content but none of it parses as JSONL | `session-audit: transcript '<path>' is not valid JSONL` |
+
+On any non-zero exit, stdout is empty and stderr contains exactly one line.
+
+---
+
 ### `audit` — agent/skill inventory and hygiene report
 
 ```bash

--- a/src/claude_prospector/__main__.py
+++ b/src/claude_prospector/__main__.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import sys
 
 import claude_prospector
-from claude_prospector.cli import audit, config, dashboard, session_summary
+from claude_prospector.cli import (
+    audit,
+    config,
+    dashboard,
+    session_audit,
+    session_summary,
+)
 
 
 def main() -> None:
@@ -31,6 +37,7 @@ def main() -> None:
 
     dashboard.build_parser(subparsers)
     session_summary.build_parser(subparsers)
+    session_audit.build_parser(subparsers)
     config.build_parser(subparsers)
     audit.build_parser(subparsers)
 
@@ -45,6 +52,9 @@ def main() -> None:
 
     if args.subcommand == "session-summary":
         sys.exit(session_summary.run(args))
+
+    if args.subcommand == "session-audit":
+        sys.exit(session_audit.run(args))
 
     if args.subcommand == "config":
         sys.exit(config.run(args))

--- a/src/claude_prospector/cli/session_audit.py
+++ b/src/claude_prospector/cli/session_audit.py
@@ -94,11 +94,11 @@ def _is_tool_result_entry(entry: dict) -> bool:
     # At least one block must be present, and every block with a
     # recognisable type must be "tool_result".
     tool_result_blocks = [
-        b for b in content
-        if isinstance(b, dict) and b.get("type") == "tool_result"
+        b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"
     ]
     other_typed_blocks = [
-        b for b in content
+        b
+        for b in content
         if isinstance(b, dict)
         and b.get("type") is not None
         and b.get("type") != "tool_result"
@@ -119,10 +119,7 @@ def _is_real_user_ask(entry: dict) -> bool:
     Returns:
         ``True`` for genuine user asks.
     """
-    if not (
-        entry.get("type") == "user"
-        and entry.get("userType") == "external"
-    ):
+    if not (entry.get("type") == "user" and entry.get("userType") == "external"):
         return False
     return not _is_tool_result_entry(entry)
 
@@ -391,8 +388,7 @@ def run(args: argparse.Namespace) -> int:
     skipped = non_blank_lines - len(entries)
     if skipped > 0:
         print(
-            f"session-audit: skipped {skipped} malformed line(s) in "
-            f"'{path}'",
+            f"session-audit: skipped {skipped} malformed line(s) in " f"'{path}'",
             file=sys.stderr,
         )
 

--- a/src/claude_prospector/cli/session_audit.py
+++ b/src/claude_prospector/cli/session_audit.py
@@ -1,0 +1,407 @@
+"""Session-audit subcommand: extract ask vs. action data from a transcript.
+
+Walks a Claude Code transcript JSONL once and emits structured JSON (or
+human-readable text) capturing what was asked and what file edits were
+made, at **zero LLM cost** — purely deterministic extraction.
+
+JSON schema (``--format json``, the default)::
+
+    {
+        "original_ask": "<string or null>",
+        "prior_asks":   ["<string>", ...],
+        "actions":      [
+            {"tool": "<Edit|Write|NotebookEdit>", "file_path": "<string>"},
+            ...
+        ]
+    }
+
+Fields:
+    original_ask:
+        Verbatim text of the first non-system, non-tool-result external
+        user message.  ``null`` when the transcript has no qualifying
+        user turn.
+    prior_asks:
+        Verbatim text of each *subsequent* distinct external user message,
+        in transcript order.  Empty array for single-ask sessions.
+    actions:
+        Chronologically ordered list of ``Edit``/``Write``/``NotebookEdit``
+        tool_use events, each with the target ``file_path`` and the
+        ``tool`` name.  Bash invocations are excluded (out of scope).
+
+Exit codes:
+    0  Success — output written to stdout.
+    1  IO failure — file missing, unreadable, or other OSError.
+    2  No user turns — transcript has no external user entries.
+    3  Not JSONL — file has non-blank content but every line fails
+       json.loads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Re-use the shared read_transcript and text-extraction helper so we
+# don't maintain a divergent copy of the same JSONL parsing logic.
+from claude_prospector.cli.session_summary import (
+    _EDIT_TOOLS,
+    _extract_text_from_content,
+    read_transcript,
+)
+
+EXIT_OK = 0
+EXIT_IO_FAILURE = 1
+EXIT_NO_USER_TURNS = 2
+EXIT_NOT_JSONL = 3
+
+# ---------------------------------------------------------------------------
+# Type alias for the audit result dict (avoids a heavy TypedDict dependency
+# while keeping the return type explicit in docstrings).
+# ---------------------------------------------------------------------------
+
+AuditResult = dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Core extraction — pure function, no I/O
+# ---------------------------------------------------------------------------
+
+
+def _is_tool_result_entry(entry: dict) -> bool:
+    """Return True when a user entry carries only tool_result content.
+
+    Tool-result entries are API artifacts that deliver tool output back
+    to the model.  They look like user turns but are NOT genuine user
+    asks and must be excluded from ``original_ask`` / ``prior_asks``.
+
+    A user entry is classified as a tool_result entry when its
+    ``message.content`` is a list whose every non-empty block has
+    ``type == "tool_result"``.
+
+    Args:
+        entry: A parsed JSONL entry dict.
+
+    Returns:
+        ``True`` when the entry carries only tool_result content blocks.
+    """
+    msg = entry.get("message", {})
+    content = msg.get("content", "")
+    if not isinstance(content, list):
+        return False
+    # At least one block must be present, and every block with a
+    # recognisable type must be "tool_result".
+    tool_result_blocks = [
+        b for b in content
+        if isinstance(b, dict) and b.get("type") == "tool_result"
+    ]
+    other_typed_blocks = [
+        b for b in content
+        if isinstance(b, dict)
+        and b.get("type") is not None
+        and b.get("type") != "tool_result"
+    ]
+    return len(tool_result_blocks) > 0 and len(other_typed_blocks) == 0
+
+
+def _is_real_user_ask(entry: dict) -> bool:
+    """Return True when *entry* represents a genuine external user ask.
+
+    A genuine ask is:
+    - ``type == "user"`` AND ``userType == "external"``
+    - NOT a tool_result entry (see :func:`_is_tool_result_entry`)
+
+    Args:
+        entry: A parsed JSONL entry dict.
+
+    Returns:
+        ``True`` for genuine user asks.
+    """
+    if not (
+        entry.get("type") == "user"
+        and entry.get("userType") == "external"
+    ):
+        return False
+    return not _is_tool_result_entry(entry)
+
+
+def _extract_ask_text(entry: dict) -> str:
+    """Extract the verbatim text from a user ask entry.
+
+    Args:
+        entry: A genuine user ask entry (pre-validated by
+            :func:`_is_real_user_ask`).
+
+    Returns:
+        The extracted text string (may be empty if the content is
+        structurally unusual).
+    """
+    msg = entry.get("message", {})
+    content = msg.get("content", "")
+    return _extract_text_from_content(content).strip()
+
+
+def _collect_edit_actions(entries: list[dict]) -> list[dict[str, str]]:
+    """Collect all Edit/Write/NotebookEdit tool_use events from entries.
+
+    Iterates assistant entries in file order, extracts tool_use blocks
+    whose ``name`` is in ``_EDIT_TOOLS``, and returns them as a list
+    of ``{"tool": "<name>", "file_path": "<path>"}`` dicts.
+
+    Args:
+        entries: Parsed JSONL entries in file order.
+
+    Returns:
+        Chronologically ordered list of action dicts.
+    """
+    actions: list[dict[str, str]] = []
+    for entry in entries:
+        if entry.get("type") != "assistant":
+            continue
+        msg = entry.get("message", {})
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_use":
+                continue
+            name: str = block.get("name", "")
+            if name not in _EDIT_TOOLS:
+                continue
+            inp: dict = block.get("input", {})
+            file_path: str = inp.get("file_path", "")
+            actions.append({"tool": name, "file_path": file_path})
+    return actions
+
+
+def audit_session(entries: list[dict]) -> AuditResult:
+    """Derive ask-vs-action audit data from already-parsed transcript entries.
+
+    Pure function — no I/O.  The caller is responsible for reading and
+    parsing the JSONL file; this function only classifies and extracts.
+
+    Algorithm:
+        1. Walk entries in order collecting genuine user asks (filtering
+           out tool_result entries).
+        2. ``original_ask`` = text of the first genuine ask (or ``None``
+           when absent).
+        3. ``prior_asks`` = texts of all subsequent genuine asks in order.
+        4. ``actions`` = all Edit/Write/NotebookEdit tool_use events.
+
+    Args:
+        entries: Parsed JSONL entry dicts in file order.  May be empty.
+
+    Returns:
+        An :data:`AuditResult` dict with keys ``original_ask`` (``str``
+        or ``None``), ``prior_asks`` (``list[str]``), and ``actions``
+        (``list[dict[str, str]]``).
+    """
+    ask_texts: list[str] = []
+    for entry in entries:
+        if _is_real_user_ask(entry):
+            text = _extract_ask_text(entry)
+            ask_texts.append(text)
+
+    original_ask: str | None = ask_texts[0] if ask_texts else None
+    prior_asks: list[str] = ask_texts[1:] if len(ask_texts) > 1 else []
+    actions = _collect_edit_actions(entries)
+
+    return {
+        "original_ask": original_ask,
+        "prior_asks": prior_asks,
+        "actions": actions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+
+def render_json(result: AuditResult) -> str:
+    """Render an audit result as a pretty-printed JSON string.
+
+    Uses ``indent=2`` and ``ensure_ascii=False`` for consistency with
+    the ``session-summary`` subcommand.  Does **not** append a trailing
+    newline — the caller (``run``) adds exactly one.
+
+    Args:
+        result: The audit result dict from :func:`audit_session`.
+
+    Returns:
+        A JSON string without a trailing newline.
+    """
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+def render_text(result: AuditResult) -> str:
+    """Render an audit result as a human-readable text summary.
+
+    Intended for ``--format text``.  Output template::
+
+        Original ask: <text or "(none)">
+
+        Prior asks:
+          - <ask 1>
+          ...
+
+        Actions (Edit/Write/NotebookEdit):
+          - <tool>: <file_path>
+          ...
+
+    Does **not** append a trailing newline — the caller (``run``) adds
+    exactly one.
+
+    Args:
+        result: The audit result dict from :func:`audit_session`.
+
+    Returns:
+        Multi-line string without a trailing newline.
+    """
+    original = result.get("original_ask") or "(none)"
+    prior = result.get("prior_asks", [])
+    actions = result.get("actions", [])
+
+    lines = [f"Original ask: {original}", ""]
+    if prior:
+        lines.append("Prior asks:")
+        for ask in prior:
+            lines.append(f"  - {ask}")
+    else:
+        lines.append("Prior asks: (none)")
+    lines.append("")
+    lines.append("Actions (Edit/Write/NotebookEdit):")
+    if actions:
+        for action in actions:
+            tool = action.get("tool", "?")
+            fp = action.get("file_path", "?")
+            lines.append(f"  - {tool}: {fp}")
+    else:
+        lines.append("  (none)")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def build_parser(
+    parent: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Register the 'session-audit' subparser and return it.
+
+    Args:
+        parent: The subparsers action from the top-level argument parser.
+
+    Returns:
+        The configured session-audit ArgumentParser.
+    """
+    p = parent.add_parser(
+        "session-audit",
+        help=(
+            "Extract ask-vs-action audit data from a Claude Code "
+            "transcript at zero LLM cost."
+        ),
+    )
+    p.add_argument(
+        "--path",
+        required=True,
+        help="Path to the transcript JSONL file.",
+    )
+    p.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["json", "text"],
+        default="json",
+        help="Output format: 'json' (default) or 'text' (human-readable).",
+    )
+    p.add_argument(
+        "--batch",
+        action="store_true",
+        default=False,
+        help=(
+            "Walk ~/.claude/projects/**/*.jsonl and emit an array of "
+            "per-session audits.  (Not yet implemented — exits with a "
+            "clear NotImplementedError message.)"
+        ),
+    )
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    """Entry point for the session-audit subcommand.
+
+    Dispatches ``--path`` through the full parse → audit → render
+    pipeline, printing JSON (or text) to stdout on success and a
+    diagnostic line to stderr on failure.
+
+    Args:
+        args: Parsed CLI namespace.  Expected attributes:
+            ``args.path`` (str), ``args.output_format`` (str),
+            ``args.batch`` (bool).
+
+    Returns:
+        Integer exit code (one of ``EXIT_OK``, ``EXIT_IO_FAILURE``,
+        ``EXIT_NO_USER_TURNS``, ``EXIT_NOT_JSONL``).
+    """
+    # --batch is stubbed pending clean implementation (issue #162 notes).
+    if getattr(args, "batch", False):
+        print(
+            "session-audit: --batch is not yet implemented",
+            file=sys.stderr,
+        )
+        return EXIT_IO_FAILURE
+
+    path = Path(args.path)
+
+    # ── IO failure ──────────────────────────────────────────────────────
+    try:
+        entries, non_blank_lines = read_transcript(path)
+    except OSError as exc:
+        print(
+            f"session-audit: cannot read transcript at '{path}': "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_IO_FAILURE
+
+    # ── Not JSONL ───────────────────────────────────────────────────────
+    if not entries and non_blank_lines > 0:
+        print(
+            f"session-audit: transcript '{path}' is not valid JSONL",
+            file=sys.stderr,
+        )
+        return EXIT_NOT_JSONL
+
+    # ── No user turns ───────────────────────────────────────────────────
+    has_user_turns = any(_is_real_user_ask(e) for e in entries)
+    if not has_user_turns:
+        print(
+            f"session-audit: transcript '{path}' contains no user turns",
+            file=sys.stderr,
+        )
+        return EXIT_NO_USER_TURNS
+
+    # ── Success path ────────────────────────────────────────────────────
+    skipped = non_blank_lines - len(entries)
+    if skipped > 0:
+        print(
+            f"session-audit: skipped {skipped} malformed line(s) in "
+            f"'{path}'",
+            file=sys.stderr,
+        )
+
+    result = audit_session(entries)
+
+    if args.output_format == "json":
+        output = render_json(result)
+    else:
+        output = render_text(result)
+
+    print(output, flush=True)
+    return EXIT_OK

--- a/tests/unit/test_session_audit.py
+++ b/tests/unit/test_session_audit.py
@@ -1,0 +1,584 @@
+"""Tests for the session-audit subcommand.
+
+Covers: empty transcript, single-ask session, multi-ask session
+(original_ask = first, prior_asks populated), tool-use extraction
+(Edit/Write/NotebookEdit paths), malformed/garbage JSONL lines
+(skipped gracefully), tool_result user-entries excluded from asks,
+and CLI routing.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests (no fixtures needed for simple JSONL building)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _user_line(
+    text: str | list,
+    user_type: str = "external",
+    session_id: str = "test-session",
+) -> dict:
+    """Build a minimal user message dict for JSONL fixtures.
+
+    Args:
+        text: Message content — either a plain string or a list of
+            content blocks (for tool_result entries or multi-block
+            messages).
+        user_type: The ``userType`` field. Use ``"external"`` for
+            real user asks, any other value for internal entries.
+        session_id: The session identifier string.
+
+    Returns:
+        A dict shaped like a real Claude Code JSONL user entry.
+    """
+    return {
+        "type": "user",
+        "userType": user_type,
+        "sessionId": session_id,
+        "message": {
+            "role": "user",
+            "content": text,
+        },
+    }
+
+
+def _tool_result_user_line(
+    tool_use_id: str = "tu-1",
+    session_id: str = "test-session",
+) -> dict:
+    """Build a user entry whose content is a tool_result block.
+
+    These are NOT real user asks and must be excluded from
+    original_ask / prior_asks.
+
+    Args:
+        tool_use_id: The tool_use_id referenced by the tool_result.
+        session_id: The session identifier string.
+
+    Returns:
+        A dict shaped like a Claude Code JSONL tool-result user entry.
+    """
+    return {
+        "type": "user",
+        "userType": "external",
+        "sessionId": session_id,
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": "tool output here",
+                }
+            ],
+        },
+    }
+
+
+def _assistant_with_tool_use(
+    tool_name: str,
+    file_path: str,
+    session_id: str = "test-session",
+) -> dict:
+    """Build an assistant message containing a single tool_use block.
+
+    Args:
+        tool_name: The tool name (e.g. ``"Edit"``, ``"Write"``).
+        file_path: The ``input.file_path`` value for the tool_use.
+        session_id: The session identifier string.
+
+    Returns:
+        A dict shaped like a real Claude Code JSONL assistant entry.
+    """
+    return {
+        "type": "assistant",
+        "sessionId": session_id,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu-1",
+                    "name": tool_name,
+                    "input": {"file_path": file_path},
+                }
+            ],
+        },
+    }
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    """Write a list of dicts as JSONL to *path*.
+
+    Args:
+        path: Destination file path.
+        lines: Dicts to serialise, one per line.
+    """
+    path.write_text(
+        "\n".join(json.dumps(line) for line in lines),
+        encoding="utf-8",
+    )
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[bytes]:
+    """Run claude_prospector as a module and capture raw output bytes.
+
+    Returns raw bytes rather than decoded text so callers control the
+    encoding.  Use ``.stdout.decode("utf-8")`` when expecting JSON or
+    known-UTF-8 output; avoid decoding help text (which argparse emits
+    in the system locale encoding on Windows).
+
+    Args:
+        *args: CLI arguments appended after the module name.
+
+    Returns:
+        CompletedProcess with stdout/stderr as bytes and returncode.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "claude_prospector", *args],
+        capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Import target — delayed until implementation exists so tests can be
+# collected even if the module is missing (they'll fail at the import line
+# inside the test body, not at collection time).
+# ---------------------------------------------------------------------------
+
+
+def _import_module():
+    """Import the session_audit module, raising ImportError if absent."""
+    from claude_prospector.cli import session_audit  # noqa: PLC0415
+
+    return session_audit
+
+
+# ===========================================================================
+# TestSessionAuditImport — module must be importable and export the contract
+# ===========================================================================
+
+
+class TestSessionAuditImport:
+    """The session_audit module must exist and export required symbols."""
+
+    def test_module_importable(self) -> None:
+        """session_audit module must be importable from cli package."""
+        mod = _import_module()
+        assert mod is not None
+
+    def test_build_parser_callable(self) -> None:
+        """session_audit must export a build_parser callable."""
+        mod = _import_module()
+        assert callable(mod.build_parser)
+
+    def test_run_callable(self) -> None:
+        """session_audit must export a run callable."""
+        mod = _import_module()
+        assert callable(mod.run)
+
+    def test_audit_session_callable(self) -> None:
+        """session_audit must export an audit_session pure function."""
+        mod = _import_module()
+        assert callable(mod.audit_session)
+
+
+# ===========================================================================
+# TestAuditSession — pure function over in-memory entries
+# ===========================================================================
+
+
+class TestAuditSession:
+    """Unit tests for audit_session() — no I/O, synthetic entry lists."""
+
+    def test_empty_transcript_returns_none_original_ask(self) -> None:
+        """An empty entry list yields original_ask = None."""
+        mod = _import_module()
+        result = mod.audit_session([])
+        assert result["original_ask"] is None
+
+    def test_empty_transcript_prior_asks_empty(self) -> None:
+        """An empty entry list yields prior_asks = []."""
+        mod = _import_module()
+        result = mod.audit_session([])
+        assert result["prior_asks"] == []
+
+    def test_empty_transcript_actions_empty(self) -> None:
+        """An empty entry list yields actions = []."""
+        mod = _import_module()
+        result = mod.audit_session([])
+        assert result["actions"] == []
+
+    def test_single_ask_sets_original_ask(self) -> None:
+        """A session with one user message sets original_ask to its text."""
+        mod = _import_module()
+        entries = [
+            _user_line("Please add a --dry-run flag to the CLI."),
+        ]
+        result = mod.audit_session(entries)
+        assert result["original_ask"] == "Please add a --dry-run flag to the CLI."
+
+    def test_single_ask_prior_asks_empty(self) -> None:
+        """A session with one user message leaves prior_asks empty."""
+        mod = _import_module()
+        entries = [
+            _user_line("Please add a --dry-run flag to the CLI."),
+        ]
+        result = mod.audit_session(entries)
+        assert result["prior_asks"] == []
+
+    def test_multi_ask_first_is_original(self) -> None:
+        """With multiple user asks original_ask is the FIRST, not the last.
+
+        This is the core regression case: the 696584a5 session started
+        "Add a --dry-run flag…" but a last-message recall bug would have
+        returned the final message ("close the pr") as the original ask.
+        """
+        mod = _import_module()
+        entries = [
+            _user_line("Add a --dry-run flag to the CLI."),
+            _user_line("Now also write tests for it."),
+            _user_line("close the pr"),
+        ]
+        result = mod.audit_session(entries)
+        assert result["original_ask"] == "Add a --dry-run flag to the CLI."
+
+    def test_multi_ask_subsequent_in_prior_asks(self) -> None:
+        """Subsequent user asks must appear in prior_asks in order."""
+        mod = _import_module()
+        entries = [
+            _user_line("Add a --dry-run flag to the CLI."),
+            _user_line("Now also write tests for it."),
+            _user_line("close the pr"),
+        ]
+        result = mod.audit_session(entries)
+        assert result["prior_asks"] == [
+            "Now also write tests for it.",
+            "close the pr",
+        ]
+
+    def test_tool_result_user_entries_excluded_from_original_ask(self) -> None:
+        """tool_result user entries must NOT be treated as user asks.
+
+        A user entry whose content is a list of tool_result blocks is
+        an API artifact, not a real user message.
+        """
+        mod = _import_module()
+        entries = [
+            _tool_result_user_line("tu-1"),
+            _user_line("This is the real ask."),
+        ]
+        result = mod.audit_session(entries)
+        assert result["original_ask"] == "This is the real ask."
+
+    def test_tool_result_user_entries_excluded_from_prior_asks(self) -> None:
+        """tool_result entries interspersed between asks must not appear
+        in prior_asks."""
+        mod = _import_module()
+        entries = [
+            _user_line("First ask."),
+            _tool_result_user_line("tu-1"),
+            _user_line("Second real ask."),
+        ]
+        result = mod.audit_session(entries)
+        assert result["prior_asks"] == ["Second real ask."]
+
+    def test_edit_tool_use_captured_in_actions(self) -> None:
+        """Edit tool_use events must appear in actions with file_path."""
+        mod = _import_module()
+        entries = [
+            _user_line("Fix the bug."),
+            _assistant_with_tool_use("Edit", "src/foo.py"),
+        ]
+        result = mod.audit_session(entries)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["file_path"] == "src/foo.py"
+        assert result["actions"][0]["tool"] == "Edit"
+
+    def test_write_tool_use_captured_in_actions(self) -> None:
+        """Write tool_use events must appear in actions with file_path."""
+        mod = _import_module()
+        entries = [
+            _user_line("Create the module."),
+            _assistant_with_tool_use("Write", "src/new_module.py"),
+        ]
+        result = mod.audit_session(entries)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["file_path"] == "src/new_module.py"
+        assert result["actions"][0]["tool"] == "Write"
+
+    def test_notebook_edit_tool_use_captured_in_actions(self) -> None:
+        """NotebookEdit tool_use events must appear in actions with file_path."""
+        mod = _import_module()
+        entries = [
+            _user_line("Edit the notebook."),
+            _assistant_with_tool_use("NotebookEdit", "analysis.ipynb"),
+        ]
+        result = mod.audit_session(entries)
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["file_path"] == "analysis.ipynb"
+        assert result["actions"][0]["tool"] == "NotebookEdit"
+
+    def test_bash_tool_use_not_in_actions(self) -> None:
+        """Bash tool_use events must NOT appear in the actions list.
+
+        Bash invocations are out of scope for session-audit 1a per the
+        design spec.
+        """
+        mod = _import_module()
+        entries = [
+            _user_line("Run the tests."),
+            {
+                "type": "assistant",
+                "sessionId": "test-session",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu-2",
+                            "name": "Bash",
+                            "input": {"command": "pytest"},
+                        }
+                    ],
+                },
+            },
+        ]
+        result = mod.audit_session(entries)
+        assert result["actions"] == []
+
+    def test_multiple_edit_tools_all_captured(self) -> None:
+        """Multiple edit tool_use events across assistant entries are all
+        captured in order."""
+        mod = _import_module()
+        entries = [
+            _user_line("Refactor everything."),
+            _assistant_with_tool_use("Edit", "src/a.py"),
+            _assistant_with_tool_use("Write", "src/b.py"),
+            _assistant_with_tool_use("NotebookEdit", "notebooks/c.ipynb"),
+        ]
+        result = mod.audit_session(entries)
+        assert len(result["actions"]) == 3
+        assert result["actions"][0]["file_path"] == "src/a.py"
+        assert result["actions"][1]["file_path"] == "src/b.py"
+        assert result["actions"][2]["file_path"] == "notebooks/c.ipynb"
+
+    def test_content_block_list_extracts_text(self) -> None:
+        """User messages with list content blocks have text extracted."""
+        mod = _import_module()
+        entries = [
+            _user_line(
+                [{"type": "text", "text": "Ask from content block."}]
+            ),
+        ]
+        result = mod.audit_session(entries)
+        assert result["original_ask"] == "Ask from content block."
+
+    def test_only_tool_results_no_real_asks(self) -> None:
+        """A transcript with only tool_result user entries has no original_ask."""
+        mod = _import_module()
+        entries = [
+            _tool_result_user_line("tu-1"),
+            _tool_result_user_line("tu-2"),
+        ]
+        result = mod.audit_session(entries)
+        assert result["original_ask"] is None
+        assert result["prior_asks"] == []
+
+    def test_result_schema_keys_present(self) -> None:
+        """audit_session result must contain the required schema keys."""
+        mod = _import_module()
+        result = mod.audit_session([])
+        required_keys = {"original_ask", "prior_asks", "actions"}
+        assert required_keys.issubset(result.keys())
+
+    def test_no_duplicate_asks_adjacent_equal_messages(self) -> None:
+        """Identical adjacent user messages both appear (no deduplication).
+
+        The spec says 'distinct' in the sense of subsequent, not unique
+        — identical repeated asks are each genuine asks.
+        """
+        mod = _import_module()
+        entries = [
+            _user_line("Run it again."),
+            _user_line("Run it again."),
+        ]
+        result = mod.audit_session(entries)
+        assert result["original_ask"] == "Run it again."
+        assert result["prior_asks"] == ["Run it again."]
+
+
+# ===========================================================================
+# TestReadTranscriptGraceful — I/O edge cases (malformed JSONL)
+# ===========================================================================
+
+
+class TestReadTranscriptGraceful:
+    """Malformed and edge-case JSONL lines must be skipped gracefully."""
+
+    def test_malformed_lines_skipped_gracefully(
+        self, tmp_path: Path
+    ) -> None:
+        """Garbage JSONL lines must be skipped; valid lines must be parsed.
+
+        A file with 1 valid user-ask line and 2 garbage lines must
+        still yield original_ask from the valid line.
+        """
+        mod = _import_module()
+        f = tmp_path / "test.jsonl"
+        valid = json.dumps(_user_line("The real ask."))
+        f.write_text(
+            "\n".join([
+                "NOT JSON AT ALL }{",
+                valid,
+                "also garbage",
+            ]),
+            encoding="utf-8",
+        )
+        entries, _count = mod.read_transcript(f)
+        result = mod.audit_session(entries)
+        assert result["original_ask"] == "The real ask."
+
+    def test_empty_file_returns_empty_entries(self, tmp_path: Path) -> None:
+        """An empty JSONL file yields zero entries and zero non-blank lines."""
+        mod = _import_module()
+        f = tmp_path / "empty.jsonl"
+        f.write_text("", encoding="utf-8")
+        entries, non_blank = mod.read_transcript(f)
+        assert entries == []
+        assert non_blank == 0
+
+    def test_blank_lines_only_skipped(self, tmp_path: Path) -> None:
+        """A file with only blank lines yields zero entries."""
+        mod = _import_module()
+        f = tmp_path / "blanks.jsonl"
+        f.write_text("\n\n\n", encoding="utf-8")
+        entries, non_blank = mod.read_transcript(f)
+        assert entries == []
+        assert non_blank == 0
+
+    def test_all_garbage_nonzero_non_blank_count(self, tmp_path: Path) -> None:
+        """A file with only unparseable lines has non_blank_lines > 0."""
+        mod = _import_module()
+        f = tmp_path / "garbage.jsonl"
+        f.write_text("}{garbage\nalso garbage\n", encoding="utf-8")
+        entries, non_blank = mod.read_transcript(f)
+        assert entries == []
+        assert non_blank == 2
+
+
+# ===========================================================================
+# TestOutputFormats — render_json and render_text
+# ===========================================================================
+
+
+class TestOutputFormats:
+    """Output rendering must produce valid JSON or human-readable text."""
+
+    def test_render_json_is_valid_json(self) -> None:
+        """render_json must produce a parseable JSON string."""
+        mod = _import_module()
+        result = mod.audit_session([_user_line("Fix the bug.")])
+        output = mod.render_json(result)
+        parsed = json.loads(output)
+        assert "original_ask" in parsed
+
+    def test_render_json_schema_structure(self) -> None:
+        """render_json output must match the documented schema shape."""
+        mod = _import_module()
+        result = mod.audit_session([
+            _user_line("First ask."),
+            _user_line("Second ask."),
+            _assistant_with_tool_use("Edit", "src/foo.py"),
+        ])
+        parsed = json.loads(mod.render_json(result))
+        assert parsed["original_ask"] == "First ask."
+        assert parsed["prior_asks"] == ["Second ask."]
+        assert len(parsed["actions"]) == 1
+        assert parsed["actions"][0]["tool"] == "Edit"
+        assert parsed["actions"][0]["file_path"] == "src/foo.py"
+
+    def test_render_text_contains_original_ask(self) -> None:
+        """render_text output must contain the original_ask text."""
+        mod = _import_module()
+        result = mod.audit_session([_user_line("Do the thing.")])
+        output = mod.render_text(result)
+        assert "Do the thing." in output
+
+    def test_render_text_contains_section_headers(self) -> None:
+        """render_text must include labelled sections."""
+        mod = _import_module()
+        result = mod.audit_session([
+            _user_line("Fix it."),
+            _assistant_with_tool_use("Write", "out.py"),
+        ])
+        output = mod.render_text(result)
+        # Must include labelled headers
+        assert "Original ask" in output or "original_ask" in output.lower()
+        assert "Actions" in output or "actions" in output.lower()
+
+
+# ===========================================================================
+# TestCLIRouting — subprocess integration
+# ===========================================================================
+
+
+class TestCLIRouting:
+    """session-audit subcommand must be wired into the CLI entry point."""
+
+    def test_session_audit_in_help_output(self) -> None:
+        """'python -m claude_prospector' help must list 'session-audit'."""
+        result = _run_cli()
+        # Decode with errors="replace" — help text may contain locale chars.
+        combined = (
+            result.stdout.decode("utf-8", errors="replace")
+            + result.stderr.decode("utf-8", errors="replace")
+        )
+        assert "session-audit" in combined
+
+    def test_session_audit_help_exits_0(self) -> None:
+        """'session-audit --help' must exit 0."""
+        result = _run_cli("session-audit", "--help")
+        assert result.returncode == 0
+
+    def test_session_audit_missing_file_exits_nonzero(
+        self, tmp_path: Path
+    ) -> None:
+        """Passing a nonexistent --path must exit non-zero."""
+        missing = str(tmp_path / "nonexistent.jsonl")
+        result = _run_cli("session-audit", "--path", missing)
+        assert result.returncode != 0
+
+    def test_session_audit_valid_file_exits_0(self, tmp_path: Path) -> None:
+        """A valid single-ask transcript must exit 0 and emit JSON."""
+        f = tmp_path / "session.jsonl"
+        _write_jsonl(f, [_user_line("Do the thing.")])
+        result = _run_cli("session-audit", "--path", str(f))
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout.decode("utf-8"))
+        assert parsed["original_ask"] == "Do the thing."
+
+    def test_session_audit_format_text_exits_0(self, tmp_path: Path) -> None:
+        """'session-audit --format text' must exit 0."""
+        f = tmp_path / "session.jsonl"
+        _write_jsonl(f, [_user_line("Do the thing.")])
+        result = _run_cli("session-audit", "--path", str(f), "--format", "text")
+        assert result.returncode == 0
+        assert "Do the thing." in result.stdout.decode("utf-8")
+
+    def test_session_audit_empty_transcript_exits_nonzero(
+        self, tmp_path: Path
+    ) -> None:
+        """An empty transcript (no user turns) must exit non-zero."""
+        f = tmp_path / "empty.jsonl"
+        f.write_text("", encoding="utf-8")
+        result = _run_cli("session-audit", "--path", str(f))
+        assert result.returncode != 0

--- a/tests/unit/test_session_audit.py
+++ b/tests/unit/test_session_audit.py
@@ -375,9 +375,7 @@ class TestAuditSession:
         """User messages with list content blocks have text extracted."""
         mod = _import_module()
         entries = [
-            _user_line(
-                [{"type": "text", "text": "Ask from content block."}]
-            ),
+            _user_line([{"type": "text", "text": "Ask from content block."}]),
         ]
         result = mod.audit_session(entries)
         assert result["original_ask"] == "Ask from content block."
@@ -424,9 +422,7 @@ class TestAuditSession:
 class TestReadTranscriptGraceful:
     """Malformed and edge-case JSONL lines must be skipped gracefully."""
 
-    def test_malformed_lines_skipped_gracefully(
-        self, tmp_path: Path
-    ) -> None:
+    def test_malformed_lines_skipped_gracefully(self, tmp_path: Path) -> None:
         """Garbage JSONL lines must be skipped; valid lines must be parsed.
 
         A file with 1 valid user-ask line and 2 garbage lines must
@@ -436,11 +432,13 @@ class TestReadTranscriptGraceful:
         f = tmp_path / "test.jsonl"
         valid = json.dumps(_user_line("The real ask."))
         f.write_text(
-            "\n".join([
-                "NOT JSON AT ALL }{",
-                valid,
-                "also garbage",
-            ]),
+            "\n".join(
+                [
+                    "NOT JSON AT ALL }{",
+                    valid,
+                    "also garbage",
+                ]
+            ),
             encoding="utf-8",
         )
         entries, _count = mod.read_transcript(f)
@@ -494,11 +492,13 @@ class TestOutputFormats:
     def test_render_json_schema_structure(self) -> None:
         """render_json output must match the documented schema shape."""
         mod = _import_module()
-        result = mod.audit_session([
-            _user_line("First ask."),
-            _user_line("Second ask."),
-            _assistant_with_tool_use("Edit", "src/foo.py"),
-        ])
+        result = mod.audit_session(
+            [
+                _user_line("First ask."),
+                _user_line("Second ask."),
+                _assistant_with_tool_use("Edit", "src/foo.py"),
+            ]
+        )
         parsed = json.loads(mod.render_json(result))
         assert parsed["original_ask"] == "First ask."
         assert parsed["prior_asks"] == ["Second ask."]
@@ -516,10 +516,12 @@ class TestOutputFormats:
     def test_render_text_contains_section_headers(self) -> None:
         """render_text must include labelled sections."""
         mod = _import_module()
-        result = mod.audit_session([
-            _user_line("Fix it."),
-            _assistant_with_tool_use("Write", "out.py"),
-        ])
+        result = mod.audit_session(
+            [
+                _user_line("Fix it."),
+                _assistant_with_tool_use("Write", "out.py"),
+            ]
+        )
         output = mod.render_text(result)
         # Must include labelled headers
         assert "Original ask" in output or "original_ask" in output.lower()
@@ -538,10 +540,9 @@ class TestCLIRouting:
         """'python -m claude_prospector' help must list 'session-audit'."""
         result = _run_cli()
         # Decode with errors="replace" — help text may contain locale chars.
-        combined = (
-            result.stdout.decode("utf-8", errors="replace")
-            + result.stderr.decode("utf-8", errors="replace")
-        )
+        combined = result.stdout.decode(
+            "utf-8", errors="replace"
+        ) + result.stderr.decode("utf-8", errors="replace")
         assert "session-audit" in combined
 
     def test_session_audit_help_exits_0(self) -> None:
@@ -549,9 +550,7 @@ class TestCLIRouting:
         result = _run_cli("session-audit", "--help")
         assert result.returncode == 0
 
-    def test_session_audit_missing_file_exits_nonzero(
-        self, tmp_path: Path
-    ) -> None:
+    def test_session_audit_missing_file_exits_nonzero(self, tmp_path: Path) -> None:
         """Passing a nonexistent --path must exit non-zero."""
         missing = str(tmp_path / "nonexistent.jsonl")
         result = _run_cli("session-audit", "--path", missing)
@@ -574,9 +573,7 @@ class TestCLIRouting:
         assert result.returncode == 0
         assert "Do the thing." in result.stdout.decode("utf-8")
 
-    def test_session_audit_empty_transcript_exits_nonzero(
-        self, tmp_path: Path
-    ) -> None:
+    def test_session_audit_empty_transcript_exits_nonzero(self, tmp_path: Path) -> None:
         """An empty transcript (no user turns) must exit non-zero."""
         f = tmp_path / "empty.jsonl"
         f.write_text("", encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "claude-prospector"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## What

Implements #162 — a new `session-audit` CLI subcommand that reads a single Claude Code session transcript (`.jsonl`) and emits structured "what was asked vs. what was done" data at **zero LLM cost**. This is the deterministic, transcript-based replacement for the abandoned Stop-hook self-audit spike (#129, retired per cost/UX escalation #161 — see `docs/spikes/2026-05-19-self-audit-spike.md`).

## Usage

```bash
python -m claude_prospector session-audit --path <transcript.jsonl>            # JSON (default)
python -m claude_prospector session-audit --path <transcript.jsonl> --format text
```

## JSON schema

```json
{
  "original_ask": "<string | null>",
  "prior_asks":   ["<string>", "..."],
  "actions":      [{"tool": "<Edit|Write|NotebookEdit>", "file_path": "<string>"}]
}
```

- **`original_ask`** — verbatim text of the **first** non-system, non-tool-result external user message (`null` if absent).
- **`prior_asks`** — subsequent distinct user asks, in order (empty for single-ask sessions). This is the resolution of #162's open question: first ask stays authoritative, later asks are surfaced for context — directly fixing the multi-task recall bug the spike found in session `696584a5` (it had quoted the *last* message as the ask).
- **`actions`** — chronological `Edit`/`Write`/`NotebookEdit` tool_use events with target file paths.

## Implementation notes

- Reuses `read_transcript`, `_extract_text_from_content`, and `_EDIT_TOOLS` from `session_summary.py` — no divergent copies.
- Tool-result `type: user` entries are correctly excluded from asks.
- `--batch` (walk `~/.claude/projects/**/*.jsonl`) is **stubbed** for a follow-up; the single-file path is fully implemented. Exits 1 with a clear message.
- Incidental: `uv.lock` version reconciled 0.9.1 → 0.10.0 (the lock lagged the v0.10.0 release on `main`).

## Verification

- Baseline: **529 passed, 2 skipped** → post-change: **565 passed, 2 skipped** (+36 new unit tests, 0 regressions).
- `uv run ruff check src/ tests/` → clean (re-verified by router).
- New tests cover: empty transcript, single-ask, multi-task (original_ask = first, prior_asks populated), tool-use extraction, malformed/garbage lines skipped, and tool_result exclusion.
- README documents the subcommand + schema.

## Out of scope (intentional, per #162)

LLM-assisted judgment fields (`Variance`, `What was NOT done`) → that's #163 (1b). Dashboard surfacing → separate follow-up.

Closes #162
Closes #129

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_