### PR TITLE
fix: correct setup-prospector default slug + harden CLAUDE_PLUGIN_DATA trust

### DIFF
--- a/skills/setup-prospector/SKILL.md
+++ b/skills/setup-prospector/SKILL.md
@@ -23,14 +23,21 @@ and after any plugin version update.
 
 ## Step 1: Resolve `${CLAUDE_PLUGIN_DATA}`
 
-Read the `CLAUDE_PLUGIN_DATA` environment variable. If unset, compute the default:
+Read the `CLAUDE_PLUGIN_DATA` environment variable, but **do not trust it
+blindly**. When this skill is driven from a main session, `CLAUDE_PLUGIN_DATA`
+may be set to a *different* plugin's data dir (observed in the wild as
+`.../data/codex-openai-codex`). Before using it, confirm its basename matches
+this plugin's slug `claude-prospector-glitchwerks`. If `CLAUDE_PLUGIN_DATA` is
+unset, empty, or its basename points at another plugin, ignore it and compute
+the default instead:
 
 ```
-~/.claude/plugins/data/claude-prospector-claude-prospector/
+~/.claude/plugins/data/claude-prospector-glitchwerks/
 ```
 
-The slug is the plugin ID `claude-prospector@claude-prospector` with every
-character outside `[a-zA-Z0-9_-]` replaced by a hyphen.
+The slug is `<plugin>-<marketplace>` — `claude-prospector` published from the
+`glitchwerks` marketplace — with every character outside `[a-zA-Z0-9_-]`
+replaced by a hyphen.
 
 Create the directory if it does not exist.
 
@@ -116,7 +123,7 @@ Write `${CLAUDE_PLUGIN_DATA}/setup-state.json` with this shape:
 ```
 
 The `venv_path` is the absolute path to the venv root (e.g.
-`C:/Users/alice/.claude/plugins/data/claude-prospector-claude-prospector/venv`).
+`C:/Users/alice/.claude/plugins/data/claude-prospector-glitchwerks/venv`).
 The `interpreter` is the raw command string from Step 2 (e.g. `py -3` or
 `python3`), not an absolute path, so re-setup can reuse it.
 

--- a/skills/setup-prospector/SKILL.md
+++ b/skills/setup-prospector/SKILL.md
@@ -26,10 +26,13 @@ and after any plugin version update.
 Read the `CLAUDE_PLUGIN_DATA` environment variable, but **do not trust it
 blindly**. When this skill is driven from a main session, `CLAUDE_PLUGIN_DATA`
 may be set to a *different* plugin's data dir (observed in the wild as
-`.../data/codex-openai-codex`). Before using it, confirm its basename matches
-this plugin's slug `claude-prospector-glitchwerks`. If `CLAUDE_PLUGIN_DATA` is
-unset, empty, or its basename points at another plugin, ignore it and compute
-the default instead:
+`.../data/codex-openai-codex`). Before using it, confirm its basename begins
+with `claude-prospector-` — i.e. it is *this* plugin's data dir. The marketplace
+suffix may legitimately differ (`-glitchwerks` for the public install, or
+another suffix for a local/forked marketplace), so match the `claude-prospector-`
+prefix, **not** a hardcoded marketplace. If `CLAUDE_PLUGIN_DATA` is unset, empty,
+or its basename belongs to a *different* plugin, ignore it and compute the
+default instead (using the canonical `glitchwerks` marketplace slug):
 
 ```
 ~/.claude/plugins/data/claude-prospector-glitchwerks/


### PR DESCRIPTION
## Summary
Fixes two Step-1 problems in `skills/setup-prospector/SKILL.md` (#209).

## Changes
- **Slug corrected** — prose default was `claude-prospector-claude-prospector`; the real convention is `<plugin>-<marketplace>` → `claude-prospector-glitchwerks`, consistent with the skill's own rendered header path. Fixed at both occurrences (Step 1 default + the `venv_path` example).
- **`CLAUDE_PLUGIN_DATA` hardened** — guidance no longer trusts the env var blindly. When driven from a main session it can point at another plugin's data dir (observed: `.../data/codex-openai-codex`); Step 1 now says verify the basename matches `claude-prospector-glitchwerks`, else ignore it and use the computed default.

## Notes
The analogous `claude-wayfinder-claude-wayfinder` slug bug lives in the **claude-wayfinder** repo (different repo) — tracked separately, not in scope here.

Fixes #209

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_