### PR TITLE
feat(cli): `drift-report` subcommand — variance aggregation + trend (Phase 1, #219)

### DIFF
--- a/src/claude_prospector/__main__.py
+++ b/src/claude_prospector/__main__.py
@@ -9,6 +9,7 @@ from claude_prospector.cli import (
     audit,
     config,
     dashboard,
+    drift_report,
     session_audit,
     session_summary,
     variance_save,
@@ -42,6 +43,7 @@ def main() -> None:
     config.build_parser(subparsers)
     audit.build_parser(subparsers)
     variance_save.build_parser(subparsers)
+    drift_report.build_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -66,6 +68,9 @@ def main() -> None:
 
     if args.subcommand == "variance-save":
         sys.exit(variance_save.run(args))
+
+    if args.subcommand == "drift-report":
+        sys.exit(drift_report.run(args))
 
 
 if __name__ == "__main__":

--- a/src/claude_prospector/cli/drift_report.py
+++ b/src/claude_prospector/cli/drift_report.py
@@ -1,0 +1,579 @@
+"""Drift-report subcommand: aggregate drift frequency across variance records.
+
+Reads all ``<base_dir>/variance/*.json`` records written by ``variance-save``,
+filters to a configurable time window, and computes drift frequency, severity
+distribution, and a per-day trend.
+
+No LLM cost — purely deterministic aggregation.
+
+JSON output schema (``--format json``, the default)::
+
+    {
+        "window": {
+            "from": "<ISO-8601 UTC>",
+            "to":   "<ISO-8601 UTC>"
+        },
+        "total_records":            <int>,
+        "skipped_records":          <int>,
+        "records_without_timestamp": <int>,
+        "drift": {
+            "drifted":    <int>,
+            "clean":      <int>,
+            "drift_rate": <float, 3 dp>
+        },
+        "severity_distribution": {
+            "0": <int>, "1": <int>, "2": <int>,
+            "3": <int>, "null": <int>
+        },
+        "trend": [
+            {
+                "date":       "YYYY-MM-DD",
+                "total":      <int>,
+                "drifted":    <int>,
+                "drift_rate": <float, 3 dp>
+            },
+            ...
+        ]
+    }
+
+Invariant: ``sum(severity_distribution.values()) == total_records``.
+
+Exit codes:
+    0  Success — JSON or text written to stdout.
+    1  IO failure — unreadable variance directory or OS-level error.
+       Records that fail ``json.loads`` are silently skipped (not IO failures).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from claude_prospector.cli.dashboard import _parse_date, _parse_window
+from claude_prospector.paths import base_dir as _resolve_base_dir
+
+EXIT_OK = 0
+EXIT_IO_FAILURE = 1
+
+# Internal sentinel constant used as a marker that a key was absent.
+_ABSENT = object()
+
+# Sentinel strings recognised as "no drift" in the prose fallback.
+# Case-insensitive match; empty string (after strip) is also clean.
+# Do NOT expand this set without verifying against real 1b skill output
+# and updating the skill instructions in lockstep (see spec §5).
+_CLEAN_SENTINELS: frozenset[str] = frozenset({"no variance"})
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — unit-testable, no I/O
+# ---------------------------------------------------------------------------
+
+
+def is_drifted(variance: str) -> bool:
+    """Return True when a variance prose string indicates drift.
+
+    This is the **null-severity fallback** used only when ``severity`` is
+    null or absent.  The severity value is the authoritative drift signal
+    when present (0 = clean; 1–3 = drifted); prose is not consulted then.
+
+    A record is **clean** when its ``variance`` string, after ``.strip()``,
+    is either the empty string or (case-insensitively) in
+    :data:`_CLEAN_SENTINELS`.  Every other non-empty string is drifted.
+
+    Args:
+        variance: The ``variance`` field from a variance record.
+
+    Returns:
+        ``True`` when the record is drifted; ``False`` when clean.
+    """
+    stripped = variance.strip()
+    if not stripped:
+        return False
+    return stripped.lower() not in _CLEAN_SENTINELS
+
+
+def severity_bucket(severity: Any) -> str:
+    """Map a severity value to its string bucket key.
+
+    Valid values 0, 1, 2, 3 map to ``"0"``, ``"1"``, ``"2"``, ``"3"``.
+    ``None``, absent (caller passes ``None``), or any out-of-range value
+    maps to ``"null"``.  ``null`` is intentionally its own bucket — it is
+    semantically distinct from "0, on task".
+
+    Args:
+        severity: Raw severity value from a variance record.  Typically
+            ``int | None``; out-of-range values are also handled.
+
+    Returns:
+        One of ``"0"``, ``"1"``, ``"2"``, ``"3"``, or ``"null"``.
+    """
+    if severity in (0, 1, 2, 3):
+        return str(severity)
+    return "null"
+
+
+def record_anchor_time(record: dict, file_mtime: float) -> datetime:
+    """Return the UTC datetime to use as this record's time anchor.
+
+    Uses the record's ``timestamp`` field (ISO-8601, tz-aware UTC) when
+    present and non-null.  Falls back to ``file_mtime`` (a POSIX timestamp
+    float) for legacy records that pre-date the ``timestamp`` field.
+
+    The caller is responsible for tracking how many records needed the
+    mtime fallback (via ``_mtime`` injection — see :func:`aggregate_drift`).
+
+    Args:
+        record: A parsed variance record dict.  May or may not contain a
+            ``"timestamp"`` key.
+        file_mtime: File modification time as a POSIX timestamp float
+            (from ``Path.stat().st_mtime``).
+
+    Returns:
+        A tz-aware UTC :class:`datetime` for the record.
+    """
+    raw_ts = record.get("timestamp")
+    if raw_ts:
+        # Normalise Z → +00:00 for fromisoformat compatibility.
+        normalised = raw_ts.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(normalised)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            pass  # fall through to mtime
+
+    return datetime.fromtimestamp(file_mtime, tz=timezone.utc)
+
+
+def aggregate_drift(
+    records: list[dict],
+    from_dt: datetime,
+    to_dt: datetime,
+) -> dict[str, Any]:
+    """Aggregate drift statistics over *records* within [from_dt, to_dt).
+
+    Applies severity-primary drift classification (§5):
+    - ``severity`` in {1, 2, 3} → drifted.
+    - ``severity == 0`` → clean.
+    - ``severity`` null/absent → falls back to :func:`is_drifted` prose check.
+
+    Drift rate is rounded to 3 decimal places; ``0.0`` when total is 0.
+
+    Invariant: ``sum(severity_distribution.values()) == total_records``.
+
+    Args:
+        records: List of variance record dicts, each optionally containing
+            a ``_mtime`` key (float) injected by :func:`load_variance_records`
+            for the mtime fallback.
+        from_dt: Start of the time window (inclusive, tz-aware UTC).
+        to_dt: End of the time window (exclusive, tz-aware UTC).
+
+    Returns:
+        A dict matching the §4.1 JSON output shape.
+    """
+    dist: dict[str, int] = {"0": 0, "1": 0, "2": 0, "3": 0, "null": 0}
+
+    # Per-day trend accumulator: date_str → {"total": int, "drifted": int}
+    day_totals: dict[str, dict[str, int]] = {}
+
+    # Enumerate all calendar days in [from_dt, to_dt).
+    current = from_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    if current < from_dt:
+        current += timedelta(days=1)
+    # Ensure we start from the date of from_dt.
+    start_day = from_dt.replace(
+        hour=0, minute=0, second=0, microsecond=0, tzinfo=from_dt.tzinfo
+    )
+    # Walk every calendar day in [from_dt.date, to_dt.date)
+    day_cursor = start_day
+    while day_cursor < to_dt:
+        day_key = day_cursor.strftime("%Y-%m-%d")
+        day_totals[day_key] = {"total": 0, "drifted": 0}
+        day_cursor += timedelta(days=1)
+
+    total_records = 0
+    drifted_count = 0
+    without_timestamp = 0
+
+    for rec in records:
+        file_mtime: float = rec.get("_mtime", 0.0)
+        anchor = record_anchor_time(rec, file_mtime)
+
+        # Filter to window [from_dt, to_dt).
+        if anchor < from_dt or anchor >= to_dt:
+            continue
+
+        # Track whether this record used the mtime fallback.
+        if not rec.get("timestamp"):
+            without_timestamp += 1
+
+        total_records += 1
+
+        # Severity-primary classification.
+        severity = rec.get("severity", None)
+        bucket = severity_bucket(severity)
+        dist[bucket] += 1
+
+        if severity in (1, 2, 3):
+            is_drift = True
+        elif severity == 0:
+            is_drift = False
+        else:
+            # null / absent — prose fallback.
+            is_drift = is_drifted(rec.get("variance", ""))
+
+        if is_drift:
+            drifted_count += 1
+
+        # Accumulate into trend day bucket.
+        day_key = anchor.strftime("%Y-%m-%d")
+        if day_key in day_totals:
+            day_totals[day_key]["total"] += 1
+            if is_drift:
+                day_totals[day_key]["drifted"] += 1
+
+    # Build trend list (sorted, continuous — all days present).
+    trend = []
+    for day_key in sorted(day_totals):
+        day = day_totals[day_key]
+        d_total = day["total"]
+        d_drifted = day["drifted"]
+        d_rate = round(d_drifted / d_total, 3) if d_total else 0.0
+        trend.append(
+            {
+                "date": day_key,
+                "total": d_total,
+                "drifted": d_drifted,
+                "drift_rate": d_rate,
+            }
+        )
+
+    drift_rate = round(drifted_count / total_records, 3) if total_records else 0.0
+
+    return {
+        "window": {
+            "from": from_dt.isoformat(),
+            "to": to_dt.isoformat(),
+        },
+        "total_records": total_records,
+        "skipped_records": 0,  # populated by run() after load_variance_records
+        "records_without_timestamp": without_timestamp,
+        "drift": {
+            "drifted": drifted_count,
+            "clean": total_records - drifted_count,
+            "drift_rate": drift_rate,
+        },
+        "severity_distribution": dist,
+        "trend": trend,
+    }
+
+
+def render_text(report: dict) -> str:
+    """Render a drift report dict as a plain ASCII text summary.
+
+    Produces the §4.2 human-readable format: a header, session count,
+    drift fraction, severity histogram, and a per-day trend bar chart.
+    No ANSI colour, no Unicode — output is copy-pasteable plain text.
+
+    When ``records_without_timestamp > 0``, appends a temporal-distortion
+    warning line to the session count line.
+
+    Args:
+        report: A dict in the §4.1 JSON output shape as returned by
+            :func:`aggregate_drift`.
+
+    Returns:
+        A multi-line ASCII string.
+    """
+    window = report["window"]
+    # Extract just the date portion for the header (YYYY-MM-DD).
+    from_date = window["from"][:10]
+    to_date = window["to"][:10]
+
+    total = report["total_records"]
+    drifted = report["drift"]["drifted"]
+    rate_pct = int(report["drift"]["drift_rate"] * 100)
+    dist = report["severity_distribution"]
+    without_ts = report["records_without_timestamp"]
+
+    lines: list[str] = []
+    lines.append(f"Drift report -- {from_date} to {to_date}")
+
+    # Sessions analyzed line — with optional mtime warning.
+    sessions_line = f"  Sessions analyzed:  {total}"
+    if without_ts > 0:
+        sessions_line += (
+            f"   ({without_ts} dated by file mtime"
+            " -- temporal position may be unreliable"
+            " for pre-migration records)"
+        )
+    lines.append(sessions_line)
+
+    lines.append(f"  Drifted:            {drifted} / {total}  ({rate_pct}%)")
+
+    # Severity histogram.
+    sev_parts = "  ".join(f"{k}:{dist[k]}" for k in ("0", "1", "2", "3", "null"))
+    lines.append(f"  Severity:           {sev_parts}")
+    lines.append("")
+    lines.append("  Trend (drift rate by day):")
+
+    for entry in report["trend"]:
+        day = entry["date"][5:]  # MM-DD
+        d_total = entry["total"]
+        d_drifted = entry["drifted"]
+        d_rate = entry["drift_rate"]
+
+        if d_total == 0:
+            lines.append(f"    {day}  (no sessions)")
+        else:
+            # ASCII bar: each '#' = 5% drift rate (max 20 chars wide).
+            bar_len = min(20, int(d_rate * 20))
+            bar = "#" * bar_len
+            pct = int(d_rate * 100)
+            lines.append(f"    {day}  {bar:<20}  {pct:3d}%  ({d_drifted}/{d_total})")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Loader — file I/O
+# ---------------------------------------------------------------------------
+
+
+class _RecordList(list):
+    """List subclass carrying a ``_skipped`` count alongside the records.
+
+    Used only by :func:`load_variance_records` to return the skipped count
+    without changing the function signature.  Callers access the count via
+    ``getattr(result, "_skipped", 0)``.
+    """
+
+    _skipped: int = 0
+
+
+def load_variance_records(base_dir: Path) -> list[dict]:
+    """Glob ``<base_dir>/variance/*.json`` and return parsed record dicts.
+
+    Records that fail ``json.loads`` are silently skipped and counted via
+    a ``_skipped`` attribute on the returned list subclass.  Callers
+    should access the count via ``getattr(result, "_skipped", 0)``.
+
+    Each successfully loaded dict has a ``_mtime`` key (float, POSIX
+    timestamp) injected from the file's ``st_mtime`` so
+    :func:`record_anchor_time` can use it as a fallback for legacy records
+    lacking a ``timestamp`` field.
+
+    An absent or unreadable ``variance/`` directory is not an error — it
+    returns an empty list.  Only OS-level read failures on individual files
+    that *do* exist are propagated.
+
+    Args:
+        base_dir: Root directory whose ``variance/`` sub-directory is
+            scanned.
+
+    Returns:
+        A :class:`_RecordList` (subclass of ``list``) of parsed record
+        dicts, each with ``_mtime`` injected.  The list carries a
+        ``_skipped`` attribute (int) counting parse failures.
+    """
+    variance_dir = base_dir / "variance"
+    result = _RecordList()
+
+    if not variance_dir.is_dir():
+        return result
+
+    for json_file in sorted(variance_dir.glob("*.json")):
+        stat = json_file.stat()
+        try:
+            raw = json_file.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            result._skipped += 1
+            continue
+        # Inject file mtime for records without a timestamp field.
+        data["_mtime"] = stat.st_mtime
+        result.append(data)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def build_parser(
+    parent: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Register the 'drift-report' subparser and return it.
+
+    ``--window`` and ``--from/--to`` form a mutually exclusive group;
+    ``--window`` defaults to ``7d`` (168 hours).  Both limits are
+    validated in :func:`run`:
+
+    - ``from_dt >= to_dt`` → error.
+    - ``(to_dt - from_dt).days > 366`` → error.
+
+    Args:
+        parent: The subparsers action from the top-level argument parser.
+
+    Returns:
+        The configured drift-report ArgumentParser.
+    """
+    p = parent.add_parser(
+        "drift-report",
+        help=(
+            "Aggregate drift frequency, severity distribution, and trend "
+            "across variance records in <base_dir>/variance/."
+        ),
+    )
+
+    # Mutually exclusive: --window vs --from/--to.
+    window_group = p.add_mutually_exclusive_group()
+    window_group.add_argument(
+        "--window",
+        dest="window",
+        type=_parse_window,
+        default=None,
+        metavar="WINDOW",
+        help=(
+            "Relative time window, e.g. '7d' or '48h' (default: 7d). "
+            "Maximum effective range is 366 days. "
+            "Mutually exclusive with --from/--to."
+        ),
+    )
+    window_group.add_argument(
+        "--from",
+        dest="from_date",
+        type=_parse_date,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help=(
+            "Absolute start date (inclusive). "
+            "Requires --to or defaults to now. "
+            "Mutually exclusive with --window. "
+            "Range must not exceed 366 days."
+        ),
+    )
+
+    p.add_argument(
+        "--to",
+        dest="to_date",
+        type=_parse_date,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help=(
+            "Absolute end date (exclusive). "
+            "Defaults to now when --from is given without --to."
+        ),
+    )
+
+    p.add_argument(
+        "--format",
+        dest="format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format: 'json' (default, machine-readable) or 'text'.",
+    )
+
+    p.add_argument(
+        "--base-dir",
+        dest="base_dir",
+        type=Path,
+        default=None,
+        help=(
+            "Override the variance-records root directory.  "
+            "Defaults to the plugin data base dir resolved from "
+            "CLAUDE_PROSPECTOR_BASE_DIR > CLAUDE_PLUGIN_DATA > "
+            "~/.claude/claude-prospector."
+        ),
+    )
+
+    return p
+
+
+def run(args: argparse.Namespace) -> int:
+    """Entry point for the drift-report subcommand.
+
+    Resolves the time window, loads variance records, aggregates drift
+    statistics, and prints JSON or text output to stdout.
+
+    Args:
+        args: Parsed CLI namespace.  Expected attributes:
+            ``args.window`` (float hours or None),
+            ``args.from_date`` (datetime or None),
+            ``args.to_date`` (datetime or None),
+            ``args.format`` (str: 'json' or 'text'),
+            ``args.base_dir`` (Path or None).
+
+    Returns:
+        Integer exit code (``EXIT_OK`` on success, ``EXIT_IO_FAILURE`` on
+        unrecoverable I/O error).
+    """
+    now = datetime.now(timezone.utc)
+
+    # Resolve time window.
+    window_val: float | None = getattr(args, "window", None)
+    from_date: datetime | None = getattr(args, "from_date", None)
+    to_date: datetime | None = getattr(args, "to_date", None)
+
+    if from_date is not None:
+        # --from / --to path.
+        from_dt = from_date
+        to_dt = to_date if to_date is not None else now
+    else:
+        # --window path (or unset → default 7d).
+        window_hours: float = window_val if window_val is not None else 7 * 24
+        from_dt = now - timedelta(hours=window_hours)
+        to_dt = now
+
+    # Validate range.
+    if from_dt >= to_dt:
+        print(
+            "drift-report: invalid range: --from must precede --to",
+            file=sys.stderr,
+        )
+        return EXIT_IO_FAILURE
+
+    if (to_dt - from_dt).days > 366:
+        print(
+            "drift-report: window exceeds 366 days -- use a narrower range",
+            file=sys.stderr,
+        )
+        return EXIT_IO_FAILURE
+
+    # Resolve base directory.
+    effective_base: Path = (
+        args.base_dir if args.base_dir is not None else _resolve_base_dir()
+    )
+
+    # Load records.
+    try:
+        records = load_variance_records(effective_base)
+    except OSError as exc:
+        print(
+            f"drift-report: I/O error reading variance dir: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_IO_FAILURE
+
+    skipped: int = getattr(records, "_skipped", 0)
+
+    # Aggregate.
+    report = aggregate_drift(records, from_dt, to_dt)
+    report["skipped_records"] = skipped
+
+    # Emit output.
+    fmt: str = getattr(args, "format", "json")
+    if fmt == "json":
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(render_text(report), end="")
+
+    return EXIT_OK

--- a/tests/unit/test_drift_report.py
+++ b/tests/unit/test_drift_report.py
@@ -1,0 +1,786 @@
+"""Tests for drift_report CLI module.
+
+Covers all pure functions (is_drifted, severity_bucket, record_anchor_time,
+aggregate_drift, render_text) and the run() end-to-end path via subprocess.
+
+TDD: tests were written before implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from claude_prospector.cli.drift_report import (
+    EXIT_OK,
+    aggregate_drift,
+    is_drifted,
+    load_variance_records,
+    record_anchor_time,
+    render_text,
+    severity_bucket,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UTC = timezone.utc
+
+
+def _dt(year: int, month: int, day: int, hour: int = 0) -> datetime:
+    """Build a UTC datetime."""
+    return datetime(year, month, day, hour, tzinfo=_UTC)
+
+
+def _make_record(
+    *,
+    session_id: str = "abc123",
+    variance: str = "no variance",
+    severity: int | None = 0,
+    timestamp: str | None = None,
+) -> dict:
+    """Build a minimal variance record dict."""
+    return {
+        "session_id": session_id,
+        "original_ask": None,
+        "prior_asks": [],
+        "actions": [],
+        "variance": variance,
+        "not_done": "",
+        "severity": severity,
+        "timestamp": timestamp,
+    }
+
+
+def _write_records(base_dir: Path, records: list[dict]) -> None:
+    """Write records into <base_dir>/variance/<session_id>.json."""
+    var_dir = base_dir / "variance"
+    var_dir.mkdir(parents=True, exist_ok=True)
+    for rec in records:
+        path = var_dir / f"{rec['session_id']}.json"
+        path.write_text(json.dumps(rec), encoding="utf-8")
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    """Run the drift-report subcommand as a subprocess."""
+    return subprocess.run(
+        [sys.executable, "-m", "claude_prospector", "drift-report", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_drifted — prose fallback (null-severity only)
+# ---------------------------------------------------------------------------
+
+
+class TestIsDrifted:
+    """Tests for is_drifted() prose sentinel matching."""
+
+    def test_no_variance_lowercase_is_clean(self) -> None:
+        """'no variance' (canonical) is clean."""
+        assert is_drifted("no variance") is False
+
+    def test_no_variance_mixed_case_is_clean(self) -> None:
+        """'No Variance' is clean (case-insensitive)."""
+        assert is_drifted("No Variance") is False
+
+    def test_no_variance_all_caps_is_clean(self) -> None:
+        """'NO VARIANCE' is clean (case-insensitive)."""
+        assert is_drifted("NO VARIANCE") is False
+
+    def test_empty_string_is_clean(self) -> None:
+        """Empty string is clean."""
+        assert is_drifted("") is False
+
+    def test_whitespace_only_is_clean(self) -> None:
+        """Whitespace-only string (after strip) is clean."""
+        assert is_drifted("   ") is False
+
+    def test_prose_content_is_drifted(self) -> None:
+        """Non-empty prose (not a sentinel) is drifted."""
+        assert is_drifted("Added extra logging not in spec") is True
+
+    def test_short_prose_is_drifted(self) -> None:
+        """Single-word non-sentinel is drifted."""
+        assert is_drifted("refactored") is True
+
+    def test_no_variance_with_padding_is_clean(self) -> None:
+        """'  no variance  ' (whitespace padded) is clean."""
+        assert is_drifted("  no variance  ") is False
+
+    def test_none_string_literal_is_drifted(self) -> None:
+        """'none' (string) is NOT in sentinel set — it is drifted."""
+        assert is_drifted("none") is True
+
+    def test_na_string_is_drifted(self) -> None:
+        """'n/a' is NOT in sentinel set — it is drifted."""
+        assert is_drifted("n/a") is True
+
+
+# ---------------------------------------------------------------------------
+# severity_bucket
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityBucket:
+    """Tests for severity_bucket()."""
+
+    def test_zero_maps_to_zero(self) -> None:
+        assert severity_bucket(0) == "0"
+
+    def test_one_maps_to_one(self) -> None:
+        assert severity_bucket(1) == "1"
+
+    def test_two_maps_to_two(self) -> None:
+        assert severity_bucket(2) == "2"
+
+    def test_three_maps_to_three(self) -> None:
+        assert severity_bucket(3) == "3"
+
+    def test_none_maps_to_null(self) -> None:
+        assert severity_bucket(None) == "null"
+
+    def test_missing_key_sentinel_maps_to_null(self) -> None:
+        """Callers pass None for absent keys; verify null mapping."""
+        assert severity_bucket(None) == "null"
+
+    def test_out_of_range_positive_maps_to_null(self) -> None:
+        assert severity_bucket(7) == "null"
+
+    def test_out_of_range_negative_maps_to_null(self) -> None:
+        assert severity_bucket(-1) == "null"
+
+    def test_float_out_of_range_maps_to_null(self) -> None:
+        """A float value (malformed) outside 0-3 maps to null."""
+        assert severity_bucket(4.5) == "null"
+
+
+# ---------------------------------------------------------------------------
+# record_anchor_time
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAnchorTime:
+    """Tests for record_anchor_time()."""
+
+    def test_uses_record_timestamp_when_present(self) -> None:
+        """Record with ISO-8601 timestamp uses that value directly."""
+        ts = "2026-05-20T10:00:00+00:00"
+        rec = _make_record(timestamp=ts)
+        mtime_float = 0.0  # should be ignored
+        dt = record_anchor_time(rec, mtime_float)
+        assert dt == datetime(2026, 5, 20, 10, 0, 0, tzinfo=_UTC)
+
+    def test_falls_back_to_mtime_when_timestamp_absent(self) -> None:
+        """Record without timestamp uses file mtime."""
+        rec = _make_record(timestamp=None)
+        # Use a known epoch — 2026-01-01 00:00:00 UTC
+        mtime_float = datetime(2026, 1, 1, tzinfo=_UTC).timestamp()
+        dt = record_anchor_time(rec, mtime_float)
+        assert dt == datetime(2026, 1, 1, tzinfo=_UTC)
+
+    def test_falls_back_to_mtime_when_timestamp_key_absent(self) -> None:
+        """Record dict with no 'timestamp' key uses mtime fallback."""
+        rec = {
+            "session_id": "x",
+            "variance": "no variance",
+            "severity": 0,
+        }
+        mtime_float = datetime(2026, 3, 15, tzinfo=_UTC).timestamp()
+        dt = record_anchor_time(rec, mtime_float)
+        assert dt == datetime(2026, 3, 15, tzinfo=_UTC)
+
+    def test_result_is_utc_aware(self) -> None:
+        """Returned datetime is always tz-aware UTC."""
+        ts = "2026-04-10T08:30:00+00:00"
+        rec = _make_record(timestamp=ts)
+        dt = record_anchor_time(rec, 0.0)
+        assert dt.tzinfo is not None
+        assert dt.utcoffset() == timedelta(0)
+
+
+# ---------------------------------------------------------------------------
+# aggregate_drift — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateDrift:
+    """Tests for aggregate_drift()."""
+
+    def test_empty_records_returns_zero_rate(self) -> None:
+        """Zero records in window → drift_rate 0.0, no division-by-zero."""
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 6, 2)
+        result = aggregate_drift([], from_dt, to_dt)
+
+        assert result["total_records"] == 0
+        assert result["drift"]["drifted"] == 0
+        assert result["drift"]["clean"] == 0
+        assert result["drift"]["drift_rate"] == 0.0
+
+    def test_empty_records_all_severity_buckets_present(self) -> None:
+        """Even with no records, all 5 severity keys are present and 0."""
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 6, 2)
+        result = aggregate_drift([], from_dt, to_dt)
+        dist = result["severity_distribution"]
+        assert set(dist.keys()) == {"0", "1", "2", "3", "null"}
+        assert all(v == 0 for v in dist.values())
+
+    def test_empty_records_trend_includes_all_days(self) -> None:
+        """Trend spans [from, to) calendar days even with zero records."""
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 5, 28)  # 2 days: May 26, May 27
+        result = aggregate_drift([], from_dt, to_dt)
+        dates = [entry["date"] for entry in result["trend"]]
+        assert dates == ["2026-05-26", "2026-05-27"]
+
+    def test_empty_records_trend_zero_day_filling(self) -> None:
+        """Zero-record days in trend have total=0, drifted=0, drift_rate=0."""
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 5, 28)
+        result = aggregate_drift([], from_dt, to_dt)
+        for entry in result["trend"]:
+            assert entry["total"] == 0
+            assert entry["drifted"] == 0
+            assert entry["drift_rate"] == 0.0
+
+    def test_severity_primary_zero_is_clean(self) -> None:
+        """severity=0 → clean regardless of variance prose."""
+        ts = "2026-05-27T12:00:00+00:00"
+        rec = _make_record(
+            session_id="s1",
+            variance="some drift prose",  # would be drifted by prose
+            severity=0,
+            timestamp=ts,
+        )
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 5, 29)
+        result = aggregate_drift([rec], from_dt, to_dt)
+        assert result["drift"]["drifted"] == 0
+        assert result["drift"]["clean"] == 1
+
+    def test_severity_primary_one_is_drifted(self) -> None:
+        """severity=1 → drifted regardless of variance prose."""
+        ts = "2026-05-27T12:00:00+00:00"
+        rec = _make_record(
+            session_id="s1",
+            variance="no variance",  # would be clean by prose
+            severity=1,
+            timestamp=ts,
+        )
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 5, 29)
+        result = aggregate_drift([rec], from_dt, to_dt)
+        assert result["drift"]["drifted"] == 1
+        assert result["drift"]["clean"] == 0
+
+    def test_severity_primary_two_is_drifted(self) -> None:
+        """severity=2 → drifted."""
+        ts = "2026-05-27T12:00:00+00:00"
+        rec = _make_record(session_id="s1", severity=2, timestamp=ts)
+        result = aggregate_drift([rec], _dt(2026, 5, 26), _dt(2026, 5, 29))
+        assert result["drift"]["drifted"] == 1
+
+    def test_severity_primary_three_is_drifted(self) -> None:
+        """severity=3 → drifted."""
+        ts = "2026-05-27T12:00:00+00:00"
+        rec = _make_record(session_id="s1", severity=3, timestamp=ts)
+        result = aggregate_drift([rec], _dt(2026, 5, 26), _dt(2026, 5, 29))
+        assert result["drift"]["drifted"] == 1
+
+    def test_null_severity_prose_fallback_drifted(self) -> None:
+        """severity=None + non-empty variance → prose fallback, drifted."""
+        ts = "2026-05-27T12:00:00+00:00"
+        rec = _make_record(
+            session_id="s1",
+            variance="added extra stuff",
+            severity=None,
+            timestamp=ts,
+        )
+        result = aggregate_drift([rec], _dt(2026, 5, 26), _dt(2026, 5, 29))
+        assert result["drift"]["drifted"] == 1
+
+    def test_null_severity_prose_fallback_clean(self) -> None:
+        """severity=None + 'no variance' → prose fallback, clean."""
+        ts = "2026-05-27T12:00:00+00:00"
+        rec = _make_record(
+            session_id="s1",
+            variance="no variance",
+            severity=None,
+            timestamp=ts,
+        )
+        result = aggregate_drift([rec], _dt(2026, 5, 26), _dt(2026, 5, 29))
+        assert result["drift"]["drifted"] == 0
+        assert result["drift"]["clean"] == 1
+
+    def test_drift_rate_rounded_to_3_decimals(self) -> None:
+        """drift_rate is rounded to exactly 3 decimal places."""
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 6, 2)
+        # 1 drifted out of 3 = 0.333...
+        records = []
+        for i, (sev, ts_day) in enumerate([(1, "05-26"), (0, "05-27"), (0, "05-28")]):
+            records.append(
+                _make_record(
+                    session_id=f"s{i}",
+                    severity=sev,
+                    timestamp=f"2026-{ts_day}T12:00:00+00:00",
+                )
+            )
+        result = aggregate_drift(records, from_dt, to_dt)
+        assert result["drift"]["drift_rate"] == round(1 / 3, 3)
+
+    def test_severity_distribution_invariant(self) -> None:
+        """sum(severity_distribution.values()) == total_records."""
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 6, 2)
+        records = [
+            _make_record(
+                session_id="a",
+                severity=0,
+                timestamp="2026-05-27T00:00:00+00:00",
+            ),
+            _make_record(
+                session_id="b",
+                severity=1,
+                timestamp="2026-05-28T00:00:00+00:00",
+            ),
+            _make_record(
+                session_id="c",
+                severity=2,
+                timestamp="2026-05-29T00:00:00+00:00",
+            ),
+            _make_record(
+                session_id="d",
+                severity=None,
+                timestamp="2026-05-30T00:00:00+00:00",
+            ),
+        ]
+        result = aggregate_drift(records, from_dt, to_dt)
+        dist_sum = sum(result["severity_distribution"].values())
+        assert dist_sum == result["total_records"]
+
+    def test_window_filtering_excludes_out_of_range(self) -> None:
+        """Records outside [from, to) are excluded from totals."""
+        # Record is from May 10, window is May 26–Jun 2
+        rec_old = _make_record(
+            session_id="old",
+            severity=1,
+            timestamp="2026-05-10T00:00:00+00:00",
+        )
+        rec_in = _make_record(
+            session_id="in",
+            severity=0,
+            timestamp="2026-05-27T00:00:00+00:00",
+        )
+        result = aggregate_drift([rec_old, rec_in], _dt(2026, 5, 26), _dt(2026, 6, 2))
+        assert result["total_records"] == 1
+
+    def test_window_boundary_to_is_exclusive(self) -> None:
+        """Record at exactly to_dt is excluded (half-open interval)."""
+        ts_at_boundary = "2026-06-02T00:00:00+00:00"
+        rec = _make_record(
+            session_id="boundary",
+            severity=1,
+            timestamp=ts_at_boundary,
+        )
+        result = aggregate_drift([rec], _dt(2026, 5, 26), _dt(2026, 6, 2))
+        assert result["total_records"] == 0
+
+    def test_records_without_timestamp_counted(self) -> None:
+        """Records using mtime fallback increment records_without_timestamp."""
+        rec = _make_record(session_id="s1", severity=0, timestamp=None)
+        # Provide a mtime in range: May 27
+        mtime_in_range = datetime(2026, 5, 27, tzinfo=_UTC).timestamp()
+        # We need to pass raw records — aggregate_drift uses file_mtime
+        # from record metadata injected by load_variance_records.
+        # Since we test aggregate_drift directly, we inject _mtime into rec.
+        rec["_mtime"] = mtime_in_range
+        result = aggregate_drift([rec], _dt(2026, 5, 26), _dt(2026, 6, 2))
+        assert result["records_without_timestamp"] == 1
+
+    def test_trend_includes_zero_record_days(self) -> None:
+        """Days in window with no records still appear in trend."""
+        ts = "2026-05-27T12:00:00+00:00"
+        rec = _make_record(session_id="s1", severity=0, timestamp=ts)
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 5, 29)  # 3 days: 26, 27, 28
+        result = aggregate_drift([rec], from_dt, to_dt)
+        dates = [e["date"] for e in result["trend"]]
+        assert "2026-05-26" in dates
+        assert "2026-05-27" in dates
+        assert "2026-05-28" in dates
+        # May 26 should have zero records (record is May 27)
+        day26 = next(e for e in result["trend"] if e["date"] == "2026-05-26")
+        assert day26["total"] == 0
+
+    def test_window_field_in_output(self) -> None:
+        """Output contains window.from and window.to as ISO strings."""
+        from_dt = _dt(2026, 5, 26)
+        to_dt = _dt(2026, 6, 2)
+        result = aggregate_drift([], from_dt, to_dt)
+        assert "window" in result
+        assert result["window"]["from"] == from_dt.isoformat()
+        assert result["window"]["to"] == to_dt.isoformat()
+
+    def test_skipped_records_initialises_to_zero(self) -> None:
+        """aggregate_drift itself doesn't set skipped_records (loader does)."""
+        result = aggregate_drift([], _dt(2026, 5, 26), _dt(2026, 6, 2))
+        # aggregate_drift should include skipped_records = 0 in output shape
+        assert "skipped_records" in result
+        assert result["skipped_records"] == 0
+
+
+# ---------------------------------------------------------------------------
+# load_variance_records
+# ---------------------------------------------------------------------------
+
+
+class TestLoadVarianceRecords:
+    """Tests for load_variance_records()."""
+
+    def test_loads_valid_records(self, tmp_path: Path) -> None:
+        """Valid JSON files in variance/ are loaded."""
+        records = [
+            _make_record(session_id="s1"),
+            _make_record(session_id="s2"),
+        ]
+        _write_records(tmp_path, records)
+        loaded = load_variance_records(tmp_path)
+        assert len(loaded) == 2
+
+    def test_skips_malformed_json(self, tmp_path: Path) -> None:
+        """Malformed JSON is skipped silently."""
+        var_dir = tmp_path / "variance"
+        var_dir.mkdir()
+        # Write one valid and one invalid file
+        (var_dir / "good.json").write_text(
+            json.dumps(_make_record(session_id="good")), encoding="utf-8"
+        )
+        (var_dir / "bad.json").write_text("{ not valid json }", encoding="utf-8")
+        loaded = load_variance_records(tmp_path)
+        assert len(loaded) == 1
+        assert loaded[0]["session_id"] == "good"
+
+    def test_skipped_count_in_result(self, tmp_path: Path) -> None:
+        """skipped_records count is available via the loader metadata."""
+        var_dir = tmp_path / "variance"
+        var_dir.mkdir()
+        (var_dir / "good.json").write_text(
+            json.dumps(_make_record(session_id="good")), encoding="utf-8"
+        )
+        (var_dir / "bad.json").write_text("INVALID", encoding="utf-8")
+        # load_variance_records returns enriched dicts;
+        # test that exactly 1 record is returned (bad skipped)
+        loaded = load_variance_records(tmp_path)
+        assert len(loaded) == 1
+
+    def test_missing_variance_dir_returns_empty(self, tmp_path: Path) -> None:
+        """Missing variance/ dir returns empty list (not an error)."""
+        loaded = load_variance_records(tmp_path)
+        assert loaded == []
+
+    def test_empty_variance_dir_returns_empty(self, tmp_path: Path) -> None:
+        """Empty variance/ dir returns empty list."""
+        (tmp_path / "variance").mkdir()
+        loaded = load_variance_records(tmp_path)
+        assert loaded == []
+
+    def test_mtime_injected_into_records(self, tmp_path: Path) -> None:
+        """Loaded records have _mtime injected for fallback use."""
+        _write_records(tmp_path, [_make_record(session_id="s1")])
+        loaded = load_variance_records(tmp_path)
+        assert "_mtime" in loaded[0]
+        assert isinstance(loaded[0]["_mtime"], float)
+
+
+# ---------------------------------------------------------------------------
+# render_text
+# ---------------------------------------------------------------------------
+
+
+class TestRenderText:
+    """Tests for render_text()."""
+
+    def _make_report(
+        self,
+        *,
+        drifted: int = 2,
+        total: int = 5,
+        records_without_ts: int = 0,
+    ) -> dict:
+        """Build a minimal report dict for render_text."""
+        rate = round(drifted / total, 3) if total else 0.0
+        return {
+            "window": {
+                "from": "2026-05-26T00:00:00+00:00",
+                "to": "2026-06-02T00:00:00+00:00",
+            },
+            "total_records": total,
+            "skipped_records": 0,
+            "records_without_timestamp": records_without_ts,
+            "drift": {
+                "drifted": drifted,
+                "clean": total - drifted,
+                "drift_rate": rate,
+            },
+            "severity_distribution": {
+                "0": total - drifted,
+                "1": drifted,
+                "2": 0,
+                "3": 0,
+                "null": 0,
+            },
+            "trend": [
+                {
+                    "date": "2026-05-26",
+                    "total": total,
+                    "drifted": drifted,
+                    "drift_rate": rate,
+                }
+            ],
+        }
+
+    def test_output_is_string(self) -> None:
+        """render_text returns a string."""
+        report = self._make_report()
+        assert isinstance(render_text(report), str)
+
+    def test_header_contains_dates(self) -> None:
+        """Header line includes from/to dates."""
+        report = self._make_report()
+        text = render_text(report)
+        assert "2026-05-26" in text
+        assert "2026-06-02" in text
+
+    def test_shows_drifted_fraction(self) -> None:
+        """Output shows drifted count and total."""
+        report = self._make_report(drifted=2, total=5)
+        text = render_text(report)
+        assert "2" in text
+        assert "5" in text
+
+    def test_no_timestamp_warning_when_zero(self) -> None:
+        """No mtime warning when records_without_timestamp is 0."""
+        report = self._make_report(records_without_ts=0)
+        text = render_text(report)
+        assert "mtime" not in text
+        assert "temporal" not in text
+
+    def test_timestamp_warning_when_nonzero(self) -> None:
+        """Warning line appears when records_without_timestamp > 0."""
+        report = self._make_report(records_without_ts=3)
+        text = render_text(report)
+        assert "mtime" in text
+
+    def test_trend_section_present(self) -> None:
+        """Trend section header is present."""
+        report = self._make_report()
+        text = render_text(report)
+        assert "Trend" in text or "trend" in text
+
+    def test_ascii_only_no_unicode_bars(self) -> None:
+        """Output contains only ASCII (no Unicode sparklines)."""
+        report = self._make_report()
+        text = render_text(report)
+        assert text.isascii()
+
+    def test_no_color_codes(self) -> None:
+        """No ANSI escape sequences in output."""
+        report = self._make_report()
+        text = render_text(report)
+        assert "\x1b[" not in text
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via subprocess run()
+# ---------------------------------------------------------------------------
+
+
+class TestRunCLI:
+    """End-to-end tests exercising run() through the CLI entry point."""
+
+    def test_default_7d_window_json_output(self, tmp_path: Path) -> None:
+        """--window 7d (default) produces correct window.from/to in JSON."""
+        ts_now = datetime.now(_UTC)
+        ts_in_window = (ts_now - timedelta(days=3)).isoformat()
+        rec = _make_record(session_id="recent", severity=0, timestamp=ts_in_window)
+        _write_records(tmp_path, [rec])
+
+        result = _run_cli("--base-dir", str(tmp_path), "--format", "json")
+        assert result.returncode == EXIT_OK
+        data = json.loads(result.stdout)
+        assert "window" in data
+        # from should be approximately 7 days ago
+        from_dt = datetime.fromisoformat(data["window"]["from"])
+        diff_hours = (ts_now - from_dt).total_seconds() / 3600
+        # Allow ±5 minutes tolerance
+        assert 167.9 <= diff_hours <= 168.1
+
+    def test_json_output_shape(self, tmp_path: Path) -> None:
+        """JSON output matches the §4.1 required top-level fields."""
+        _write_records(tmp_path, [])
+        result = _run_cli(
+            "--base-dir",
+            str(tmp_path),
+            "--window",
+            "7d",
+            "--format",
+            "json",
+        )
+        assert result.returncode == EXIT_OK
+        data = json.loads(result.stdout)
+        for key in (
+            "window",
+            "total_records",
+            "skipped_records",
+            "records_without_timestamp",
+            "drift",
+            "severity_distribution",
+            "trend",
+        ):
+            assert key in data, f"Missing key: {key}"
+
+    def test_format_text_runs_without_crashing(self, tmp_path: Path) -> None:
+        """--format text produces output and exits 0."""
+        ts = (datetime.now(_UTC) - timedelta(days=1)).isoformat()
+        _write_records(
+            tmp_path,
+            [_make_record(session_id="s1", severity=1, timestamp=ts)],
+        )
+        result = _run_cli("--base-dir", str(tmp_path), "--format", "text")
+        assert result.returncode == EXIT_OK
+        assert len(result.stdout) > 0
+
+    def test_format_text_spot_check_line(self, tmp_path: Path) -> None:
+        """--format text output contains 'Drift report'."""
+        result = _run_cli("--base-dir", str(tmp_path), "--format", "text")
+        assert result.returncode == EXIT_OK
+        assert "Drift report" in result.stdout
+
+    def test_window_and_from_are_mutually_exclusive(self, tmp_path: Path) -> None:
+        """--window and --from together produce an error exit."""
+        result = _run_cli(
+            "--base-dir",
+            str(tmp_path),
+            "--window",
+            "7d",
+            "--from",
+            "2026-05-01",
+        )
+        assert result.returncode != EXIT_OK
+
+    def test_bad_window_format_exits_nonzero(self, tmp_path: Path) -> None:
+        """Invalid --window value exits non-zero."""
+        result = _run_cli("--base-dir", str(tmp_path), "--window", "badval")
+        assert result.returncode != EXIT_OK
+
+    def test_bad_from_format_exits_nonzero(self, tmp_path: Path) -> None:
+        """Invalid --from date exits non-zero."""
+        result = _run_cli(
+            "--base-dir",
+            str(tmp_path),
+            "--from",
+            "not-a-date",
+        )
+        assert result.returncode != EXIT_OK
+
+    def test_inverted_range_exits_nonzero(self, tmp_path: Path) -> None:
+        """--from after --to exits non-zero."""
+        result = _run_cli(
+            "--base-dir",
+            str(tmp_path),
+            "--from",
+            "2026-06-01",
+            "--to",
+            "2026-05-01",
+        )
+        assert result.returncode != EXIT_OK
+
+    def test_window_exceeding_366_days_exits_nonzero(self, tmp_path: Path) -> None:
+        """Window > 366 days exits non-zero."""
+        result = _run_cli(
+            "--base-dir",
+            str(tmp_path),
+            "--from",
+            "2024-01-01",
+            "--to",
+            "2026-01-01",
+        )
+        assert result.returncode != EXIT_OK
+
+    def test_empty_variance_dir_exits_ok(self, tmp_path: Path) -> None:
+        """Empty variance/ dir produces zero report and exits 0."""
+        (tmp_path / "variance").mkdir()
+        result = _run_cli("--base-dir", str(tmp_path), "--format", "json")
+        assert result.returncode == EXIT_OK
+        data = json.loads(result.stdout)
+        assert data["total_records"] == 0
+
+    def test_missing_variance_dir_exits_ok(self, tmp_path: Path) -> None:
+        """Missing variance/ dir (no dir at all) exits 0 with empty report."""
+        result = _run_cli("--base-dir", str(tmp_path), "--format", "json")
+        assert result.returncode == EXIT_OK
+        data = json.loads(result.stdout)
+        assert data["total_records"] == 0
+
+    def test_malformed_json_record_skipped_and_counted(self, tmp_path: Path) -> None:
+        """One malformed + one valid → total=1, skipped=1, exit 0."""
+        var_dir = tmp_path / "variance"
+        var_dir.mkdir()
+        ts = (datetime.now(_UTC) - timedelta(days=1)).isoformat()
+        good = _make_record(session_id="good", severity=0, timestamp=ts)
+        (var_dir / "good.json").write_text(json.dumps(good), encoding="utf-8")
+        (var_dir / "bad.json").write_text("NOT JSON", encoding="utf-8")
+
+        result = _run_cli(
+            "--base-dir",
+            str(tmp_path),
+            "--window",
+            "7d",
+            "--format",
+            "json",
+        )
+        assert result.returncode == EXIT_OK
+        data = json.loads(result.stdout)
+        assert data["total_records"] == 1
+        assert data["skipped_records"] == 1
+
+    def test_from_without_to_defaults_to_now(self, tmp_path: Path) -> None:
+        """--from without --to uses current time as to_dt."""
+        result = _run_cli(
+            "--base-dir",
+            str(tmp_path),
+            "--from",
+            "2026-05-01",
+            "--format",
+            "json",
+        )
+        assert result.returncode == EXIT_OK
+        data = json.loads(result.stdout)
+        # to should be approximately now (within a minute)
+        to_dt = datetime.fromisoformat(data["window"]["to"])
+        now = datetime.now(_UTC)
+        diff_secs = abs((now - to_dt).total_seconds())
+        assert diff_secs < 60
+
+    def test_severity_distribution_all_five_keys(self, tmp_path: Path) -> None:
+        """severity_distribution always has keys 0, 1, 2, 3, null."""
+        result = _run_cli("--base-dir", str(tmp_path), "--format", "json")
+        data = json.loads(result.stdout)
+        assert set(data["severity_distribution"].keys()) == {
+            "0",
+            "1",
+            "2",
+            "3",
+            "null",
+        }


### PR DESCRIPTION
## Phase 1 of drift-aggregation (#63)

Adds the deterministic `drift-report` CLI that reads accumulated `variance/<id>.json` records and reports drift frequency, severity distribution, and a per-day trend over a configurable window. Builds on the Phase 0 `timestamp` field (#217). Implements spec §3–§6.

Satisfies #63 AC #2 (aggregation CLI) and AC #3 (trend report). README (#63 AC #4) and the skill/opt-in extension (#63 AC #5) follow as Phases 2–3 — so this **does not close #63**.

## Changes

- **New `src/claude_prospector/cli/drift_report.py`** (579 lines): `load_variance_records`, `record_anchor_time` (timestamp → mtime fallback), `is_drifted` (null-severity prose fallback), `severity_bucket`, `aggregate_drift` (§4.1 JSON shape), `render_text` (§4.2 ASCII), `build_parser` + `run`.
- **`__main__.py`**: registers the `drift-report` subcommand (mirrors `variance-save` / `session-audit` wiring).

## Spec-conformance highlights

- **Drift = severity-primary** (`severity ∈ {1,2,3}` drifted, `0` clean); prose fallback only when severity is null/absent. Sentinel set is `{"no variance"}` + `""` — `none`/`n/a` are *not* clean (§5).
- `severity_bucket`: null and out-of-range both → `"null"`, never coerced to `0`. Invariant `sum(severity_distribution.values()) == total_records` holds.
- `drift_rate` rounded to 3 decimals; `0.0` when no records (no div-by-zero).
- `trend`: one entry per UTC calendar day in `[from, to)`, zero-days included.
- `run()`: `_parse_window` hours-float → `timedelta(hours=…)` conversion explicit; `--window` ⊻ `--from/--to`; range + 366-day validation → exit 1; malformed JSON skipped + counted (`skipped_records`), exit still 0.
- Smoke-checked: `python -m claude_prospector drift-report --help` renders correct flags + mutual exclusivity.

## Verification (CI-mirrored, via `uv run` — both Lint gates run)

| Gate | Result |
|------|--------|
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check .` | 68 files already formatted |
| `uv run pytest` (full suite) | 689 passed, 2 skipped, 0 failed |

Baseline 620 passed / 2 skipped; **+69 net-new tests**, zero regressions.

Closes #219

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*