### PR TITLE
docs: document accepted best-effort limit of slug-only worktree fold (#232)

### DIFF
--- a/src/claude_prospector/parser.py
+++ b/src/claude_prospector/parser.py
@@ -129,6 +129,16 @@ def _fold_worktree_slug_segments(segments: list[str]) -> str | None:
 
     Returns:
         Owner repo name string, or ``None`` if no worktree segment found.
+
+    Note:
+        **Known limitation (accepted, issue #232):** this path is
+        best-effort.  The slug encoding flattens ``/`` boundaries into
+        ``-``, so a multi-token repo name (e.g. ``my-awesome-api``) may
+        be truncated to its last two tokens (``awesome-api``).  This can
+        split such a repo across dashboard rows for sessions that have no
+        ``cwd``.  The cwd-based path in ``derive_project_name`` is
+        unaffected and correct.  Do not change this heuristic without
+        revisiting issue #232.
     """
     for i, seg in enumerate(segments):
         if (


### PR DESCRIPTION
## Summary
Records the maintainer decision on #232: the no-`cwd` slug-only worktree fallback in `_fold_worktree_slug_segments` is **accepted as a best-effort limitation** rather than changed.

## Why
The slug encoding flattens `/` path boundaries into `-`, so a clean repo leaf is not deterministically recoverable; a multi-token repo name can be truncated (`my-awesome-api` → `awesome-api`) for sessions with no `cwd`. The cwd-based path (the modern, common case) is correct and unaffected. Decision per #232: document, don't guess.

## Change
A 4-line docstring note at the function so the heuristic isn't silently "fixed" without revisiting #232. No behavior change — comment only.

## Verification
- `uv run ruff check .` clean · `uv run ruff format --check .` clean · `uv run pytest` → **705 passed, 2 skipped** (unchanged)

Closes #232

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_