### PR TITLE
feat(variance-save): add `timestamp` field to variance records (Phase 0, #217)

### DIFF
--- a/src/claude_prospector/cli/variance_save.py
+++ b/src/claude_prospector/cli/variance_save.py
@@ -133,9 +133,7 @@ def _earliest_transcript_timestamp(
         ISO-8601 UTC string for the earliest entry timestamp, or
         ``None`` when no entry carries a ``"timestamp"`` key.
     """
-    ts_candidates = [
-        e["timestamp"] for e in entries if "timestamp" in e
-    ]
+    ts_candidates = [e["timestamp"] for e in entries if "timestamp" in e]
     if not ts_candidates:
         return None
 

--- a/src/claude_prospector/cli/variance_save.py
+++ b/src/claude_prospector/cli/variance_save.py
@@ -44,7 +44,8 @@ Combined JSON schema::
                           "file_path": "<str>"}, ...],
         "variance":     "<str>",
         "not_done":     "<str>",
-        "severity":     <int | null>
+        "severity":     <int | null>,
+        "timestamp":    "<ISO-8601 UTC str | null>"
     }
 
 Fields:
@@ -65,6 +66,10 @@ Fields:
     severity:
         Integer severity rating (caller-defined scale), or ``null``.
         Optional.
+    timestamp:
+        ISO-8601 UTC string of the earliest transcript entry that carries
+        a top-level ``"timestamp"`` key, or ``null`` when no such entry
+        exists.  Derived from the raw transcript entries at write time.
 
 Exit codes:
     0  Success — path of written file printed to stdout.
@@ -77,6 +82,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -97,6 +103,61 @@ EXIT_VALIDATION_FAILURE = 2
 
 JudgmentDict = dict[str, Any]
 VarianceRecord = dict[str, Any]
+
+# ---------------------------------------------------------------------------
+# Timestamp derivation — pure helper, no I/O
+# ---------------------------------------------------------------------------
+
+
+def _earliest_transcript_timestamp(
+    entries: list[dict],
+) -> str | None:
+    """Derive the earliest timestamp from raw transcript entry dicts.
+
+    Collects every top-level ``"timestamp"`` value found in *entries*,
+    normalises each using the ``Z``→``+00:00`` substitution (mirroring
+    ``parser._parse_timestamp``), takes the minimum, and returns it as
+    an ISO-8601 UTC string.
+
+    When no entry carries a ``"timestamp"`` key the function returns
+    ``None`` — the aggregator's mtime fallback handles this at read time.
+
+    The entries are **raw** ``json.loads`` dicts as returned by
+    :func:`~claude_prospector.cli.session_summary.read_transcript`;
+    they are not ``parser.Message`` objects.
+
+    Args:
+        entries: List of raw dicts parsed from a JSONL transcript.
+
+    Returns:
+        ISO-8601 UTC string for the earliest entry timestamp, or
+        ``None`` when no entry carries a ``"timestamp"`` key.
+    """
+    ts_candidates = [
+        e["timestamp"] for e in entries if "timestamp" in e
+    ]
+    if not ts_candidates:
+        return None
+
+    # Normalise each candidate string (Z → +00:00) and parse to datetime.
+    parsed: list[datetime] = []
+    for raw_ts in ts_candidates:
+        normalised = raw_ts.replace("Z", "+00:00")
+        try:
+            parsed.append(datetime.fromisoformat(normalised))
+        except ValueError:
+            # Malformed timestamp — skip this entry.
+            continue
+
+    if not parsed:
+        return None
+
+    earliest = min(parsed)
+    # Ensure result is UTC-aware and format as ISO-8601.
+    if earliest.tzinfo is None:
+        earliest = earliest.replace(tzinfo=timezone.utc)
+    return earliest.isoformat()
+
 
 # ---------------------------------------------------------------------------
 # Validation
@@ -130,6 +191,7 @@ def combine_variance(
     session_id: str,
     audit: dict[str, Any],
     judgment: JudgmentDict,
+    timestamp: str | None = None,
 ) -> VarianceRecord:
     """Merge 1a audit data with judgment fields into the combined schema.
 
@@ -138,6 +200,9 @@ def combine_variance(
     (via :func:`validate_judgment`).
 
     ``severity`` defaults to ``None`` when absent from *judgment*.
+    ``timestamp`` defaults to ``None`` (legacy path); pass the value
+    returned by :func:`_earliest_transcript_timestamp` from
+    :func:`save_variance_record` to populate the field.
 
     Args:
         session_id: The Claude Code session identifier.
@@ -145,6 +210,10 @@ def combine_variance(
             and ``actions`` (as returned by :func:`audit_session`).
         judgment: Dict with keys ``variance`` (str), ``not_done`` (str),
             and optionally ``severity`` (int or None).
+        timestamp: ISO-8601 UTC string of the earliest transcript entry
+            timestamp, or ``None`` when no entry carries a timestamp.
+            Defaults to ``None`` so existing positional callers are
+            unaffected.
 
     Returns:
         A combined :data:`VarianceRecord` dict matching the module-level
@@ -158,6 +227,7 @@ def combine_variance(
         "variance": judgment["variance"],
         "not_done": judgment["not_done"],
         "severity": judgment.get("severity"),
+        "timestamp": timestamp,
     }
 
 
@@ -240,7 +310,11 @@ def save_variance_record(
     entries, _non_blank = read_transcript(transcript_path)
     audit = audit_session(entries)
 
-    record = combine_variance(session_id, audit, judgment)
+    # Derive earliest timestamp from raw entry dicts while `entries` is in
+    # scope (raw json.loads dicts — not parser.Message objects).
+    timestamp = _earliest_transcript_timestamp(entries)
+
+    record = combine_variance(session_id, audit, judgment, timestamp=timestamp)
 
     if out_path is None:
         effective_base = (

--- a/tests/unit/test_variance_save.py
+++ b/tests/unit/test_variance_save.py
@@ -378,7 +378,10 @@ class TestCombineVariance:
         self,
         good_judgment: dict,
     ) -> None:
-        """combine_variance output has all required combined-schema keys."""
+        """combine_variance output has all required combined-schema keys.
+
+        Phase 0: schema now includes 'timestamp'.
+        """
         mod = _import_variance_save()
         audit = {
             "original_ask": "Do the thing.",
@@ -394,8 +397,32 @@ class TestCombineVariance:
             "variance",
             "not_done",
             "severity",
+            "timestamp",
         }
         assert required == set(result.keys())
+
+    def test_timestamp_default_is_none(
+        self,
+        good_judgment: dict,
+    ) -> None:
+        """timestamp defaults to None when not passed to combine_variance."""
+        mod = _import_variance_save()
+        audit = {"original_ask": None, "prior_asks": [], "actions": []}
+        result = mod.combine_variance("s-ts-default", audit, good_judgment)
+        assert result["timestamp"] is None
+
+    def test_timestamp_populated_when_passed(
+        self,
+        good_judgment: dict,
+    ) -> None:
+        """timestamp field is preserved when a value is passed explicitly."""
+        mod = _import_variance_save()
+        audit = {"original_ask": None, "prior_asks": [], "actions": []}
+        ts = "2026-01-15T10:30:00+00:00"
+        result = mod.combine_variance(
+            "s-ts-value", audit, good_judgment, timestamp=ts
+        )
+        assert result["timestamp"] == ts
 
     def test_session_id_in_output(
         self,
@@ -543,6 +570,7 @@ class TestVarianceSaveIntegration:
             "variance",
             "not_done",
             "severity",
+            "timestamp",
         }
         assert required == set(record.keys())
         assert record["session_id"] == session_id
@@ -1041,3 +1069,185 @@ class TestDecoupledRoots:
         assert (
             args.data_dir == expected_default
         ), f"Expected data_dir default {expected_default}, got {args.data_dir}"
+
+
+# ===========================================================================
+# TestTimestampProducer — Phase 0: timestamp derivation in save_variance_record
+# ===========================================================================
+
+
+def _user_line_with_ts(
+    text: str,
+    timestamp: str,
+    session_id: str = "test-session",
+) -> dict:
+    """Build a minimal user message dict with a top-level timestamp.
+
+    Args:
+        text: Plain-text message content.
+        timestamp: ISO-8601 timestamp string.
+        session_id: The session identifier string.
+
+    Returns:
+        A dict shaped like a real Claude Code JSONL user entry with
+        a top-level ``"timestamp"`` key.
+    """
+    return {
+        "type": "user",
+        "userType": "external",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "message": {"role": "user", "content": text},
+    }
+
+
+class TestTimestampProducer:
+    """save_variance_record must compute earliest transcript timestamp.
+
+    Phase 0 regression tests:
+    - Earliest timestamp from raw entry dicts is written to the record.
+    - When no entry carries a timestamp, the field is null.
+    - The saved record JSON file includes the ``timestamp`` key.
+    """
+
+    @pytest.fixture()
+    def transcript_with_timestamps(
+        self,
+        tmp_path: Path,
+    ) -> tuple[Path, str]:
+        """Transcript where entries carry ``timestamp`` keys.
+
+        Two entries: later timestamp first, earlier timestamp second.
+        The producer must pick the earliest (second entry).
+
+        Returns:
+            Tuple of ``(data_dir, session_id)``.
+        """
+        session_id = "ts-session-001"
+        project_dir = tmp_path / "projects" / "C--ts-project"
+        project_dir.mkdir(parents=True)
+        transcript = project_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            transcript,
+            [
+                _user_line_with_ts(
+                    "Later ask.",
+                    "2026-03-10T12:00:00Z",
+                    session_id=session_id,
+                ),
+                _user_line_with_ts(
+                    "Earlier ask.",
+                    "2026-03-10T09:15:30Z",
+                    session_id=session_id,
+                ),
+                _assistant_with_edit(
+                    "Edit", "src/foo.py", session_id=session_id
+                ),
+            ],
+        )
+        return tmp_path, session_id
+
+    @pytest.fixture()
+    def transcript_without_timestamps(
+        self,
+        tmp_path: Path,
+    ) -> tuple[Path, str]:
+        """Transcript where no entry carries a ``timestamp`` key.
+
+        Returns:
+            Tuple of ``(data_dir, session_id)``.
+        """
+        session_id = "no-ts-session-001"
+        project_dir = tmp_path / "projects" / "C--no-ts-project"
+        project_dir.mkdir(parents=True)
+        transcript = project_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            transcript,
+            [
+                _user_line("Build it.", session_id=session_id),
+                _assistant_with_edit(
+                    "Edit", "src/bar.py", session_id=session_id
+                ),
+            ],
+        )
+        return tmp_path, session_id
+
+    def test_earliest_timestamp_written_to_record(
+        self,
+        transcript_with_timestamps: tuple[Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """Record timestamp equals the earliest entry timestamp in the transcript."""
+        data_dir, session_id = transcript_with_timestamps
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_base_dir=data_dir,
+        )
+        with open(out_path, encoding="utf-8") as fh:
+            record = json.load(fh)
+        # Earliest raw entry is "2026-03-10T09:15:30Z" → normalised UTC
+        assert record["timestamp"] is not None
+        assert "2026-03-10" in record["timestamp"]
+        assert "09:15:30" in record["timestamp"]
+
+    def test_timestamp_is_utc_iso_string(
+        self,
+        transcript_with_timestamps: tuple[Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """Record timestamp is a valid ISO-8601 UTC string (parseable)."""
+        from datetime import datetime
+
+        data_dir, session_id = transcript_with_timestamps
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_base_dir=data_dir,
+        )
+        with open(out_path, encoding="utf-8") as fh:
+            record = json.load(fh)
+        ts = record["timestamp"]
+        assert ts is not None
+        parsed = datetime.fromisoformat(ts)
+        assert parsed.tzinfo is not None, "timestamp must be tz-aware"
+
+    def test_timestamp_null_when_no_entries_carry_timestamp(
+        self,
+        transcript_without_timestamps: tuple[Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """timestamp is null when no transcript entry carries a timestamp key."""
+        data_dir, session_id = transcript_without_timestamps
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_base_dir=data_dir,
+        )
+        with open(out_path, encoding="utf-8") as fh:
+            record = json.load(fh)
+        assert record["timestamp"] is None
+
+    def test_record_json_includes_timestamp_key(
+        self,
+        transcript_with_timestamps: tuple[Path, str],
+        good_judgment: dict,
+    ) -> None:
+        """Written JSON record must always contain the 'timestamp' key."""
+        data_dir, session_id = transcript_with_timestamps
+        mod = _import_variance_save()
+        out_path = mod.save_variance_record(
+            session_id=session_id,
+            data_dir=data_dir,
+            judgment=good_judgment,
+            out_base_dir=data_dir,
+        )
+        with open(out_path, encoding="utf-8") as fh:
+            record = json.load(fh)
+        assert "timestamp" in record

--- a/tests/unit/test_variance_save.py
+++ b/tests/unit/test_variance_save.py
@@ -419,9 +419,7 @@ class TestCombineVariance:
         mod = _import_variance_save()
         audit = {"original_ask": None, "prior_asks": [], "actions": []}
         ts = "2026-01-15T10:30:00+00:00"
-        result = mod.combine_variance(
-            "s-ts-value", audit, good_judgment, timestamp=ts
-        )
+        result = mod.combine_variance("s-ts-value", audit, good_judgment, timestamp=ts)
         assert result["timestamp"] == ts
 
     def test_session_id_in_output(
@@ -1140,9 +1138,7 @@ class TestTimestampProducer:
                     "2026-03-10T09:15:30Z",
                     session_id=session_id,
                 ),
-                _assistant_with_edit(
-                    "Edit", "src/foo.py", session_id=session_id
-                ),
+                _assistant_with_edit("Edit", "src/foo.py", session_id=session_id),
             ],
         )
         return tmp_path, session_id
@@ -1165,9 +1161,7 @@ class TestTimestampProducer:
             transcript,
             [
                 _user_line("Build it.", session_id=session_id),
-                _assistant_with_edit(
-                    "Edit", "src/bar.py", session_id=session_id
-                ),
+                _assistant_with_edit("Edit", "src/bar.py", session_id=session_id),
             ],
         )
         return tmp_path, session_id


### PR DESCRIPTION
## Phase 0 of drift-aggregation (#63)

Adds a per-record `timestamp` to `variance/<id>.json` so the forthcoming `drift-report` CLI has a real time anchor for its configurable window. Standalone producer change; no aggregation code yet.

Spec: `docs/superpowers/specs/drift-aggregation.md` §2 + §10.

## Changes

`src/claude_prospector/cli/variance_save.py`:
- New pure helper `_earliest_transcript_timestamp(entries)` — filters raw entry dicts for a top-level `"timestamp"`, normalizes `Z`→`+00:00` (the `parser._parse_timestamp` *technique*, not the function — entries are raw `json.loads` dicts, not `Message` objects), takes the min, returns ISO-8601 UTC or `None`.
- `combine_variance` gains `timestamp: str | None = None` (4th param, keyword-default — existing 3-arg callers unaffected); returned record now includes `"timestamp"`.
- `save_variance_record` derives the timestamp where the raw `entries` are in scope and threads it through.
- No backfill migration (out of scope per spec §8).

`tests/unit/test_variance_save.py`:
- `TestCombineVariance` updated for the new key + default-`None` and populated paths.
- New `TestTimestampProducer` (4 tests): earliest-timestamp correctness, UTC ISO-8601 format, `None` when no entry carries a timestamp, key always present in written JSON.

## Verification (CI-mirrored, via `uv run`)

| Gate | Result |
|------|--------|
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run pytest` (full suite) | 620 passed, 2 skipped, 0 failed |

Baseline was 614 passed / 2 skipped; +6 net-new tests, no regressions.

Closes #217

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*