### PR TITLE
feat: recognize new "fable" model tier in model_short

### DIFF
--- a/src/claude_prospector/models.py
+++ b/src/claude_prospector/models.py
@@ -57,12 +57,13 @@ class MessageRecord:
         after a model-version bump (issue #196).
 
         Returns:
-            ``"opus"``, ``"sonnet"``, or ``"haiku"`` when the tier name is
-            found as a substring of :attr:`model`.  Returns the full
-            :attr:`model` string when no known tier name is present (e.g. a
-            hypothetical future model ID that omits the tier name entirely).
+            ``"opus"``, ``"sonnet"``, ``"haiku"``, or ``"fable"`` when the
+            tier name is found as a substring of :attr:`model`.  Returns the
+            full :attr:`model` string when no known tier name is present
+            (e.g. a hypothetical future model ID that omits the tier name
+            entirely).
         """
-        for name in ("opus", "sonnet", "haiku"):
+        for name in ("opus", "sonnet", "haiku", "fable"):
             if name in self.model:
                 return name
         return self.model

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -295,6 +295,22 @@ class TestAgentPath:
                 f"{model!r} must map to 'opus'. " f"Got {record.model_short!r} instead."
             )
 
+    def test_model_short_fable(self) -> None:
+        """claude-fable-* model IDs must classify as 'fable' (issue #224).
+
+        'fable' is a new Anthropic model tier.  model_short uses substring
+        matching, so any ID containing 'fable' must return 'fable', not the
+        full model string.
+        """
+        record = self._make(
+            agent_path=("general-purpose",), model="claude-fable-1-0"
+        )
+        assert record.model_short == "fable", (
+            "claude-fable-1-0 must map to 'fable' via substring match. "
+            "If this fails, 'fable' is not yet in the model_short tier tuple "
+            "and the property falls back to returning the full model string."
+        )
+
     def test_parallel_field_independence(self):
         """agent_type and agent_path are stored independently — neither derived.
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -302,9 +302,7 @@ class TestAgentPath:
         matching, so any ID containing 'fable' must return 'fable', not the
         full model string.
         """
-        record = self._make(
-            agent_path=("general-purpose",), model="claude-fable-1-0"
-        )
+        record = self._make(agent_path=("general-purpose",), model="claude-fable-1-0")
         assert record.model_short == "fable", (
             "claude-fable-1-0 must map to 'fable' via substring match. "
             "If this fails, 'fable' is not yet in the model_short tier tuple "


### PR DESCRIPTION
## Summary
Adds `"fable"` to the `MessageRecord.model_short` tier tuple so token usage for the new Fable model (1M-context) groups under its own `fable` tier instead of falling through to the raw model-ID string in aggregation.

## Changes
- `src/claude_prospector/models.py`: `"fable"` added to the tier tuple; docstring Returns section updated to list `"fable"`. Substring match keeps it version-agnostic (`claude-fable-1-0`, etc.), consistent with the issue #196 design.
- `tests/test_models.py`: regression test `TestAgentPath::test_model_short_fable` asserting `claude-fable-1-0` → `"fable"`. Written test-first (failed for the right reason before the fix).

## Verification
- `uv run pytest` — **690 passed, 2 skipped** (2 skips pre-existing).
- `uv run ruff check src/ tests/` — clean.

No pricing/context-window logic touched — prospector derives usage from recorded token counts; the 1M window is informational.

Closes #224

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_