### PR TITLE
feat(release): automate GitHub Release creation via workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,3 +134,45 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  # ---------------------------------------------------------------------------
+  # Create GitHub Release (stable tags only — same guard as publish-pypi).
+  # Runs after publish-pypi succeeds so a broken wheel still blocks the
+  # release.  Extracts release notes from CHANGELOG.md via the helper at
+  # scripts/extract-changelog-section.py.
+  # ---------------------------------------------------------------------------
+  github-release:
+    name: Create GitHub Release
+    needs: [publish-pypi]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref, '-rc') && !contains(github.ref, '-alpha') && !contains(github.ref, '-beta') }}
+    permissions:
+      contents: write  # Required to create a GitHub Release
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          # Strip the leading 'refs/tags/' prefix to get e.g. "v0.10.0"
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Strip the leading 'v' for the extractor (accepts both forms)
+          VERSION="${TAG#v}"
+          python scripts/extract-changelog-section.py "$VERSION" CHANGELOG.md \
+            > /tmp/release-notes.md
+          echo "--- release notes for $TAG ---"
+          cat /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --verify-tag \
+            --title "$TAG" \
+            --notes-file /tmp/release-notes.md \
+            --latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Automated GitHub Release creation** in `release.yml` (#214). A new
+  `github-release` workflow job runs after `publish-pypi` succeeds on
+  stable tags (same `!contains(-rc/-alpha/-beta)` guard). It extracts the
+  matching `## [X.Y.Z]` section from `CHANGELOG.md` via
+  `scripts/extract-changelog-section.py` and creates the GitHub Release via
+  `gh release create --verify-tag --latest`. Pre-release tags continue to
+  publish to TestPyPI only and do not produce a GitHub Release.
+- `scripts/extract-changelog-section.py` — helper script that extracts a
+  single version's section from a Keep-a-Changelog formatted file. Accepts
+  `<version>` (with or without a leading `v`) and an optional
+  `<changelog-path>`; exits non-zero when the version is absent. Used by the
+  `github-release` workflow job; covered by unit tests in
+  `tests/unit/test_extract_changelog_section.py`.
+
+### Changed
+
+- `docs/release-process.md` updated with a post-release checklist, a revised
+  step 5 (verify all four workflow jobs), a new step 5a (verify/fallback for
+  GitHub Release), an updated Quick Reference Card, and a new Footguns entry
+  documenting the v0.8.2–v0.10.0 incident where GitHub Releases were silently
+  skipped (#214).
+
 ## [0.10.0] - 2026-05-30
 
 ### Added

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -15,6 +15,12 @@ The **Quick reference card** at the end is the section to keep open during a rel
 - [ ] `.claude-plugin/plugin.json` `version` = target version
 - [ ] Release PR body lists `Closes #N` for every issue being closed (one keyword per issue)
 
+## Post-release checklist
+
+- [ ] `publish-pypi` workflow job is green
+- [ ] `github-release` workflow job is green — GitHub Release exists at `https://github.com/glitchwerks/claude-prospector/releases/tag/vX.Y.Z`
+- [ ] Marketplace pin bumped (steps 7–9)
+
 ---
 
 ## Release classification
@@ -54,7 +60,7 @@ git -C <repo> tag -a vX.Y.Z <merge-sha> -m "vX.Y.Z"
 git -C <repo> push origin vX.Y.Z
 ```
 
-This triggers `release.yml`: build → wheel-smoke → publish-pypi, in sequence. Pre-release tags (`-rc`, `-alpha`, `-beta`) publish to TestPyPI instead.
+This triggers `release.yml`: build → wheel-smoke → publish-pypi → github-release, in sequence. Pre-release tags (`-rc`, `-alpha`, `-beta`) publish to TestPyPI instead and do **not** create a GitHub Release.
 
 **5. Wait for the release workflow**
 
@@ -63,7 +69,28 @@ gh run list --repo glitchwerks/claude-prospector
 gh run view <run-id> --repo glitchwerks/claude-prospector
 ```
 
-All three jobs must be green. The `wheel-smoke` job gates publish: it installs the wheel into a fresh venv and runs `python -m claude_prospector dashboard` against a fixture. Do not proceed until publish-pypi is green.
+All four jobs must be green: `build`, `wheel-smoke`, `publish-pypi`, and `github-release`. The `wheel-smoke` job gates `publish-pypi`; `publish-pypi` gates `github-release`. Do not proceed until all four are green.
+
+**5a. Verify the GitHub Release was created**
+
+The `github-release` workflow job creates the Release automatically. Verify it exists:
+
+```bash
+gh release view vX.Y.Z --repo glitchwerks/claude-prospector
+```
+
+If the `github-release` job failed, create the Release manually using the extracted release notes:
+
+```bash
+python scripts/extract-changelog-section.py X.Y.Z CHANGELOG.md > /tmp/release-notes.md
+gh release create vX.Y.Z --repo glitchwerks/claude-prospector \
+  --verify-tag \
+  --title "vX.Y.Z" \
+  --notes-file /tmp/release-notes.md \
+  --latest
+```
+
+Do not proceed to step 6 until the GitHub Release exists.
 
 **6. Dereference the annotated tag**
 
@@ -166,6 +193,16 @@ Then open a new Claude Code session and run `/reload-plugins`.
 
 ---
 
+### GitHub Releases were silently skipped for v0.8.2–v0.10.0
+
+**Rule:** Always verify the `github-release` workflow job is green after pushing a tag. Do not consider a release complete until a GitHub Release exists at `https://github.com/glitchwerks/claude-prospector/releases/tag/vX.Y.Z`.
+
+**Source of truth:** Issue #214. Tags and PyPI packages were shipped for v0.8.2, v0.9.0, v0.9.1, and v0.10.0 with no corresponding GitHub Releases, because neither the runbook nor the workflow had a GitHub Release step. The releases were backfilled manually from `CHANGELOG.md`.
+
+**Comply:** The `github-release` workflow job (added in PR #214) automates this. Verify it is green in step 5 above. If it fails, use the manual fallback in step 5a before proceeding.
+
+---
+
 ## Rollback procedure
 
 1. **Yank from PyPI** — use the PyPI web UI (`https://pypi.org/manage/project/claude-prospector/releases/`) to yank the version. Yank hides it from unconstrained installs; Delete is irreversible.
@@ -191,7 +228,10 @@ Pre-flight
     git -C <repo> tag -a vX.Y.Z <sha> -m "vX.Y.Z"
 4.  git -C <repo> push origin vX.Y.Z
 5.  gh run view <run-id> --repo glitchwerks/claude-prospector
-    # wait for build + wheel-smoke + publish-pypi all green
+    # wait for build + wheel-smoke + publish-pypi + github-release all green
+5a. gh release view vX.Y.Z --repo glitchwerks/claude-prospector
+    # verify GitHub Release exists; use manual fallback in step 5a if job failed
+    # [ ] GitHub Release at https://github.com/glitchwerks/claude-prospector/releases/tag/vX.Y.Z
 6.  git -C <repo> rev-parse 'vX.Y.Z^{commit}'   # commit SHA (not tag-obj SHA)
 7.  Open PR on glitchwerks/plugins: bump sha + version in marketplace.json
 8.  Merge marketplace PR

--- a/scripts/extract-changelog-section.py
+++ b/scripts/extract-changelog-section.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Extract a single version's section from a Keep-a-Changelog formatted file.
+
+Usage::
+
+    python scripts/extract-changelog-section.py <version> [<changelog-path>]
+
+Arguments:
+    version: The version to extract, e.g. ``0.10.0`` or ``v0.10.0`` (the
+        leading ``v`` is stripped automatically).
+    changelog-path: Path to the CHANGELOG file. Defaults to ``CHANGELOG.md``
+        relative to the current working directory.
+
+Exit codes:
+    0: Section found; content written to stdout.
+    1: Version not found in the file, or the CHANGELOG file does not exist.
+
+The output is the content of the ``## [X.Y.Z]`` section — everything after the
+heading line up to (but not including) the next ``## `` heading — with leading
+and trailing blank lines stripped.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def extract_section(changelog_text: str, version: str) -> str | None:
+    """Return the body of the ``## [version]`` section, or ``None`` if absent.
+
+    The section starts on the line immediately after the matching
+    ``## [X.Y.Z]`` heading and ends just before the next ``## `` heading
+    (or at the end of the file, whichever comes first).  Leading and
+    trailing blank lines are stripped from the result.
+
+    Args:
+        changelog_text: Full text of the CHANGELOG file.
+        version: Version to look for (without a leading ``v``).
+
+    Returns:
+        The section body as a stripped string, or ``None`` when the version
+        is not present in the file.
+    """
+    # Match lines like "## [0.10.0] - 2026-05-30" (date is optional).
+    heading_re = re.compile(r"^## \[", re.MULTILINE)
+    target_re = re.compile(
+        r"^## \[" + re.escape(version) + r"\]",
+        re.MULTILINE,
+    )
+
+    match = target_re.search(changelog_text)
+    if match is None:
+        return None
+
+    # Find the start of the section body (the line after the heading).
+    section_start = changelog_text.index("\n", match.start()) + 1
+
+    # Find the next ## heading after the current one.
+    next_heading = heading_re.search(changelog_text, section_start)
+    if next_heading:
+        section_body = changelog_text[section_start : next_heading.start()]
+    else:
+        section_body = changelog_text[section_start:]
+
+    # Strip link-reference definitions that appear at the bottom of some sections.
+    # Lines like "[0.10.0]: https://..."  are not release notes.
+    lines = section_body.splitlines()
+    content_lines = [
+        line
+        for line in lines
+        if not re.match(r"^\[[\d.]+\]:\s+https?://", line)
+    ]
+
+    return "\n".join(content_lines).strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the changelog extractor.
+
+    Args:
+        argv: Command-line arguments. Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        Exit code: 0 on success, 1 on failure.
+    """
+    args = argv if argv is not None else sys.argv[1:]
+
+    if len(args) < 1:
+        print(
+            "Usage: extract-changelog-section.py <version> [<changelog-path>]",
+            file=sys.stderr,
+        )
+        return 1
+
+    raw_version = args[0]
+    # Strip a leading 'v' so both "0.10.0" and "v0.10.0" are accepted.
+    version = raw_version.lstrip("v")
+
+    changelog_path = Path(args[1]) if len(args) >= 2 else Path("CHANGELOG.md")
+
+    if not changelog_path.exists():
+        print(
+            f"error: CHANGELOG file not found: {changelog_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    changelog_text = changelog_path.read_text(encoding="utf-8")
+    section = extract_section(changelog_text, version)
+
+    if section is None:
+        print(
+            f"error: version {version!r} not found in {changelog_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(section)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/extract-changelog-section.py
+++ b/scripts/extract-changelog-section.py
@@ -68,9 +68,7 @@ def extract_section(changelog_text: str, version: str) -> str | None:
     # Lines like "[0.10.0]: https://..."  are not release notes.
     lines = section_body.splitlines()
     content_lines = [
-        line
-        for line in lines
-        if not re.match(r"^\[[\d.]+\]:\s+https?://", line)
+        line for line in lines if not re.match(r"^\[[\d.]+\]:\s+https?://", line)
     ]
 
     return "\n".join(content_lines).strip()

--- a/tests/unit/test_extract_changelog_section.py
+++ b/tests/unit/test_extract_changelog_section.py
@@ -1,0 +1,156 @@
+"""Tests for scripts/extract-changelog-section.py.
+
+Covers: normal extraction, missing version, first version (no next heading),
+multiple versions in file, CLI exit code, and blank/whitespace trimming.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "extract-changelog-section.py"
+
+# ---------------------------------------------------------------------------
+# Fixture CHANGELOG content used across tests
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CHANGELOG = textwrap.dedent(
+    """\
+    # Changelog
+
+    All notable changes to this project will be documented in this file.
+
+    ## [Unreleased]
+
+    ## [0.10.0] - 2026-05-30
+
+    ### Added
+
+    - Added `audit` subcommand (closes #191).
+    - **cwd-first project names** in the dashboard (#203, closes #205).
+
+    ### Fixed
+
+    - **Today/daily activity bucketed by local timezone** (#197, closes #199).
+
+    ## [0.9.1] - 2026-05-26
+
+    ### Fixed
+
+    - **Dashboard `--window` no longer filters out prior-period data** (#188).
+
+    ## [0.9.0] - 2026-05-26
+
+    ### Added
+
+    - **Economy v1 dashboard** (#144).
+
+    [0.10.0]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.10.0
+    [0.9.1]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.9.1
+    [0.9.0]: https://github.com/glitchwerks/claude-prospector/releases/tag/v0.9.0
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _run_script(
+    changelog_text: str,
+    version: str,
+    tmp_path: Path,
+) -> subprocess.CompletedProcess:
+    """Write a temporary CHANGELOG and run the extractor against it.
+
+    Args:
+        changelog_text: Full text content of the CHANGELOG.
+        version: Version string to extract (e.g. ``"0.10.0"``).
+        tmp_path: Pytest temporary directory for the CHANGELOG file.
+
+    Returns:
+        The ``CompletedProcess`` result from the script invocation.
+    """
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog_text, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), version, str(changelog_path)],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractChangelogSection:
+    """Unit tests for the changelog section extractor."""
+
+    def test_extracts_middle_version(self, tmp_path: Path) -> None:
+        """Extracts the content of 0.9.1 (sandwiched between two other versions)."""
+        result = _run_script(_SAMPLE_CHANGELOG, "0.9.1", tmp_path)
+        assert result.returncode == 0, result.stderr
+        output = result.stdout.strip()
+        # Should contain the 0.9.1 content
+        assert "Dashboard `--window`" in output
+        assert "#188" in output
+        # Should NOT contain content from 0.10.0 or 0.9.0
+        assert "audit" not in output
+        assert "Economy v1" not in output
+
+    def test_extracts_latest_version(self, tmp_path: Path) -> None:
+        """Extracts the latest (most recent) version section at the top."""
+        result = _run_script(_SAMPLE_CHANGELOG, "0.10.0", tmp_path)
+        assert result.returncode == 0, result.stderr
+        output = result.stdout.strip()
+        assert "audit" in output
+        assert "closes #191" in output
+        # Must not bleed into 0.9.1
+        assert "Dashboard `--window`" not in output
+
+    def test_extracts_oldest_version(self, tmp_path: Path) -> None:
+        """Extracts the last version in the file (no following ## heading)."""
+        result = _run_script(_SAMPLE_CHANGELOG, "0.9.0", tmp_path)
+        assert result.returncode == 0, result.stderr
+        output = result.stdout.strip()
+        assert "Economy v1" in output
+        assert "#144" in output
+        # Must not include the link reference section
+        assert "https://github.com" not in output
+
+    def test_strips_leading_and_trailing_blank_lines(self, tmp_path: Path) -> None:
+        """Output has no leading or trailing blank lines."""
+        result = _run_script(_SAMPLE_CHANGELOG, "0.9.1", tmp_path)
+        assert result.returncode == 0, result.stderr
+        output = result.stdout
+        assert not output.startswith("\n")
+        assert output.endswith("\n") or output == output.strip()
+
+    def test_missing_version_exits_nonzero(self, tmp_path: Path) -> None:
+        """Exits with a non-zero code and writes an error if version not found."""
+        result = _run_script(_SAMPLE_CHANGELOG, "1.99.0", tmp_path)
+        assert result.returncode != 0
+        assert "1.99.0" in result.stderr or "not found" in result.stderr.lower()
+
+    def test_version_with_v_prefix_accepted(self, tmp_path: Path) -> None:
+        """Version prefixed with 'v' (e.g. v0.10.0) is accepted and normalised."""
+        result = _run_script(_SAMPLE_CHANGELOG, "v0.10.0", tmp_path)
+        assert result.returncode == 0, result.stderr
+        assert "audit" in result.stdout
+
+    def test_missing_changelog_file_exits_nonzero(self, tmp_path: Path) -> None:
+        """Exits with a non-zero code when the CHANGELOG file does not exist."""
+        missing = tmp_path / "DOES_NOT_EXIST.md"
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "0.10.0", str(missing)],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode != 0


### PR DESCRIPTION
## Summary

- Adds a `github-release` workflow job to `release.yml` that runs after `publish-pypi` succeeds on stable tags. It extracts the matching `## [X.Y.Z]` section from `CHANGELOG.md` using `scripts/extract-changelog-section.py` and creates the GitHub Release via `gh release create --verify-tag --latest`.
- Adds `scripts/extract-changelog-section.py` — a stdlib-only helper for extracting a single version section from a Keep-a-Changelog file. Covered by 7 unit tests.
- Updates `docs/release-process.md` with a post-release checklist, revised step 5 (4 jobs to wait for), new step 5a (verify/manual fallback for the GitHub Release), updated Quick Reference Card, and a Footguns entry documenting the v0.8.2–v0.10.0 incident.
- Adds `CHANGELOG.md` `[Unreleased]` entry for all additions.

## Design decisions

**`gh release create` (CLI) vs `softprops/action-gh-release` (Action):** The `gh` CLI is already available in all GitHub-hosted runners (`ubuntu-latest`) and requires no pinned action SHA to manage. This repo's workflow already pins actions to commit SHAs for supply-chain safety — adding another pinned action would need a verified SHA, whereas `gh` is part of the runner image and maintained by GitHub. Using `gh` keeps the job simple and avoids an extra dependency.

**Python script vs inline shell:** The extractor has clear boundaries (version not found → non-zero exit), multiple cases to cover (first/last/middle version, v-prefix, missing file), and needs unit tests. An inline `awk`/`sed` one-liner is hard to test and opaque to read. A Python script in `scripts/` is natural for a Python-first repo and integrates with the ruff + pytest CI gates.

**Pre-release guard:** Uses `!contains(github.ref, '-rc') && !contains(github.ref, '-alpha') && !contains(github.ref, '-beta')` — exactly mirroring the `publish-pypi` job's guard — so the GitHub Release is created if and only if PyPI publication occurs.

## Test plan

- [x] `uv run ruff check src/ tests/ scripts/` — clean
- [x] `uv run pytest` — 614 passed, 2 skipped, 1 warning (607 baseline + 7 new extractor tests; no regressions)
- [x] YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — OK
- [ ] Workflow runs on next stable tag push (cannot simulate locally; `github-release` job will be visible in Actions)

Closes #214

> 🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_