### PR TITLE
feat: LLM-assisted variance analysis via session-analysis skill (1b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Claude Code efficiency and hygiene toolkit. Surfaces token spend across the thre
 | `usage-analysis` | where your tokens are going |
 | `usage-dashboard` | regenerate the cost dashboard surface |
 | `claude-audit` | where your config has agent / skill overlap or bloat |
-| `session-variance` | whether a session stayed on task (opt-in LLM judgment) |
+| `session-analysis` | whether a session stayed on task (opt-in LLM judgment) |
 
 Claude Code's built-in `/usage` shows current-session token totals and — for Max/Pro subscribers — plan-usage bars on the same screen. It doesn't surface multi-day history, per-agent attribution with sub-agent nesting, per-skill invocation counts, or per-project breakdowns, and there's no way to ask "where are my Sonnet-7d tokens going this week?" from inside the session. There's also no built-in way to detect when two installed plugins ship overlapping `code-reviewer` agents or near-duplicate skills.
 
@@ -85,9 +85,9 @@ Audits your project's effective Claude Code configuration — custom and plugin-
 
 The skill is read-only — it does not modify any files. All recommendations are presented for your review.
 
-### `session-variance` skill
+### `session-analysis` skill
 
-The interpretive (LLM) complement to the deterministic `session-audit` CLI. Where `session-audit` extracts ask-vs-done for free, `session-variance` adds the judgment layer: did the agent stay on the original ask, and what did it acknowledge skipping?
+The interpretive (LLM) complement to the deterministic `session-audit` CLI. Where `session-audit` extracts ask-vs-done for free, `session-analysis` adds the judgment layer: did the agent stay on the original ask, and what did it acknowledge skipping?
 
 The skill loads `session-audit`'s extract (the 1a fields), then has the agent produce two judgment fields — `Variance` and `What was NOT done` — and persists a combined record via the `variance-save` subcommand.
 
@@ -96,14 +96,14 @@ The skill loads `session-audit`'s extract (the 1a fields), then has the agent pr
 - **Opt-in, not automatic.** Costs ~1-3k tokens of the current session; run it selectively on sessions you suspect drifted, not on every session.
 - **Sonnet or stronger recommended.** Judgment quality depends on the model.
 
-Trigger phrases: `/session-variance`, "did this session stay on task", "analyze session drift", "did the agent do what I asked", "what did this session skip".
+Trigger phrases: `/session-analysis`, "did this session stay on task", "analyze session drift", "did the agent do what I asked", "what did this session skip".
 
 Cross-references:
 - `session-audit` — free deterministic ask/actions extract (run this first)
 - `usage-analysis` — token-spend insights
 - `claude-audit` — agent/skill config overlap
 
-The full skill definition is at `skills/session-variance/SKILL.md`.
+The full skill definition is at `skills/session-analysis/SKILL.md`.
 
 ### `setup-prospector` skill
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Claude Code efficiency and hygiene toolkit. Surfaces token spend across the thre
 | `usage-analysis` | where your tokens are going |
 | `usage-dashboard` | regenerate the cost dashboard surface |
 | `claude-audit` | where your config has agent / skill overlap or bloat |
+| `session-variance` | whether a session stayed on task (opt-in LLM judgment) |
 
 Claude Code's built-in `/usage` shows current-session token totals and — for Max/Pro subscribers — plan-usage bars on the same screen. It doesn't surface multi-day history, per-agent attribution with sub-agent nesting, per-skill invocation counts, or per-project breakdowns, and there's no way to ask "where are my Sonnet-7d tokens going this week?" from inside the session. There's also no built-in way to detect when two installed plugins ship overlapping `code-reviewer` agents or near-duplicate skills.
 
@@ -83,6 +84,26 @@ Audits your project's effective Claude Code configuration — custom and plugin-
 - "what's redundant in my setup"
 
 The skill is read-only — it does not modify any files. All recommendations are presented for your review.
+
+### `session-variance` skill
+
+The interpretive (LLM) complement to the deterministic `session-audit` CLI. Where `session-audit` extracts ask-vs-done for free, `session-variance` adds the judgment layer: did the agent stay on the original ask, and what did it acknowledge skipping?
+
+The skill loads `session-audit`'s extract (the 1a fields), then has the agent produce two judgment fields — `Variance` and `What was NOT done` — and persists a combined record via the `variance-save` subcommand.
+
+**Key constraints:**
+
+- **Opt-in, not automatic.** Costs ~1-3k tokens of the current session; run it selectively on sessions you suspect drifted, not on every session.
+- **Sonnet or stronger recommended.** Judgment quality depends on the model.
+
+Trigger phrases: `/session-variance`, "did this session stay on task", "analyze session drift", "did the agent do what I asked", "what did this session skip".
+
+Cross-references:
+- `session-audit` — free deterministic ask/actions extract (run this first)
+- `usage-analysis` — token-spend insights
+- `claude-audit` — agent/skill config overlap
+
+The full skill definition is at `skills/session-variance/SKILL.md`.
 
 ### `setup-prospector` skill
 
@@ -269,7 +290,11 @@ On any non-zero exit, stdout is empty and stderr contains exactly one line.
 ### `session-audit` — ask-vs-action extraction at zero LLM cost
 
 ```bash
+# By path
 python -m claude_prospector session-audit --path <transcript.jsonl>
+
+# By session-id (resolves transcript under ~/.claude/projects/)
+python -m claude_prospector session-audit --session-id <id>
 ```
 
 Reads a single Claude Code session transcript (`.jsonl`) and emits
@@ -280,7 +305,8 @@ with **no API calls**.
 
 | Flag | Default | Description |
 |---|---|---|
-| `--path <file>` | *(required)* | Path to the transcript JSONL file |
+| `--path <file>` | *(mutually exclusive with `--session-id`)* | Path to the transcript JSONL file |
+| `--session-id <id>` | *(mutually exclusive with `--path`)* | Session id; the transcript is resolved under `~/.claude/projects/` (override root with `--data-dir`) |
 | `--format json\|text` | `json` | Output format |
 | `--batch` | off | *(not yet implemented)* Walk `~/.claude/projects/**/*.jsonl` and emit per-session array |
 
@@ -329,6 +355,60 @@ with **no API calls**.
 | `3` | File has content but none of it parses as JSONL | `session-audit: transcript '<path>' is not valid JSONL` |
 
 On any non-zero exit, stdout is empty and stderr contains exactly one line.
+
+---
+
+### `variance-save` — persist combined audit + judgment
+
+```bash
+# Judgment supplied as a file
+python -m claude_prospector variance-save --session-id <id> --judgment-file <f>
+
+# Judgment supplied on stdin (--judgment-file omitted)
+python -m claude_prospector variance-save --session-id <id> < judgment.json
+```
+
+Re-runs `session-audit` internally (1a), merges the result with the supplied judgment JSON, and writes a combined record. Transcript search and output location are independent — the transcript is resolved under `~/.claude/projects/` (override with `--data-dir`); output goes to `<plugin-data-dir>/variance/<session-id>.json` by default (override with `--out <path>`). Prints the written path on success.
+
+#### Judgment input shape
+
+```json
+{"variance": "<str>", "not_done": "<str>", "severity": <int|null>}
+```
+
+`severity` is optional (0 = on task, 1 = minor drift, 2 = notable scope or skipped ask, 3 = session largely off task).
+
+#### Combined output schema
+
+```json
+{
+  "session_id": "<id>",
+  "original_ask": "<str|null>",
+  "prior_asks": ["<str>"],
+  "actions": [{"tool": "<Edit|Write|NotebookEdit>", "file_path": "<str>"}],
+  "variance": "<str>",
+  "not_done": "<str>",
+  "severity": "<int|null>"
+}
+```
+
+This artifact is the intended input for future drift-aggregation work (see issue #63).
+
+| Flag | Default | Description |
+|---|---|---|
+| `--session-id <id>` | *(required)* | Session id; transcript resolved under `--data-dir` |
+| `--judgment-file <f>` | stdin | Path to the judgment JSON file; omit to read from stdin |
+| `--data-dir <dir>` | `~/.claude` | Root under which `projects/` is searched for the transcript |
+| `--out <path>` | `<plugin-data-dir>/variance/<id>.json` | Override the output path |
+
+#### Exit codes
+
+| Code | Meaning | stderr |
+|---|---|---|
+| `0` | Success — combined record written; path printed to stdout | *(silent)* |
+| `1` | IO failure (transcript missing, judgment unreadable, output unwritable) | `variance-save: <reason>` |
+| `2` | Transcript found but contains no user turns | `variance-save: transcript '<path>' contains no user turns` |
+| `3` | Judgment input is not valid JSON or missing required fields | `variance-save: judgment: <reason>` |
 
 ---
 

--- a/skills/session-analysis/SKILL.md
+++ b/skills/session-analysis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: session-variance
+name: session-analysis
 description: >
   Use when the user wants a judgment-level read on whether a Claude Code
   session stayed on task — did the agent do what was originally asked, and
@@ -17,13 +17,13 @@ description: >
   agent/skill config overlap. Use THIS skill for "did this session drift from
   what I asked".
 
-  Trigger phrases: "/session-variance", "did this session stay on task",
+  Trigger phrases: "/session-analysis", "did this session stay on task",
   "analyze session drift", "did the agent do what I asked", "what did this
   session skip", "variance analysis for session", "audit this session for
   drift", "check session <id> for variance".
 ---
 
-# Session Variance Skill (1b)
+# Session Analysis Skill (1b)
 
 You are producing the **judgment** half of session drift-detection: given a
 session's deterministic ask-vs-done extract (from 1a), assess whether the

--- a/skills/session-variance/SKILL.md
+++ b/skills/session-variance/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: session-variance
+description: >
+  Use when the user wants a judgment-level read on whether a Claude Code
+  session stayed on task — did the agent do what was originally asked, and
+  what did it acknowledge skipping. This is the interpretive (LLM) complement
+  to the deterministic `session-audit` CLI: 1a extracts ask-vs-done for free;
+  this skill adds the `Variance` and `What was NOT done` judgment that a parser
+  can't compute, then persists a combined record for drift analysis.
+
+  Cost: ~1-3k tokens of the current session, paid only when invoked. Opt-in by
+  design — run it selectively, not on every session. Best run in a Sonnet (or
+  stronger) session; the judgment quality depends on it.
+
+  Use `session-audit` (CLI) for the free deterministic ask/actions extract.
+  Use `usage-analysis` for token-spend insights. Use `claude-audit` for
+  agent/skill config overlap. Use THIS skill for "did this session drift from
+  what I asked".
+
+  Trigger phrases: "/session-variance", "did this session stay on task",
+  "analyze session drift", "did the agent do what I asked", "what did this
+  session skip", "variance analysis for session", "audit this session for
+  drift", "check session <id> for variance".
+---
+
+# Session Variance Skill (1b)
+
+You are producing the **judgment** half of session drift-detection: given a
+session's deterministic ask-vs-done extract (from 1a), assess whether the
+agent stayed on task and what it acknowledged leaving undone — then persist a
+combined record. This is interpretive work; a deterministic parser cannot do
+it, which is exactly why it costs LLM tokens and is opt-in.
+
+## Prerequisites
+
+This skill drives the `claude_prospector` CLI. The package must be installed
+in the environment Claude Code uses — see the
+[README install steps](https://github.com/glitchwerks/claude-prospector#install-as-a-claude-code-plugin).
+
+## Step 1 — Identify the target session
+
+The session-id (or transcript path) is `` if provided.
+
+- If `` is a session-id, use it directly.
+- If `` is empty, find the most recent transcript for the current
+  project under `~/.claude/projects/<encoded-cwd>/*.jsonl` (newest mtime) and
+  **confirm the session-id with the user before spending tokens** — variance
+  analysis is opt-in, don't guess silently.
+
+## Step 2 — Load the deterministic extract (free, 1a)
+
+```bash
+python -m claude_prospector session-audit --session-id <id> --format json
+```
+
+This returns `{original_ask, prior_asks, actions}`. `original_ask` is the
+authoritative first ask; `prior_asks` are later distinct asks in the session;
+`actions` are the Edit/Write/NotebookEdit file paths. Reason over this — it is
+your ground truth for "what was asked" and "what was changed".
+
+For richer context (reasoning, tool failures, what the agent *said* it was
+doing), also read the transcript itself at the resolved
+`~/.claude/projects/<…>/<id>.jsonl`. Use it to judge intent, not to recompute
+the deterministic fields.
+
+## Step 3 — Form the judgment
+
+Assess two fields against `original_ask` (+ `prior_asks` for multi-task
+sessions):
+
+- **`variance`** — did the agent stay on the original ask? Note scope creep,
+  approach pivots, or drift onto a later ask at the expense of the first.
+  Cite specifics (a file in `actions` unrelated to the ask; a pivot point in
+  the transcript). If it stayed on task, say so plainly — "no variance" is a
+  valid, useful finding.
+- **`not_done`** — what did the agent acknowledge skipping or defer? Prefer
+  the agent's own admissions in the transcript over your speculation. If
+  nothing was skipped, say so.
+
+Optionally assign **`severity`** (integer 0-3): 0 = on task, 1 = minor drift,
+2 = notable unrequested scope or skipped ask, 3 = the session largely did not
+do what was asked. Omit (null) if you can't justify a number.
+
+Be evidence-bound: every claim cites a file path, a `prior_asks` entry, or a
+transcript moment. Do not invent drift to fill the field.
+
+## Step 4 — Persist the combined record
+
+Write the judgment to a temp JSON file (prose is multi-line; don't fight shell
+escaping), then call `variance-save`. It re-loads 1a internally and writes the
+combined `{1a fields + your judgment}` to `<data>/variance/<id>.json`:
+
+```bash
+# judgment.json: {"variance": "...", "not_done": "...", "severity": <int|null>}
+python -m claude_prospector variance-save --session-id <id> --judgment-file judgment.json
+```
+
+`variance-save` finds the transcript under `~/.claude` and writes output under
+the plugin data dir by default — no extra flags needed. It prints the written
+path; surface that to the user.
+
+## Step 5 — Report
+
+Give the user a short variance report (NOT a JSON dump):
+
+```
+Session <id> — variance: <one-line verdict, severity if assigned>
+  Asked:    <original_ask, trimmed>
+  Variance: <the judgment, with its citation>
+  Skipped:  <not_done, with its citation>
+  Saved:    <path printed by variance-save>
+```
+
+## When to run (and not)
+
+- **Run it** on a session you suspect drifted, a long multi-task session, or
+  one flagged by `prior_asks.length > 0`. Selective use is the whole cost
+  argument — 1a+1b beats the abandoned always-on hook only when 1b runs on a
+  minority of sessions.
+- **Don't** auto-run it on every session — that re-introduces the per-session
+  cost this design exists to avoid.

--- a/src/claude_prospector/__main__.py
+++ b/src/claude_prospector/__main__.py
@@ -11,6 +11,7 @@ from claude_prospector.cli import (
     dashboard,
     session_audit,
     session_summary,
+    variance_save,
 )
 
 
@@ -40,6 +41,7 @@ def main() -> None:
     session_audit.build_parser(subparsers)
     config.build_parser(subparsers)
     audit.build_parser(subparsers)
+    variance_save.build_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -61,6 +63,9 @@ def main() -> None:
 
     if args.subcommand == "audit":
         sys.exit(audit.run(args))
+
+    if args.subcommand == "variance-save":
+        sys.exit(variance_save.run(args))
 
 
 if __name__ == "__main__":

--- a/src/claude_prospector/cli/session_audit.py
+++ b/src/claude_prospector/cli/session_audit.py
@@ -66,6 +66,56 @@ AuditResult = dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
+# Session-id → path resolver (shared with variance_save)
+# ---------------------------------------------------------------------------
+
+
+def resolve_session_id_to_path(
+    session_id: str,
+    data_dir: Path,
+) -> Path:
+    """Resolve a session-id to its transcript JSONL path.
+
+    Walks ``data_dir/projects/**/<session_id>.jsonl`` (one glob level
+    deep into project directories) and returns the single matching path.
+
+    Args:
+        session_id: The Claude Code session identifier (filename stem).
+        data_dir: Root of the Claude data directory (e.g. ``~/.claude``).
+            The search walks ``<data_dir>/projects/``; if that
+            subdirectory does not exist, zero matches are returned.
+
+    Returns:
+        The resolved ``Path`` to the transcript JSONL file.
+
+    Raises:
+        FileNotFoundError: When no matching transcript is found.
+        ValueError: When more than one transcript matches the session-id.
+    """
+    projects_dir = data_dir / "projects"
+    if not projects_dir.is_dir():
+        raise FileNotFoundError(
+            f"session-id '{session_id}' not found: "
+            f"projects directory '{projects_dir}' does not exist."
+        )
+
+    matches = list(projects_dir.glob(f"*/{session_id}.jsonl"))
+
+    if len(matches) == 0:
+        raise FileNotFoundError(
+            f"session-id '{session_id}' not found under '{projects_dir}'."
+        )
+    if len(matches) > 1:
+        paths_str = ", ".join(str(m) for m in sorted(matches))
+        raise ValueError(
+            f"session-id '{session_id}' is ambiguous — "
+            f"found {len(matches)} transcripts: {paths_str}"
+        )
+
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
 # Core extraction — pure function, no I/O
 # ---------------------------------------------------------------------------
 
@@ -292,6 +342,11 @@ def build_parser(
 ) -> argparse.ArgumentParser:
     """Register the 'session-audit' subparser and return it.
 
+    Accepts either ``--path <transcript.jsonl>`` or
+    ``--session-id <id>``; exactly one is required.  When
+    ``--session-id`` is used, ``--data-dir`` controls the root of the
+    search (defaults to ``~/.claude``).
+
     Args:
         parent: The subparsers action from the top-level argument parser.
 
@@ -305,10 +360,31 @@ def build_parser(
             "transcript at zero LLM cost."
         ),
     )
-    p.add_argument(
+
+    # Mutually exclusive group: exactly one of --path or --session-id.
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument(
         "--path",
-        required=True,
         help="Path to the transcript JSONL file.",
+    )
+    group.add_argument(
+        "--session-id",
+        dest="session_id",
+        help=(
+            "Claude Code session-id.  Resolved to a transcript by "
+            "walking <data-dir>/projects/**/<id>.jsonl."
+        ),
+    )
+
+    p.add_argument(
+        "--data-dir",
+        dest="data_dir",
+        type=Path,
+        default=Path.home() / ".claude",
+        help=(
+            "Root of the Claude data directory used when resolving "
+            "--session-id (default: ~/.claude)."
+        ),
     )
     p.add_argument(
         "--format",
@@ -333,14 +409,18 @@ def build_parser(
 def run(args: argparse.Namespace) -> int:
     """Entry point for the session-audit subcommand.
 
-    Dispatches ``--path`` through the full parse → audit → render
-    pipeline, printing JSON (or text) to stdout on success and a
-    diagnostic line to stderr on failure.
+    Dispatches ``--path`` or ``--session-id`` through the full parse →
+    audit → render pipeline, printing JSON (or text) to stdout on
+    success and a diagnostic line to stderr on failure.
+
+    When ``--session-id`` is supplied, the id is resolved to a
+    transcript path by walking ``<args.data_dir>/projects/``.
 
     Args:
         args: Parsed CLI namespace.  Expected attributes:
-            ``args.path`` (str), ``args.output_format`` (str),
-            ``args.batch`` (bool).
+            ``args.path`` (str or None), ``args.session_id`` (str or
+            None), ``args.data_dir`` (Path), ``args.output_format``
+            (str), ``args.batch`` (bool).
 
     Returns:
         Integer exit code (one of ``EXIT_OK``, ``EXIT_IO_FAILURE``,
@@ -354,7 +434,19 @@ def run(args: argparse.Namespace) -> int:
         )
         return EXIT_IO_FAILURE
 
-    path = Path(args.path)
+    # Resolve transcript path from --path or --session-id.
+    if getattr(args, "session_id", None):
+        data_dir: Path = getattr(args, "data_dir", Path.home() / ".claude")
+        try:
+            path = resolve_session_id_to_path(args.session_id, data_dir)
+        except (FileNotFoundError, ValueError) as exc:
+            print(
+                f"session-audit: {exc}",
+                file=sys.stderr,
+            )
+            return EXIT_IO_FAILURE
+    else:
+        path = Path(args.path)
 
     # ── IO failure ──────────────────────────────────────────────────────
     try:

--- a/src/claude_prospector/cli/variance_save.py
+++ b/src/claude_prospector/cli/variance_save.py
@@ -1,0 +1,426 @@
+"""Variance-save subcommand: persist 1a audit data merged with judgment.
+
+Combines the deterministic output from the ``session-audit`` 1a extraction
+(``original_ask``, ``prior_asks``, ``actions``) with caller-supplied
+judgment fields (``variance``, ``not_done``, ``severity``) and writes a
+single combined JSON artifact to ``<base_dir>/variance/<session_id>.json``.
+
+The skill that calls this command is responsible for sourcing the judgment
+fields from LLM-assisted analysis.  This module is **purely deterministic**:
+it reads an existing transcript via :func:`audit_session`, merges the
+judgment, and persists the result.
+
+Root directories
+----------------
+Two roots are resolved **independently**:
+
+Transcript search root (``--data-dir``)
+    The root of the Claude data directory used to locate the session
+    transcript.  Transcripts live at
+    ``<data-dir>/projects/<project>/<session-id>.jsonl``.  Defaults to
+    ``~/.claude`` — the same default used by the Claude Code client and
+    the ``session-audit`` subcommand.  Pass ``--data-dir <path>`` to
+    override (useful in tests or non-standard installations).
+
+Variance output root
+    Where the combined JSON is written.  Defaults to
+    ``<base_dir>/variance/<session_id>.json`` where ``base_dir()`` is the
+    plugin-data directory (``CLAUDE_PROSPECTOR_BASE_DIR`` >
+    ``CLAUDE_PLUGIN_DATA`` > ``~/.claude/claude-prospector``).  Use
+    ``--out <path>`` to override the output location entirely.
+
+This decoupling means that
+``variance-save --session-id <id> --judgment-file <f>`` works with **no
+extra flags**: the transcript is found under ``~/.claude/projects/`` and
+the record is written to ``<plugin-base>/variance/<id>.json``.
+
+Combined JSON schema::
+
+    {
+        "session_id":   "<str>",
+        "original_ask": "<str | null>",
+        "prior_asks":   ["<str>", ...],
+        "actions":      [{"tool": "<Edit|Write|NotebookEdit>",
+                          "file_path": "<str>"}, ...],
+        "variance":     "<str>",
+        "not_done":     "<str>",
+        "severity":     <int | null>
+    }
+
+Fields:
+    session_id:
+        The Claude Code session identifier passed by the caller.
+    original_ask:
+        Verbatim first external user message, or ``null``.
+    prior_asks:
+        List of subsequent external user messages, in order.
+    actions:
+        Chronologically ordered Edit/Write/NotebookEdit tool_use events.
+    variance:
+        Human/LLM judgment describing what was done that was NOT asked.
+        Required.
+    not_done:
+        Human/LLM judgment describing what was asked but NOT done.
+        Required.
+    severity:
+        Integer severity rating (caller-defined scale), or ``null``.
+        Optional.
+
+Exit codes:
+    0  Success — path of written file printed to stdout.
+    1  IO failure — transcript missing, judgment unreadable, or OSError.
+    2  Validation failure — malformed or incomplete judgment JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from claude_prospector.cli.session_audit import (
+    audit_session,
+    resolve_session_id_to_path,
+)
+from claude_prospector.cli.session_summary import read_transcript
+from claude_prospector.paths import base_dir as _resolve_base_dir
+
+EXIT_OK = 0
+EXIT_IO_FAILURE = 1
+EXIT_VALIDATION_FAILURE = 2
+
+# ---------------------------------------------------------------------------
+# Type alias
+# ---------------------------------------------------------------------------
+
+JudgmentDict = dict[str, Any]
+VarianceRecord = dict[str, Any]
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+_REQUIRED_JUDGMENT_KEYS = ("variance", "not_done")
+
+
+def validate_judgment(judgment: JudgmentDict) -> None:
+    """Validate that a judgment dict contains all required keys.
+
+    Args:
+        judgment: Parsed judgment object from the caller.
+
+    Raises:
+        ValueError: When one or more required keys are absent.
+    """
+    missing = [k for k in _REQUIRED_JUDGMENT_KEYS if k not in judgment]
+    if missing:
+        raise ValueError(
+            f"Judgment is missing required key(s): " f"{', '.join(missing)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core combine logic — pure function, no I/O
+# ---------------------------------------------------------------------------
+
+
+def combine_variance(
+    session_id: str,
+    audit: dict[str, Any],
+    judgment: JudgmentDict,
+) -> VarianceRecord:
+    """Merge 1a audit data with judgment fields into the combined schema.
+
+    Pure function — no I/O.  Callers are responsible for obtaining the
+    audit data (via :func:`audit_session`) and a validated judgment dict
+    (via :func:`validate_judgment`).
+
+    ``severity`` defaults to ``None`` when absent from *judgment*.
+
+    Args:
+        session_id: The Claude Code session identifier.
+        audit: Dict with keys ``original_ask``, ``prior_asks``,
+            and ``actions`` (as returned by :func:`audit_session`).
+        judgment: Dict with keys ``variance`` (str), ``not_done`` (str),
+            and optionally ``severity`` (int or None).
+
+    Returns:
+        A combined :data:`VarianceRecord` dict matching the module-level
+        JSON schema.
+    """
+    return {
+        "session_id": session_id,
+        "original_ask": audit.get("original_ask"),
+        "prior_asks": audit.get("prior_asks", []),
+        "actions": audit.get("actions", []),
+        "variance": judgment["variance"],
+        "not_done": judgment["not_done"],
+        "severity": judgment.get("severity"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Session-id → path resolver (re-exported from session_audit)
+# ---------------------------------------------------------------------------
+
+# Re-export so callers and tests can import from a single place.
+__all__ = [
+    "build_parser",
+    "combine_variance",
+    "resolve_session_id_to_path",
+    "run",
+    "save_variance_record",
+    "validate_judgment",
+]
+
+
+# ---------------------------------------------------------------------------
+# Persist helper — the I/O layer
+# ---------------------------------------------------------------------------
+
+
+def save_variance_record(
+    session_id: str,
+    data_dir: Path,
+    judgment: JudgmentDict,
+    out_path: Path | None = None,
+    out_base_dir: Path | None = None,
+) -> Path:
+    """Load 1a audit data, merge with judgment, and write the combined record.
+
+    Resolves the transcript for *session_id* by calling
+    :func:`resolve_session_id_to_path` against *data_dir* (the Claude
+    data root, typically ``~/.claude``), then calls :func:`audit_session`
+    on the parsed entries, merges with *judgment* via
+    :func:`combine_variance`, and writes the result as UTF-8 JSON.
+
+    The write is idempotent: an existing file for the same session-id is
+    overwritten cleanly.
+
+    Output path resolution (highest-priority first):
+
+    1. *out_path* — explicit caller override.
+    2. ``<out_base_dir>/variance/<session_id>.json`` — when *out_base_dir*
+       is provided.
+    3. ``<base_dir()>/variance/<session_id>.json`` — default using the
+       :func:`~claude_prospector.paths.base_dir` plugin-data resolution.
+
+    The ``variance/`` subdirectory is created automatically when absent.
+
+    Note:
+        *data_dir* and the output root are **independent**.  *data_dir*
+        is used only to locate the session transcript; it does **not**
+        influence where the combined record is written.
+
+    Args:
+        session_id: The Claude Code session identifier.
+        data_dir: Root of the Claude data directory used to resolve the
+            transcript (e.g. ``~/.claude``).  The transcript is expected
+            at ``<data_dir>/projects/<project>/<session_id>.jsonl``.
+        judgment: Pre-validated judgment dict with keys ``variance``,
+            ``not_done``, and optionally ``severity``.
+        out_path: Explicit override for the output file path.  When
+            ``None`` the path is derived from *out_base_dir* (or
+            ``base_dir()`` when *out_base_dir* is also ``None``).
+        out_base_dir: Base directory for the default output path.  When
+            ``None`` and *out_path* is also ``None``, :func:`base_dir`
+            is called to resolve the plugin-data root.
+
+    Returns:
+        The resolved output path where the record was written.
+
+    Raises:
+        FileNotFoundError: When the session-id cannot be resolved.
+        ValueError: When the session-id is ambiguous (multiple matches).
+        OSError: On any I/O failure during read or write.
+    """
+    transcript_path = resolve_session_id_to_path(session_id, data_dir)
+    entries, _non_blank = read_transcript(transcript_path)
+    audit = audit_session(entries)
+
+    record = combine_variance(session_id, audit, judgment)
+
+    if out_path is None:
+        effective_base = (
+            out_base_dir if out_base_dir is not None else _resolve_base_dir()
+        )
+        variance_dir = effective_base / "variance"
+        variance_dir.mkdir(parents=True, exist_ok=True)
+        out_path = variance_dir / f"{session_id}.json"
+    else:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(out_path, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump(record, fh, indent=2, ensure_ascii=False)
+
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Judgment I/O — read from file or stdin
+# ---------------------------------------------------------------------------
+
+
+def _load_judgment(
+    judgment_file: str | None,
+) -> tuple[JudgmentDict | None, str | None]:
+    """Load and parse the judgment JSON from a file or stdin.
+
+    Reads from *judgment_file* when provided, otherwise reads from stdin.
+
+    Args:
+        judgment_file: Path string to a judgment JSON file, or ``None``
+            to read from stdin.
+
+    Returns:
+        A tuple ``(judgment, error_message)``.  On success,
+        ``judgment`` is the parsed dict and ``error_message`` is ``None``.
+        On failure, ``judgment`` is ``None`` and ``error_message``
+        describes the problem.
+    """
+    try:
+        if judgment_file:
+            raw = Path(judgment_file).read_text(encoding="utf-8")
+        else:
+            raw = sys.stdin.read()
+    except OSError as exc:
+        return None, f"cannot read judgment: {exc}"
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"judgment is not valid JSON: {exc}"
+
+    if not isinstance(parsed, dict):
+        return None, "judgment must be a JSON object, not an array or scalar"
+
+    return parsed, None
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def build_parser(
+    parent: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Register the 'variance-save' subparser and return it.
+
+    Judgment input is read from ``--judgment-file`` when provided;
+    otherwise stdin is consumed.  Exactly one of ``--judgment-file`` or
+    piped stdin must supply a JSON object.
+
+    Args:
+        parent: The subparsers action from the top-level argument parser.
+
+    Returns:
+        The configured variance-save ArgumentParser.
+    """
+    p = parent.add_parser(
+        "variance-save",
+        help=(
+            "Merge session-audit 1a output with LLM judgment fields "
+            "and write a combined variance record."
+        ),
+    )
+    p.add_argument(
+        "--session-id",
+        dest="session_id",
+        required=True,
+        help="Claude Code session-id to audit and save variance for.",
+    )
+    p.add_argument(
+        "--judgment-file",
+        dest="judgment_file",
+        default=None,
+        help=(
+            "Path to a JSON file containing judgment fields "
+            "(variance, not_done, severity).  "
+            "When omitted, judgment is read from stdin."
+        ),
+    )
+    p.add_argument(
+        "--data-dir",
+        dest="data_dir",
+        type=Path,
+        default=Path.home() / ".claude",
+        help=(
+            "Root of the Claude data directory used to locate the session "
+            "transcript.  The transcript is expected at "
+            "<data-dir>/projects/<project>/<session-id>.jsonl.  "
+            "Defaults to ~/.claude (the standard Claude Code data root)."
+        ),
+    )
+    p.add_argument(
+        "--out",
+        dest="out_path",
+        type=Path,
+        default=None,
+        help=(
+            "Explicit output path for the combined JSON record.  "
+            "When omitted, writes to "
+            "<base_dir>/variance/<session-id>.json where base_dir is "
+            "resolved via CLAUDE_PROSPECTOR_BASE_DIR > CLAUDE_PLUGIN_DATA "
+            "> ~/.claude/claude-prospector."
+        ),
+    )
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    """Entry point for the variance-save subcommand.
+
+    Resolves the session transcript, loads judgment from file or stdin,
+    combines with 1a audit data, and persists the record.  Prints the
+    written path to stdout on success.
+
+    Args:
+        args: Parsed CLI namespace.  Expected attributes:
+            ``args.session_id`` (str), ``args.judgment_file`` (str or
+            None), ``args.data_dir`` (Path or None),
+            ``args.out_path`` (Path or None).
+
+    Returns:
+        Integer exit code (0 on success, 1 on IO failure, 2 on
+        validation failure).
+    """
+    # Transcript search root: --data-dir (defaults to ~/.claude in parser).
+    data_dir: Path = args.data_dir
+
+    # Load and parse the judgment.
+    judgment, err = _load_judgment(getattr(args, "judgment_file", None))
+    if err:
+        print(f"variance-save: {err}", file=sys.stderr)
+        return EXIT_IO_FAILURE
+
+    # Validate judgment keys.
+    try:
+        validate_judgment(judgment)
+    except ValueError as exc:
+        print(f"variance-save: {exc}", file=sys.stderr)
+        return EXIT_VALIDATION_FAILURE
+
+    # Resolve session → transcript → audit → persist.
+    # Output root is base_dir() (plugin-data), independent of data_dir.
+    try:
+        out_path = save_variance_record(
+            session_id=args.session_id,
+            data_dir=data_dir,
+            judgment=judgment,
+            out_path=getattr(args, "out_path", None),
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"variance-save: {exc}", file=sys.stderr)
+        return EXIT_IO_FAILURE
+    except OSError as exc:
+        print(
+            f"variance-save: I/O error: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_IO_FAILURE
+
+    print(str(out_path), flush=True)
+    return EXIT_OK

--- a/tests/unit/test_variance_save.py
+++ b/tests/unit/test_variance_save.py
@@ -1,0 +1,1043 @@
+"""Tests for variance-save subcommand and the session-id resolver.
+
+Covers:
+- combine logic: 1a audit data + judgment fields → combined schema
+- session-id → path resolution (found / not-found / ambiguous-multiple)
+- judgment read from file and from stdin
+- malformed judgment JSON
+- missing required judgment keys (variance, not_done)
+- severity optional (defaults to null)
+- idempotent overwrite (re-run for same session-id overwrites)
+- variance/ dir created automatically
+- session-audit --session-id resolution path (CLI integration)
+- decoupled roots: transcript search root (~/.claude) vs output root (base_dir())
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _user_line(
+    text: str,
+    user_type: str = "external",
+    session_id: str = "test-session",
+) -> dict:
+    """Build a minimal user message dict for JSONL fixtures.
+
+    Args:
+        text: Plain-text message content.
+        user_type: The ``userType`` field.
+        session_id: The session identifier string.
+
+    Returns:
+        A dict shaped like a real Claude Code JSONL user entry.
+    """
+    return {
+        "type": "user",
+        "userType": user_type,
+        "sessionId": session_id,
+        "message": {
+            "role": "user",
+            "content": text,
+        },
+    }
+
+
+def _assistant_with_edit(
+    tool_name: str,
+    file_path: str,
+    session_id: str = "test-session",
+) -> dict:
+    """Build an assistant message containing a single edit tool_use block.
+
+    Args:
+        tool_name: e.g. ``"Edit"``, ``"Write"``, ``"NotebookEdit"``.
+        file_path: Target file path for the tool_use.
+        session_id: The session identifier string.
+
+    Returns:
+        A dict shaped like a real Claude Code JSONL assistant entry.
+    """
+    return {
+        "type": "assistant",
+        "sessionId": session_id,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu-1",
+                    "name": tool_name,
+                    "input": {"file_path": file_path},
+                }
+            ],
+        },
+    }
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    """Write a list of dicts as JSONL to *path*.
+
+    Args:
+        path: Destination file path.
+        lines: Dicts to serialise, one per line.
+    """
+    path.write_text(
+        "\n".join(json.dumps(line) for line in lines),
+        encoding="utf-8",
+    )
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[bytes]:
+    """Run claude_prospector as a module and capture raw output bytes.
+
+    Args:
+        *args: CLI arguments appended after the module name.
+
+    Returns:
+        CompletedProcess with stdout/stderr as bytes and returncode.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "claude_prospector", *args],
+        capture_output=True,
+    )
+
+
+def _run_cli_with_stdin(
+    stdin_data: bytes,
+    *args: str,
+) -> subprocess.CompletedProcess[bytes]:
+    """Run claude_prospector with bytes piped to stdin.
+
+    Args:
+        stdin_data: Bytes to pipe to the process stdin.
+        *args: CLI arguments appended after the module name.
+
+    Returns:
+        CompletedProcess with stdout/stderr as bytes and returncode.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "claude_prospector", *args],
+        input=stdin_data,
+        capture_output=True,
+    )
+
+
+def _import_variance_save():
+    """Import variance_save module; raise ImportError if absent."""
+    from claude_prospector.cli import variance_save  # noqa: PLC0415
+
+    return variance_save
+
+
+def _import_session_audit():
+    """Import session_audit module; raise ImportError if absent."""
+    from claude_prospector.cli import session_audit  # noqa: PLC0415
+
+    return session_audit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def claude_data_dir(tmp_path: Path) -> Path:
+    """Create a minimal ~/.claude-like data directory layout.
+
+    Returns:
+        The root data directory (the ``tmp_path``).
+    """
+    (tmp_path / "projects").mkdir()
+    return tmp_path
+
+
+@pytest.fixture()
+def transcript_in_data_dir(
+    claude_data_dir: Path,
+) -> tuple[Path, str]:
+    """Place a single-session transcript under projects/.
+
+    Creates ``projects/my-project/<session-id>.jsonl`` containing one
+    user ask and one Edit action.
+
+    Returns:
+        Tuple of ``(data_dir, session_id)``.
+    """
+    session_id = "abc-session-001"
+    project_dir = claude_data_dir / "projects" / "C--some-project"
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / f"{session_id}.jsonl"
+    _write_jsonl(
+        transcript,
+        [
+            _user_line("Implement the feature.", session_id=session_id),
+            _assistant_with_edit("Edit", "src/feature.py", session_id=session_id),
+        ],
+    )
+    return claude_data_dir, session_id
+
+
+@pytest.fixture()
+def good_judgment() -> dict:
+    """Return a minimal valid judgment dict."""
+    return {
+        "variance": "Added extra logging that was not requested.",
+        "not_done": "Tests were not written.",
+        "severity": 2,
+    }
+
+
+# ===========================================================================
+# TestVarianceSaveImport — module contract
+# ===========================================================================
+
+
+class TestVarianceSaveImport:
+    """variance_save module must exist and export the required symbols."""
+
+    def test_module_importable(self) -> None:
+        """variance_save module must be importable from the cli package."""
+        mod = _import_variance_save()
+        assert mod is not None
+
+    def test_build_parser_callable(self) -> None:
+        """variance_save must export a build_parser callable."""
+        mod = _import_variance_save()
+        assert callable(mod.build_parser)
+
+    def test_run_callable(self) -> None:
+        """variance_save must export a run callable."""
+        mod = _import_variance_save()
+        assert callable(mod.run)
+
+    def test_combine_variance_callable(self) -> None:
+        """variance_save must export a combine_variance pure function."""
+        mod = _import_variance_save()
+        assert callable(mod.combine_variance)
+
+
+# ===========================================================================
+# TestSessionIdResolver — resolve_session_id_to_path
+# ===========================================================================
+
+
+class TestSessionIdResolver:
+    """resolve_session_id_to_path must correctly map a session-id to a Path."""
+
+    def test_found_returns_path(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+    ) -> None:
+        """A known session-id resolves to the transcript path."""
+        data_dir, session_id = transcript_in_data_dir
+        mod = _import_variance_save()
+        result = mod.resolve_session_id_to_path(session_id, data_dir)
+        assert result.exists()
+        assert result.name == f"{session_id}.jsonl"
+
+    def test_not_found_raises_file_not_found(
+        self,
+        claude_data_dir: Path,
+    ) -> None:
+        """An unknown session-id raises FileNotFoundError."""
+        mod = _import_variance_save()
+        with pytest.raises(FileNotFoundError, match="no-such-id"):
+            mod.resolve_session_id_to_path("no-such-id", claude_data_dir)
+
+    def test_ambiguous_raises_value_error(
+        self,
+        claude_data_dir: Path,
+    ) -> None:
+        """Multiple matches for the same session-id raise ValueError."""
+        session_id = "duplicate-session"
+        # Place two transcripts with the same name in different projects
+        for proj in ("proj-a", "proj-b"):
+            d = claude_data_dir / "projects" / proj
+            d.mkdir(parents=True)
+            _write_jsonl(d / f"{session_id}.jsonl", [])
+        mod = _import_variance_save()
+        with pytest.raises(ValueError, match="duplicate-session"):
+            mod.resolve_session_id_to_path(session_id, claude_data_dir)
+
+    def test_error_message_names_the_session_id(
+        self,
+        claude_data_dir: Path,
+    ) -> None:
+        """FileNotFoundError message must include the session-id."""
+        session_id = "missing-xyz-999"
+        mod = _import_variance_save()
+        with pytest.raises(FileNotFoundError) as exc_info:
+            mod.resolve_session_id_to_path(session_id, claude_data_dir)
+        assert "missing-xyz-999" in str(exc_info.value)
+
+
+# ===========================================================================
+# TestSessionAuditSessionIdArg — --session-id on session-audit CLI
+# ===========================================================================
+
+
+class TestSessionAuditSessionIdArg:
+    """session-audit must accept --session-id as an alternative to --path."""
+
+    def test_session_id_resolves_and_exits_0(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+    ) -> None:
+        """--session-id resolving a known transcript exits 0 with JSON."""
+        data_dir, session_id = transcript_in_data_dir
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "session-audit",
+                "--session-id",
+                session_id,
+                "--data-dir",
+                str(data_dir),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout.decode("utf-8"))
+        assert parsed["original_ask"] == "Implement the feature."
+
+    def test_session_id_not_found_exits_nonzero(
+        self,
+        claude_data_dir: Path,
+    ) -> None:
+        """--session-id for a missing session exits non-zero."""
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(claude_data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "session-audit",
+                "--session-id",
+                "nonexistent-session-abc",
+                "--data-dir",
+                str(claude_data_dir),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode != 0
+
+    def test_path_and_session_id_mutually_exclusive(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Passing both --path and --session-id must exit non-zero."""
+        f = tmp_path / "x.jsonl"
+        _write_jsonl(f, [])
+        result = _run_cli(
+            "session-audit",
+            "--path",
+            str(f),
+            "--session-id",
+            "some-id",
+        )
+        assert result.returncode != 0
+
+    def test_neither_path_nor_session_id_exits_nonzero(self) -> None:
+        """Passing neither --path nor --session-id must exit non-zero."""
+        result = _run_cli("session-audit")
+        assert result.returncode != 0
+
+
+# ===========================================================================
+# TestCombineVariance — pure function combine_variance()
+# ===========================================================================
+
+
+class TestCombineVariance:
+    """combine_variance merges 1a audit data with judgment into full schema."""
+
+    def test_combined_schema_has_all_keys(
+        self,
+        good_judgment: dict,
+    ) -> None:
+        """combine_variance output has all required combined-schema keys."""
+        mod = _import_variance_save()
+        audit = {
+            "original_ask": "Do the thing.",
+            "prior_asks": [],
+            "actions": [],
+        }
+        result = mod.combine_variance("my-session-id", audit, good_judgment)
+        required = {
+            "session_id",
+            "original_ask",
+            "prior_asks",
+            "actions",
+            "variance",
+            "not_done",
+            "severity",
+        }
+        assert required == set(result.keys())
+
+    def test_session_id_in_output(
+        self,
+        good_judgment: dict,
+    ) -> None:
+        """session_id field in output equals the passed session-id."""
+        mod = _import_variance_save()
+        audit = {"original_ask": None, "prior_asks": [], "actions": []}
+        result = mod.combine_variance("sess-xyz", audit, good_judgment)
+        assert result["session_id"] == "sess-xyz"
+
+    def test_audit_fields_preserved(
+        self,
+        good_judgment: dict,
+    ) -> None:
+        """Audit fields (original_ask, prior_asks, actions) are preserved."""
+        mod = _import_variance_save()
+        audit = {
+            "original_ask": "Build the widget.",
+            "prior_asks": ["also do tests"],
+            "actions": [{"tool": "Edit", "file_path": "src/widget.py"}],
+        }
+        result = mod.combine_variance("sid", audit, good_judgment)
+        assert result["original_ask"] == "Build the widget."
+        assert result["prior_asks"] == ["also do tests"]
+        assert result["actions"] == [{"tool": "Edit", "file_path": "src/widget.py"}]
+
+    def test_judgment_fields_merged(self) -> None:
+        """Judgment fields (variance, not_done, severity) are merged."""
+        mod = _import_variance_save()
+        audit = {"original_ask": None, "prior_asks": [], "actions": []}
+        judgment = {
+            "variance": "Wrote extra docs.",
+            "not_done": "Tests skipped.",
+            "severity": 3,
+        }
+        result = mod.combine_variance("s1", audit, judgment)
+        assert result["variance"] == "Wrote extra docs."
+        assert result["not_done"] == "Tests skipped."
+        assert result["severity"] == 3
+
+    def test_severity_defaults_to_null_when_absent(self) -> None:
+        """severity defaults to None when not present in judgment."""
+        mod = _import_variance_save()
+        audit = {"original_ask": None, "prior_asks": [], "actions": []}
+        judgment = {"variance": "v", "not_done": "nd"}
+        result = mod.combine_variance("s2", audit, judgment)
+        assert result["severity"] is None
+
+    def test_severity_null_when_explicitly_null(self) -> None:
+        """severity=null in judgment becomes None in combined output."""
+        mod = _import_variance_save()
+        audit = {"original_ask": None, "prior_asks": [], "actions": []}
+        judgment = {"variance": "v", "not_done": "nd", "severity": None}
+        result = mod.combine_variance("s3", audit, judgment)
+        assert result["severity"] is None
+
+
+# ===========================================================================
+# TestJudgmentValidation — validate_judgment()
+# ===========================================================================
+
+
+class TestJudgmentValidation:
+    """validate_judgment must reject malformed or incomplete input."""
+
+    def test_valid_judgment_passes(self, good_judgment: dict) -> None:
+        """A complete judgment dict must not raise."""
+        mod = _import_variance_save()
+        mod.validate_judgment(good_judgment)  # must not raise
+
+    def test_missing_variance_raises_value_error(self) -> None:
+        """Missing 'variance' key raises ValueError."""
+        mod = _import_variance_save()
+        with pytest.raises(ValueError, match="variance"):
+            mod.validate_judgment({"not_done": "nd"})
+
+    def test_missing_not_done_raises_value_error(self) -> None:
+        """Missing 'not_done' key raises ValueError."""
+        mod = _import_variance_save()
+        with pytest.raises(ValueError, match="not_done"):
+            mod.validate_judgment({"variance": "v"})
+
+    def test_both_missing_raises_value_error(self) -> None:
+        """Both keys missing raises ValueError."""
+        mod = _import_variance_save()
+        with pytest.raises(ValueError):
+            mod.validate_judgment({"severity": 1})
+
+    def test_extra_keys_do_not_raise(self) -> None:
+        """Extra keys beyond the required set must not cause errors."""
+        mod = _import_variance_save()
+        mod.validate_judgment(
+            {"variance": "v", "not_done": "nd", "severity": 1, "extra": "ok"}
+        )
+
+
+# ===========================================================================
+# TestVarianceSaveIntegration — save_variance_record() I/O
+# ===========================================================================
+
+
+class TestVarianceSaveIntegration:
+    """save_variance_record writes the combined JSON to the variance dir."""
+
+    def test_writes_to_variance_subdir(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """Record is written to <out_base_dir>/variance/<session_id>.json."""
+        data_dir, session_id = transcript_in_data_dir
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_base_dir=data_dir,
+        )
+        expected = data_dir / "variance" / f"{session_id}.json"
+        assert out_path == expected
+        assert out_path.exists()
+
+    def test_written_json_is_valid(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """The written file must be valid JSON matching the combined schema."""
+        data_dir, session_id = transcript_in_data_dir
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_base_dir=data_dir,
+        )
+        with open(out_path, encoding="utf-8") as fh:
+            record = json.load(fh)
+        required = {
+            "session_id",
+            "original_ask",
+            "prior_asks",
+            "actions",
+            "variance",
+            "not_done",
+            "severity",
+        }
+        assert required == set(record.keys())
+        assert record["session_id"] == session_id
+        assert record["original_ask"] == "Implement the feature."
+        assert record["actions"][0]["file_path"] == "src/feature.py"
+
+    def test_variance_dir_created_if_absent(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """variance/ directory is created automatically if it doesn't exist."""
+        data_dir, session_id = transcript_in_data_dir
+        variance_dir = data_dir / "variance"
+        assert not variance_dir.exists()
+        mod = _import_variance_save()
+        mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_base_dir=data_dir,
+        )
+        assert variance_dir.is_dir()
+
+    def test_idempotent_overwrite(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+    ) -> None:
+        """Running twice for the same session-id overwrites the first record."""
+        data_dir, session_id = transcript_in_data_dir
+        mod = _import_variance_save()
+        first_judgment = {
+            "variance": "First variance.",
+            "not_done": "First not done.",
+            "severity": 1,
+        }
+        second_judgment = {
+            "variance": "Second variance.",
+            "not_done": "Second not done.",
+            "severity": 5,
+        }
+        mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=first_judgment,
+            out_base_dir=data_dir,
+        )
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=second_judgment,
+            out_base_dir=data_dir,
+        )
+        with open(out_path, encoding="utf-8") as fh:
+            record = json.load(fh)
+        assert record["variance"] == "Second variance."
+        assert record["severity"] == 5
+
+    def test_explicit_out_override(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        good_judgment: dict,
+        tmp_path: Path,
+    ) -> None:
+        """--out override directs the JSON file to an explicit path."""
+        data_dir, session_id = transcript_in_data_dir
+        explicit_out = tmp_path / "custom_output.json"
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_path=explicit_out,
+        )
+        assert out_path == explicit_out
+        assert explicit_out.exists()
+
+
+# ===========================================================================
+# TestVarianceSaveCLI — subprocess integration via run()
+# ===========================================================================
+
+
+class TestVarianceSaveCLI:
+    """variance-save subcommand must be wired and functional end-to-end."""
+
+    def test_variance_save_in_help_output(self) -> None:
+        """'python -m claude_prospector' help must list 'variance-save'."""
+        result = _run_cli()
+        combined = result.stdout.decode(
+            "utf-8", errors="replace"
+        ) + result.stderr.decode("utf-8", errors="replace")
+        assert "variance-save" in combined
+
+    def test_variance_save_help_exits_0(self) -> None:
+        """'variance-save --help' must exit 0."""
+        result = _run_cli("variance-save", "--help")
+        assert result.returncode == 0
+
+    def test_judgment_from_file_writes_record(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        good_judgment: dict,
+        tmp_path: Path,
+    ) -> None:
+        """--judgment-file reads judgment JSON and writes the record."""
+        data_dir, session_id = transcript_in_data_dir
+        judgment_file = tmp_path / "judgment.json"
+        judgment_file.write_text(json.dumps(good_judgment), encoding="utf-8")
+        out_path = tmp_path / "output.json"
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                session_id,
+                "--judgment-file",
+                str(judgment_file),
+                "--data-dir",
+                str(data_dir),
+                "--out",
+                str(out_path),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert out_path.exists()
+        written_path = result.stdout.decode("utf-8").strip()
+        assert written_path  # must print path to stdout
+
+    def test_judgment_from_stdin_writes_record(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        good_judgment: dict,
+        tmp_path: Path,
+    ) -> None:
+        """Judgment JSON piped to stdin writes the record."""
+        data_dir, session_id = transcript_in_data_dir
+        out_path = tmp_path / "output_stdin.json"
+        stdin_bytes = json.dumps(good_judgment).encode("utf-8")
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                session_id,
+                "--data-dir",
+                str(data_dir),
+                "--out",
+                str(out_path),
+            ],
+            input=stdin_bytes,
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert out_path.exists()
+
+    def test_malformed_judgment_json_exits_nonzero(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        tmp_path: Path,
+    ) -> None:
+        """Malformed judgment JSON exits non-zero."""
+        data_dir, session_id = transcript_in_data_dir
+        judgment_file = tmp_path / "bad.json"
+        judgment_file.write_text("}{not json", encoding="utf-8")
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                session_id,
+                "--judgment-file",
+                str(judgment_file),
+                "--data-dir",
+                str(data_dir),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode != 0
+
+    def test_missing_variance_key_exits_nonzero(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        tmp_path: Path,
+    ) -> None:
+        """Judgment missing 'variance' key exits non-zero."""
+        data_dir, session_id = transcript_in_data_dir
+        judgment_file = tmp_path / "missing_variance.json"
+        judgment_file.write_text(json.dumps({"not_done": "nd"}), encoding="utf-8")
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                session_id,
+                "--judgment-file",
+                str(judgment_file),
+                "--data-dir",
+                str(data_dir),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode != 0
+
+    def test_missing_not_done_key_exits_nonzero(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        tmp_path: Path,
+    ) -> None:
+        """Judgment missing 'not_done' key exits non-zero."""
+        data_dir, session_id = transcript_in_data_dir
+        judgment_file = tmp_path / "missing_not_done.json"
+        judgment_file.write_text(json.dumps({"variance": "v"}), encoding="utf-8")
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                session_id,
+                "--judgment-file",
+                str(judgment_file),
+                "--data-dir",
+                str(data_dir),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode != 0
+
+    def test_unknown_session_id_exits_nonzero(
+        self,
+        claude_data_dir: Path,
+        good_judgment: dict,
+        tmp_path: Path,
+    ) -> None:
+        """Unknown session-id passed to variance-save exits non-zero."""
+        judgment_file = tmp_path / "j.json"
+        judgment_file.write_text(json.dumps(good_judgment), encoding="utf-8")
+        import os
+
+        env = {
+            **os.environ,
+            "CLAUDE_PROSPECTOR_BASE_DIR": str(claude_data_dir),
+        }
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                "no-such-session-xyz",
+                "--judgment-file",
+                str(judgment_file),
+                "--data-dir",
+                str(claude_data_dir),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode != 0
+
+    def test_output_path_printed_to_stdout(
+        self,
+        transcript_in_data_dir: tuple[Path, str],
+        good_judgment: dict,
+        tmp_path: Path,
+    ) -> None:
+        """Written path is printed to stdout on success."""
+        data_dir, session_id = transcript_in_data_dir
+        judgment_file = tmp_path / "j.json"
+        judgment_file.write_text(json.dumps(good_judgment), encoding="utf-8")
+        out_path = tmp_path / "result.json"
+        import os
+
+        env = {**os.environ, "CLAUDE_PROSPECTOR_BASE_DIR": str(data_dir)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                session_id,
+                "--judgment-file",
+                str(judgment_file),
+                "--data-dir",
+                str(data_dir),
+                "--out",
+                str(out_path),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        stdout = result.stdout.decode("utf-8").strip()
+        assert str(out_path) in stdout or out_path.name in stdout
+
+
+# ===========================================================================
+# TestDecoupledRoots — transcript root vs output root are independent
+# ===========================================================================
+
+
+class TestDecoupledRoots:
+    """Transcript search root and variance output root must be independent.
+
+    The dual-root footgun: before this fix --data-dir was used for BOTH
+    locating transcripts (needs ~/.claude) AND placing output files
+    (needs base_dir()).  After the fix the two are decoupled:
+
+    - ``--data-dir`` defaults to ``~/.claude`` — used only for
+      transcript search (``projects/<id>.jsonl``).
+    - Output defaults to ``base_dir()/variance/<session_id>.json``
+      independently, controlled by ``CLAUDE_PROSPECTOR_BASE_DIR``.
+    """
+
+    @pytest.fixture()
+    def two_root_setup(self, tmp_path: Path) -> tuple[Path, Path, str]:
+        """Create two *distinct* temp directories: claude_data and base_dir.
+
+        claude_data mirrors the ~/.claude layout with a transcript.
+        base_dir is the plugin-data output root (distinct from claude_data).
+
+        Returns:
+            Tuple of (claude_data_dir, out_base_dir, session_id).
+        """
+        claude_data = tmp_path / "fake_claude_home"
+        out_base = tmp_path / "fake_plugin_data"
+        session_id = "split-roots-session-001"
+
+        # Set up a transcript under the claude_data root.
+        project_dir = claude_data / "projects" / "C--my-project"
+        project_dir.mkdir(parents=True)
+        transcript = project_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            transcript,
+            [
+                _user_line("Build the widget.", session_id=session_id),
+                _assistant_with_edit("Edit", "src/widget.py", session_id=session_id),
+            ],
+        )
+        out_base.mkdir(parents=True)
+        return claude_data, out_base, session_id
+
+    def test_transcript_found_in_claude_data_dir(
+        self,
+        two_root_setup: tuple[Path, Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """save_variance_record reads transcript from data_dir (not out_base_dir)."""
+        claude_data, out_base, session_id = two_root_setup
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=claude_data,
+            judgment=good_judgment,
+            out_base_dir=out_base,
+        )
+        # Output must exist and contain the transcript's content.
+        assert out_path.exists()
+        with open(out_path, encoding="utf-8") as fh:
+            record = json.load(fh)
+        assert record["original_ask"] == "Build the widget."
+
+    def test_output_lands_under_out_base_dir_not_data_dir(
+        self,
+        two_root_setup: tuple[Path, Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """Default output path is <out_base_dir>/variance/<id>.json, NOT under data_dir."""
+        claude_data, out_base, session_id = two_root_setup
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=claude_data,
+            judgment=good_judgment,
+            out_base_dir=out_base,
+        )
+        # Must be under out_base, NOT under claude_data.
+        assert out_path.is_relative_to(
+            out_base
+        ), f"Output {out_path} should be under out_base {out_base}"
+        assert not out_path.is_relative_to(
+            claude_data
+        ), f"Output {out_path} must NOT be under claude_data {claude_data}"
+        assert out_path == out_base / "variance" / f"{session_id}.json"
+
+    def test_roots_are_genuinely_different_directories(
+        self,
+        two_root_setup: tuple[Path, Path, str],
+    ) -> None:
+        """The two root directories in two_root_setup are distinct paths."""
+        claude_data, out_base, _session_id = two_root_setup
+        assert claude_data != out_base
+        # Neither is a parent of the other.
+        assert not out_base.is_relative_to(claude_data)
+        assert not claude_data.is_relative_to(out_base)
+
+    def test_cli_default_paths_use_separate_roots(
+        self,
+        two_root_setup: tuple[Path, Path, str],
+        good_judgment: dict,
+        tmp_path: Path,
+    ) -> None:
+        """CLI with no --out uses base_dir() for output while --data-dir is ~/.claude.
+
+        Uses CLAUDE_PROSPECTOR_BASE_DIR to redirect base_dir() to out_base,
+        and --data-dir to redirect transcript search to claude_data.
+        The two roots point at distinct directories; the output file must
+        land under out_base, not under claude_data.
+        """
+        import os
+
+        claude_data, out_base, session_id = two_root_setup
+        judgment_file = tmp_path / "j.json"
+        judgment_file.write_text(json.dumps(good_judgment), encoding="utf-8")
+
+        env = {
+            **os.environ,
+            "CLAUDE_PROSPECTOR_BASE_DIR": str(out_base),
+        }
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_prospector",
+                "variance-save",
+                "--session-id",
+                session_id,
+                "--judgment-file",
+                str(judgment_file),
+                "--data-dir",
+                str(claude_data),
+            ],
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr.decode("utf-8")
+        written_path = Path(result.stdout.decode("utf-8").strip())
+        assert written_path.is_relative_to(
+            out_base
+        ), f"Written path {written_path} should be under out_base {out_base}"
+        assert not written_path.is_relative_to(
+            claude_data
+        ), f"Written path {written_path} must NOT be under claude_data {claude_data}"
+
+    def test_data_dir_default_is_dot_claude(self) -> None:
+        """--data-dir default in the parser must be Path.home() / '.claude'."""
+        import argparse
+
+        mod = _import_variance_save()
+        top_parser = argparse.ArgumentParser()
+        subparsers = top_parser.add_subparsers()
+        mod.build_parser(subparsers)
+        args = top_parser.parse_args(
+            [
+                "variance-save",
+                "--session-id",
+                "dummy",
+                "--judgment-file",
+                "/dev/null",
+            ]
+        )
+        expected_default = Path.home() / ".claude"
+        assert (
+            args.data_dir == expected_default
+        ), f"Expected data_dir default {expected_default}, got {args.data_dir}"


### PR DESCRIPTION
## What

Implements #163 (1b) — the interpretive complement to #162's deterministic `session-audit`. Ships as a Claude Code **skill** (`session-analysis`), not a CLI subcommand: the in-session agent produces the `Variance` / `What was NOT done` judgment a parser can't compute, and a small persist helper writes a combined record for future drift-aggregation.

## Design decision: skill, not CLI/API

A skill runs inside the current Claude session, so the "fresh Claude run" #163 described is just the agent executing the skill. That means **no Stop-hook, no `anthropic` dependency, no `claude -p` subprocess** — and the ~1–3k-token cost is paid only when the skill is invoked. That *is* the opt-in cost-asymmetry the issue wanted, reached more directly than the original CLI framing. #163's body was updated to reflect this before implementation.

## Pieces

**Skill** (`skills/session-analysis/SKILL.md`) — interpretive, mirrors the existing `usage-analysis` pattern. Loads 1a's extract, reads the transcript for context, forms an evidence-bound judgment, persists it, and reports. Manual-invocation V1 (auto-trigger on `prior_asks>0` deferred to a follow-up).

**Python plumbing** (deterministic, tested):
- `variance-save` subcommand — resolves `--session-id` → transcript, re-runs 1a internally, merges caller judgment `{variance, not_done, severity}` (from `--judgment-file` or stdin), writes combined JSON to `<plugin-data>/variance/<id>.json`. **Transcript-search root (`~/.claude`) and output root (`base_dir()`) are independent** — default invocation needs no extra flags.
- `session-audit --session-id` — resolve an id → transcript (mutually exclusive with `--path`), via one id→path resolver shared by both commands.

**Combined schema** (the artifact #63 drift-aggregation will consume):
```json
{
  "session_id": "<id>", "original_ask": "<str|null>", "prior_asks": ["<str>"],
  "actions": [{"tool": "<Edit|Write|NotebookEdit>", "file_path": "<str>"}],
  "variance": "<str>", "not_done": "<str>", "severity": "<int|null>"
}
```

## Resolved design questions (were open on #163)

- **Invocation** — skill (in-session); no new dependency.
- **Model** — runs in the session's model; skill recommends Sonnet+ for judgment. No `--model` flag.
- **Trigger surface** — manual V1; auto-trigger deferred.

## Verification

- Tests: **565 → 607** (+42), 0 regressions.
- `uv run ruff check .` clean; `uv run ruff format --check .` clean; `uv run pytest` green (re-verified by router with the whole-repo gate forms CI uses — both `ruff check .` and `ruff format --check .`).
- `claude plugin validate` passes (the one warning, root `CLAUDE.md`, is pre-existing and unrelated).

## Out of scope (per #163)

Auto-invocation on every session (re-introduces the hook's cost); drift aggregation / dashboards (separate follow-up under #63).

Closes #163

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
